### PR TITLE
feat(chat): semantic retrieval via embeddings — hybrid RRF search (#48)

### DIFF
--- a/docs/research/embed-48-multilingual/findings-run.json
+++ b/docs/research/embed-48-multilingual/findings-run.json
@@ -1,0 +1,49 @@
+{
+  "model": "embeddinggemma",
+  "passed": 6,
+  "total": 6,
+  "cases": [
+    {
+      "lang": "en",
+      "query": "How much did we cut the marketing budget?",
+      "correct_rank_top": true,
+      "correct_sim": 0.581,
+      "best_distractor_sim": 0.2406
+    },
+    {
+      "lang": "nb",
+      "query": "Hvor mye kuttet vi i markedsføringsbudsjettet?",
+      "correct_rank_top": true,
+      "correct_sim": 0.4758,
+      "best_distractor_sim": 0.3809
+    },
+    {
+      "lang": "nb",
+      "query": "Hvem er ansvarlig for lanseringen?",
+      "correct_rank_top": true,
+      "correct_sim": 0.4404,
+      "best_distractor_sim": 0.3243
+    },
+    {
+      "lang": "de",
+      "query": "Wann ist die Frist für das Angebot?",
+      "correct_rank_top": true,
+      "correct_sim": 0.8112,
+      "best_distractor_sim": 0.2892
+    },
+    {
+      "lang": "es",
+      "query": "¿Quién aprobó el presupuesto?",
+      "correct_rank_top": true,
+      "correct_sim": 0.6129,
+      "best_distractor_sim": 0.2637
+    },
+    {
+      "lang": "en->nb",
+      "query": "What did we decide about hiring?",
+      "correct_rank_top": true,
+      "correct_sim": 0.5119,
+      "best_distractor_sim": 0.3618
+    }
+  ]
+}

--- a/docs/research/embed-48-multilingual/findings.md
+++ b/docs/research/embed-48-multilingual/findings.md
@@ -1,6 +1,6 @@
 # embeddinggemma multilingual sanity check (issue #48)
 
-**Status: harness ready; empirical run pending a local `embeddinggemma` pull.**
+**Status: run 2026-07-22 — 6/6 pass across en/nb/de/es + cross-lingual. Ship as-is.**
 
 This is the *non-blocking multilingual sanity check* the #48 acceptance criteria
 ask for. It is deliberately a sanity check, not a benchmark: `embeddinggemma` is
@@ -32,19 +32,35 @@ python3 docs/research/embed-48-multilingual/probe.py
 It writes `findings-run.json` (per-case cosine of the correct passage vs the
 best distractor) and exits non-zero if any case fails.
 
-## Why this wasn't auto-run in the implementing session
-
-`embeddinggemma` was not present on the dev machine, and the check is explicitly
-**non-blocking** for the slice — semantic retrieval degrades gracefully to
-keyword-only when the model is absent, so shipping #48 does not depend on it.
-Pulling a 600 MB model onto the user's machine without asking wasn't warranted
-for a sanity check. Run the command above to record results (paste the
-`findings-run.json` summary into the "Results" section below).
-
 ## Results
 
-_Pending — run `probe.py` and record the per-language pass/fail + cosine
-margins here._
+Run 2026-07-22, `embeddinggemma:latest` via Ollama `/v1/embeddings` (768 dims).
+**6/6 cases pass** — in every language the intended (semantic, non-lexical)
+passage is the top cosine match over its distractors. Raw output in
+`findings-run.json`.
+
+| Lang     | Correct sim | Best distractor | Margin |
+|----------|-------------|-----------------|--------|
+| en       | 0.581       | 0.241           | 0.340  |
+| nb       | 0.476       | 0.381           | 0.095  |
+| nb       | 0.440       | 0.324           | 0.116  |
+| de       | 0.811       | 0.289           | 0.522  |
+| es       | 0.613       | 0.264           | 0.349  |
+| en→nb    | 0.512       | 0.362           | 0.150  |
+
+**Verdict: acceptable, ship as-is.** Norwegian and English both retrieve
+correctly, and cross-lingual (English query → Norwegian passage) works — so a
+bilingual note set is served by a single embedder. Observations:
+
+- **Norwegian margins are the thinnest** (~0.10 vs English's 0.34, German's
+  0.52). Still a clean win over distractors, but Norwegian passages sit closer
+  together in the space than the Latinate languages do. Not weak enough to act
+  on — RRF's keyword half backstops it, and absolute cosine isn't comparable
+  across languages anyway (only the ranking matters).
+- Per the fixed decision framework: **no model swap**. If Norwegian recall ever
+  disappoints in real use, tune retrieval first (smaller/overlapping chunks so a
+  specific passage isn't diluted; an instruction prefix on the query if the
+  embeddinggemma card recommends one; RRF `k`).
 
 ## Decision framework (fixed regardless of results)
 

--- a/docs/research/embed-48-multilingual/findings.md
+++ b/docs/research/embed-48-multilingual/findings.md
@@ -1,0 +1,59 @@
+# embeddinggemma multilingual sanity check (issue #48)
+
+**Status: harness ready; empirical run pending a local `embeddinggemma` pull.**
+
+This is the *non-blocking multilingual sanity check* the #48 acceptance criteria
+ask for. It is deliberately a sanity check, not a benchmark: `embeddinggemma` is
+Humla's **sole** local embedder, with **no fallback model**. If a language looks
+weak, the lever is retrieval tuning (chunk boundaries, RRF `k`, query
+formatting) — **never a model swap**. So the goal here is only to confirm the
+embedder is "good enough" across the languages Humla users actually write in,
+not to rank it against alternatives.
+
+## Method
+
+`probe.py` embeds query + passage sets via Ollama's OpenAI-compatible
+`/v1/embeddings` (the same wire path the app uses) and checks, per case, that
+the intended passage is the top cosine match over plausible distractors. Cases
+are **semantic, not lexical** — the correct passage shares meaning but not the
+query's keywords, so a pass demonstrates something keyword search alone can't do.
+
+Coverage: **Norwegian (Bokmål)** and **English** as the primary targets, plus a
+spot of **German** and **Spanish**, and one **cross-lingual** case (English
+query → Norwegian passage) since real notes mix languages.
+
+## How to run
+
+```
+ollama pull embeddinggemma       # ~600 MB, one-time
+python3 docs/research/embed-48-multilingual/probe.py
+```
+
+It writes `findings-run.json` (per-case cosine of the correct passage vs the
+best distractor) and exits non-zero if any case fails.
+
+## Why this wasn't auto-run in the implementing session
+
+`embeddinggemma` was not present on the dev machine, and the check is explicitly
+**non-blocking** for the slice — semantic retrieval degrades gracefully to
+keyword-only when the model is absent, so shipping #48 does not depend on it.
+Pulling a 600 MB model onto the user's machine without asking wasn't warranted
+for a sanity check. Run the command above to record results (paste the
+`findings-run.json` summary into the "Results" section below).
+
+## Results
+
+_Pending — run `probe.py` and record the per-language pass/fail + cosine
+margins here._
+
+## Decision framework (fixed regardless of results)
+
+- **All languages pass** → ship as-is; retrieval is already good enough.
+- **A language is weak** (correct passage not top, or thin margin over
+  distractors) → tune retrieval, in this order: (1) query formatting (e.g. an
+  instruction prefix if the model card recommends one), (2) chunk boundaries
+  (smaller/overlapping chunks surface a specific passage), (3) RRF `k` and pool
+  size in `hybrid_search_chunks`. Keyword (BM25) already backstops semantic
+  misses via RRF, so a weak language still returns literal matches.
+- **Never** add a second embedding model — that reintroduces the fixed-dim-
+  per-index and re-embed-on-switch complexity #48 deliberately avoids.

--- a/docs/research/embed-48-multilingual/probe.py
+++ b/docs/research/embed-48-multilingual/probe.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""embeddinggemma multilingual sanity check (issue #48, non-blocking).
+
+Embeds a small set of query/passage pairs in Norwegian, English, and a spot of
+other languages via Ollama's OpenAI-compatible /v1/embeddings, then checks that
+each query's most-similar passage (cosine) is its intended match — i.e. that
+semantic retrieval works acceptably per language. This is a sanity check, not a
+benchmark: embeddinggemma is the sole embedder, so the lever for a weak language
+is retrieval tuning (chunk boundaries, RRF params, query formatting), never a
+model swap.
+
+Run:
+    ollama pull embeddinggemma
+    python3 probe.py            # writes findings-run.json next to this file
+"""
+
+import json, math, os, sys, urllib.request
+
+BASE = os.environ.get("OLLAMA_BASE", "http://localhost:11434/v1")
+MODEL = "embeddinggemma"
+
+# (language, query, correct_passage, [distractor_passages]) — the correct
+# passage is a semantic (not lexical) match so keyword search alone would miss.
+CASES = [
+    ("en", "How much did we cut the marketing budget?",
+     "We agreed to reduce advertising spend by twenty percent this quarter.",
+     ["The new hire starts on Monday.", "Lunch was catered by the usual place."]),
+    ("nb", "Hvor mye kuttet vi i markedsføringsbudsjettet?",
+     "Vi ble enige om å redusere annonsekostnadene med tjue prosent dette kvartalet.",
+     ["Den nyansatte begynner på mandag.", "Lunsjen ble levert av det vanlige stedet."]),
+    ("nb", "Hvem er ansvarlig for lanseringen?",
+     "Kari tar eierskap til produktlanseringen neste måned.",
+     ["Møtet ble flyttet til torsdag.", "Vi diskuterte reisebudsjettet kort."]),
+    ("de", "Wann ist die Frist für das Angebot?",
+     "Das Angebot muss bis Freitagabend eingereicht werden.",
+     ["Der Kaffee war heute besonders gut.", "Das Team wächst nächstes Jahr."]),
+    ("es", "¿Quién aprobó el presupuesto?",
+     "La directora financiera dio el visto bueno al presupuesto del tercer trimestre.",
+     ["El almuerzo fue a la una.", "La sala de reuniones estaba ocupada."]),
+    # Cross-lingual: English query, Norwegian passage (embeddinggemma is
+    # multilingual — this should still retrieve).
+    ("en->nb", "What did we decide about hiring?",
+     "Vi bestemte oss for å ansette to nye utviklere i første kvartal.",
+     ["Vi snakket om kontorlokalene.", "Budsjettet ble godkjent uten endringer."]),
+]
+
+
+def embed(texts):
+    body = json.dumps({"model": MODEL, "input": texts}).encode()
+    req = urllib.request.Request(BASE + "/embeddings", data=body,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=120) as r:
+        data = json.loads(r.read())
+    return [d["embedding"] for d in sorted(data["data"], key=lambda d: d.get("index", 0))]
+
+
+def cosine(a, b):
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def main():
+    results, passed = [], 0
+    for lang, query, correct, distractors in CASES:
+        passages = [correct] + distractors
+        vecs = embed([query] + passages)
+        qv, pvs = vecs[0], vecs[1:]
+        sims = [cosine(qv, pv) for pv in pvs]
+        best = max(range(len(sims)), key=lambda i: sims[i])
+        ok = best == 0  # index 0 is the correct passage
+        passed += ok
+        results.append({"lang": lang, "query": query, "correct_rank_top": ok,
+                        "correct_sim": round(sims[0], 4),
+                        "best_distractor_sim": round(max(sims[1:]), 4)})
+        print(f"[{'PASS' if ok else 'FAIL'}] {lang:6} sim={sims[0]:.3f} "
+              f"vs distractor {max(sims[1:]):.3f}  {query[:48]}")
+
+    report = {"model": MODEL, "passed": passed, "total": len(CASES), "cases": results}
+    out = os.path.join(os.path.dirname(os.path.abspath(__file__)), "findings-run.json")
+    with open(out, "w") as f:
+        json.dump(report, f, indent=2, ensure_ascii=False)
+    print(f"\n{passed}/{len(CASES)} passed → {out}")
+    sys.exit(0 if passed == len(CASES) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -277,6 +277,7 @@ pub async fn run_chat(
     grounding: &str,
     scope: &ToolScope,
     workspace: &str,
+    embedder: Option<&dyn crate::embed::EmbeddingAdapter>,
     user_text: &str,
     mut sink: impl FnMut(ChatEvent) + Send,
 ) -> Result<()> {
@@ -316,7 +317,8 @@ pub async fn run_chat(
     // 3. Agentic loop.
     let specs = tool_specs();
     let result = agentic_loop(
-        db, adapter, ctx, scope, workspace, &specs, base, &assistant_id, &answer_block, &mut sink,
+        db, adapter, ctx, scope, workspace, &specs, base, &assistant_id, &answer_block, embedder,
+        &mut sink,
     )
     .await;
 
@@ -350,6 +352,7 @@ async fn agentic_loop(
     base: Vec<ChatTurn>,
     assistant_id: &str,
     answer_block: &str,
+    embedder: Option<&dyn crate::embed::EmbeddingAdapter>,
     sink: &mut (impl FnMut(ChatEvent) + Send),
 ) -> Result<Vec<Part>> {
     let mut working = base;
@@ -396,9 +399,33 @@ async fn agentic_loop(
         for call in &out.tool_calls {
             let args: serde_json::Value =
                 serde_json::from_str(&call.arguments).unwrap_or_else(|_| serde_json::json!({}));
+
+            // For a search, embed the query BEFORE taking the DB lock (embedding
+            // is async; the lock is not held across .await). A failed/absent
+            // embedder yields no vector → hybrid search degrades to keyword-only
+            // (issue #48 graceful degradation).
+            let (query_vec, embed_model): (Option<Vec<f32>>, &str) = match embedder {
+                Some(emb) if call.name == tools::TOOL_SEARCH => {
+                    let q = args.get("query").and_then(|v| v.as_str()).unwrap_or("");
+                    let vec = if q.trim().is_empty() {
+                        None
+                    } else {
+                        match emb.embed(std::slice::from_ref(&q.to_string())).await {
+                            Ok(mut v) => v.pop(),
+                            Err(e) => {
+                                eprintln!("[chat] query embed failed, keyword-only: {e}");
+                                None
+                            }
+                        }
+                    };
+                    (vec, emb.model_id())
+                }
+                _ => (None, ""),
+            };
+
             let outcome = {
                 let conn = db.lock();
-                execute_tool(&conn, workspace, scope, &call.name, &args)
+                execute_tool(&conn, workspace, scope, &call.name, &args, query_vec.as_deref(), embed_model)
             };
             sink(ChatEvent::ToolActivity {
                 message_id: assistant_id.to_string(),
@@ -563,7 +590,7 @@ mod tests {
         let adapter = FakeChatAdapter::new(["Hello world"]);
         let mut events: Vec<ChatEvent> = Vec::new();
         run_chat(
-            &dbh, &adapter, FAKE_CTX, &conv_id, "GROUNDING", &ToolScope::All, "", "What happened?",
+            &dbh, &adapter, FAKE_CTX, &conv_id, "GROUNDING", &ToolScope::All, "", None, "What happened?",
             |ev| events.push(ev),
         )
         .await
@@ -596,7 +623,7 @@ mod tests {
             let (dbh, _path) = temp_db(&dir);
             conv_id = conv(&dbh, "note-1");
             let adapter = FakeChatAdapter::new(["answer"]);
-            run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "G", &ToolScope::All, "", "hi", |_| {})
+            run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "G", &ToolScope::All, "", None, "hi", |_| {})
                 .await
                 .unwrap();
         }
@@ -646,7 +673,7 @@ mod tests {
         let (dbh, _path) = temp_db(&dir);
         let conv_id = conv(&dbh, "n");
         let res = run_chat(
-            &dbh, &FailingAdapter, FAKE_CTX, &conv_id, "G", &ToolScope::All, "", "hi", |_| {},
+            &dbh, &FailingAdapter, FAKE_CTX, &conv_id, "G", &ToolScope::All, "", None, "hi", |_| {},
         )
         .await;
         assert!(res.is_err());
@@ -673,7 +700,7 @@ mod tests {
         ]);
         let mut events: Vec<ChatEvent> = Vec::new();
         run_chat(
-            &dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", "what about budget?",
+            &dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "what about budget?",
             |ev| events.push(ev),
         )
         .await
@@ -707,7 +734,7 @@ mod tests {
             FakeChatAdapter::text_step("I couldn't open that note, but here's what I know."),
         ]);
         let mut events: Vec<ChatEvent> = Vec::new();
-        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", "open note x", |ev| {
+        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "open note x", |ev| {
             events.push(ev)
         })
         .await
@@ -734,7 +761,7 @@ mod tests {
             .map(|_| FakeChatAdapter::tool_step("c", "search_notes", r#"{"query":"content"}"#))
             .collect();
         let adapter = FakeChatAdapter::scripted(steps);
-        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", "keep going", |_| {})
+        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "keep going", |_| {})
             .await
             .unwrap();
 
@@ -765,7 +792,7 @@ mod tests {
         };
         let adapter =
             FakeChatAdapter::scripted(vec![preamble, FakeChatAdapter::text_step("The answer.")]);
-        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", "q", |_| {})
+        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "q", |_| {})
             .await
             .unwrap();
 
@@ -779,6 +806,45 @@ mod tests {
             })
             .collect();
         assert_eq!(text, "The answer.", "preamble on the tool step is not stored in the answer");
+    }
+
+    #[tokio::test]
+    async fn search_degrades_to_keyword_when_the_embedder_errors() {
+        // Issue #48 graceful degradation: an embedder that fails must not break
+        // chat — search falls back to keyword-only and still finds + cites.
+        struct FailingEmbedder;
+        #[async_trait::async_trait]
+        impl crate::embed::EmbeddingAdapter for FailingEmbedder {
+            fn model_id(&self) -> &str {
+                "boom"
+            }
+            async fn embed(&self, _texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+                Err(anyhow::anyhow!("embedding backend down"))
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let (dbh, _path) = temp_db(&dir);
+        let note_id = seed_note(&dbh, "Budget review", "We cut the marketing budget in Q3.");
+        let conv_id = conv(&dbh, "all");
+
+        let adapter = FakeChatAdapter::scripted(vec![
+            FakeChatAdapter::tool_step("c1", "search_notes", r#"{"query":"budget"}"#),
+            FakeChatAdapter::text_step("Your Q3 budget was cut."),
+        ]);
+        let mut events: Vec<ChatEvent> = Vec::new();
+        run_chat(
+            &dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", Some(&FailingEmbedder),
+            "budget?", |ev| events.push(ev),
+        )
+        .await
+        .unwrap();
+
+        // The failed embed didn't error the tool; the keyword hit still cited.
+        let cited = events.iter().any(|e| matches!(e, ChatEvent::Citations { citations, .. }
+            if citations.iter().any(|c| c.note_id == note_id)));
+        assert!(cited, "keyword fallback found and cited the note despite embed failure");
+        assert!(events.iter().any(|e| matches!(e, ChatEvent::Done { .. })));
     }
 
     #[tokio::test]
@@ -797,7 +863,7 @@ mod tests {
         ]);
         let mut events: Vec<ChatEvent> = Vec::new();
         run_chat(
-            &dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::Note(anchor.clone()), "",
+            &dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::Note(anchor.clone()), "", None,
             "find it", |ev| events.push(ev),
         )
         .await

--- a/src-tauri/src/chat/tools.rs
+++ b/src-tauri/src/chat/tools.rs
@@ -176,16 +176,21 @@ fn truncate(s: &str, max: usize) -> String {
 
 /// Run one tool call against the DB. Never returns `Err` — every failure path
 /// (unknown tool, bad args, DB error) becomes a `ToolOutcome { is_error }` the
-/// model reads and recovers from.
+/// model reads and recovers from. `query_vec`/`embed_model` carry the search
+/// query's embedding when semantic retrieval is available (issue #48) — the
+/// caller embeds the query before taking the DB lock, since embedding is async;
+/// `None` degrades `search_notes` to keyword-only.
 pub fn execute_tool(
     conn: &Connection,
     workspace: &str,
     scope: &ToolScope,
     name: &str,
     args: &Value,
+    query_vec: Option<&[f32]>,
+    embed_model: &str,
 ) -> ToolOutcome {
     match name {
-        TOOL_SEARCH => run_search(conn, workspace, scope, args),
+        TOOL_SEARCH => run_search(conn, workspace, scope, args, query_vec, embed_model),
         TOOL_GET => run_get(conn, workspace, scope, args),
         TOOL_LIST => run_list(conn, workspace, scope, args),
         other => ToolOutcome::error(format!(
@@ -194,12 +199,27 @@ pub fn execute_tool(
     }
 }
 
-fn run_search(conn: &Connection, workspace: &str, scope: &ToolScope, args: &Value) -> ToolOutcome {
+fn run_search(
+    conn: &Connection,
+    workspace: &str,
+    scope: &ToolScope,
+    args: &Value,
+    query_vec: Option<&[f32]>,
+    embed_model: &str,
+) -> ToolOutcome {
     let Some(query) = str_arg(args, "query") else {
         return ToolOutcome::error("search_notes needs a non-empty \"query\" string.");
     };
     let filter = resolve_filter(scope, args);
-    let hits = match db::search_chunks(conn, query, filter, workspace, clamp_limit(args)) {
+    let hits = match db::hybrid_search_chunks(
+        conn,
+        query,
+        query_vec,
+        embed_model,
+        filter,
+        workspace,
+        clamp_limit(args),
+    ) {
         Ok(h) => h,
         Err(e) => return ToolOutcome::error(format!("search failed: {e}")),
     };
@@ -334,6 +354,11 @@ mod tests {
         db::open(&dir.path().join("t.sqlite")).unwrap()
     }
 
+    /// Keyword-only tool call (no query embedding) — the common test path.
+    fn exec(conn: &Connection, workspace: &str, scope: &ToolScope, name: &str, args: &Value) -> ToolOutcome {
+        execute_tool(conn, workspace, scope, name, args, None, "")
+    }
+
     #[test]
     fn tool_specs_cover_the_three_tools() {
         let names: Vec<&str> = tool_specs().iter().map(|s| s.name).collect();
@@ -350,7 +375,7 @@ mod tests {
         let id = seed(&conn, "Budget review", "We cut the marketing budget in Q3.");
         seed(&conn, "Hiring", "Interviewed two backend engineers.");
 
-        let out = execute_tool(&conn, "", &ToolScope::All, TOOL_SEARCH, &json!({ "query": "budget" }));
+        let out = exec(&conn, "", &ToolScope::All, TOOL_SEARCH, &json!({ "query": "budget" }));
         assert!(!out.is_error);
         assert!(out.model_text.contains("Budget review"));
         assert_eq!(out.citations.len(), 1);
@@ -360,7 +385,7 @@ mod tests {
     #[test]
     fn search_empty_query_is_an_error_outcome_not_a_panic() {
         let conn = open();
-        let out = execute_tool(&conn, "", &ToolScope::All, TOOL_SEARCH, &json!({ "query": "  " }));
+        let out = exec(&conn, "", &ToolScope::All, TOOL_SEARCH, &json!({ "query": "  " }));
         assert!(out.is_error);
         assert!(out.citations.is_empty());
     }
@@ -370,7 +395,7 @@ mod tests {
         let conn = open();
         seed(&conn, "Budget", "Money talk.");
         let out =
-            execute_tool(&conn, "", &ToolScope::All, TOOL_SEARCH, &json!({ "query": "zzznonexistent" }));
+            exec(&conn, "", &ToolScope::All, TOOL_SEARCH, &json!({ "query": "zzznonexistent" }));
         assert!(!out.is_error, "an empty result is a valid answer, not a failure");
         assert!(out.model_text.to_lowercase().contains("no notes matched"));
         assert!(out.model_text.contains("Do not guess"));
@@ -380,7 +405,7 @@ mod tests {
     fn get_note_returns_full_content_and_a_citation() {
         let conn = open();
         let id = seed(&conn, "Kickoff", "Project kickoff transcript body.");
-        let out = execute_tool(&conn, "", &ToolScope::All, TOOL_GET, &json!({ "note_id": id }));
+        let out = exec(&conn, "", &ToolScope::All, TOOL_GET, &json!({ "note_id": id }));
         assert!(!out.is_error);
         assert!(out.model_text.contains("Project kickoff transcript body."));
         assert!(out.model_text.contains("[Transcript]"));
@@ -393,8 +418,8 @@ mod tests {
     #[test]
     fn get_note_missing_id_and_unknown_note_are_recoverable_errors() {
         let conn = open();
-        assert!(execute_tool(&conn, "", &ToolScope::All, TOOL_GET, &json!({})).is_error);
-        let out = execute_tool(&conn, "", &ToolScope::All, TOOL_GET, &json!({ "note_id": "nope" }));
+        assert!(exec(&conn, "", &ToolScope::All, TOOL_GET, &json!({})).is_error);
+        let out = exec(&conn, "", &ToolScope::All, TOOL_GET, &json!({ "note_id": "nope" }));
         assert!(out.is_error);
         assert!(out.model_text.contains("No note found"));
     }
@@ -406,9 +431,9 @@ mod tests {
         let other = seed(&conn, "Other", "other content");
         let scope = ToolScope::Note(anchor.clone());
         // The anchor is reachable...
-        assert!(!execute_tool(&conn, "", &scope, TOOL_GET, &json!({ "note_id": anchor })).is_error);
+        assert!(!exec(&conn, "", &scope, TOOL_GET, &json!({ "note_id": anchor })).is_error);
         // ...a different note is not.
-        let out = execute_tool(&conn, "", &scope, TOOL_GET, &json!({ "note_id": other }));
+        let out = exec(&conn, "", &scope, TOOL_GET, &json!({ "note_id": other }));
         assert!(out.is_error);
         assert!(out.model_text.contains("out of scope"));
     }
@@ -416,7 +441,7 @@ mod tests {
     #[test]
     fn unknown_tool_is_a_recoverable_error() {
         let conn = open();
-        let out = execute_tool(&conn, "", &ToolScope::All, "frobnicate", &json!({}));
+        let out = exec(&conn, "", &ToolScope::All, "frobnicate", &json!({}));
         assert!(out.is_error);
         assert!(out.model_text.contains("Unknown tool"));
     }
@@ -426,7 +451,7 @@ mod tests {
         let conn = open();
         seed(&conn, "First", "a");
         seed(&conn, "Second", "b");
-        let out = execute_tool(&conn, "", &ToolScope::All, TOOL_LIST, &json!({}));
+        let out = exec(&conn, "", &ToolScope::All, TOOL_LIST, &json!({}));
         assert!(!out.is_error);
         assert!(out.model_text.contains("First"));
         assert!(out.model_text.contains("Second"));

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2642,6 +2642,8 @@ async fn diarize_and_apply(
         // the final transcript — refresh retrieval chunks so chat can search it.
         chat::reindex_note_content(&conn, &note_id);
     }
+    // Embed the refreshed chunks off the request path (issue #48).
+    tauri::async_runtime::spawn(chat::embed_note_bg(app.clone(), note_id.clone()));
     let _ = app.emit(
         "transcript_replaced",
         TranscriptPayload {

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -8,10 +8,83 @@
 use super::{DEFAULT_LOCAL_LLM_BASE_URL, DEFAULT_SUMMARY_MODEL};
 use crate::chat::{self, ChatCtx, ChatEvent, Citation, ToolScope};
 use crate::db::{self, CHAT_SCOPE_NOTE, CHAT_TENANT_PERSONAL};
+use crate::embed::{self, EmbeddingAdapter, OLLAMA_EMBED_MODEL, OPENAI_EMBED_MODEL};
 use crate::openai;
 use crate::AppState;
+use parking_lot::Mutex;
+use rusqlite::Connection;
 use serde::Serialize;
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager, State};
+
+/// Derive the embedding config from the resolved chat provider (issue #48) —
+/// no user-facing embedding choice. Cloud chat embeds with OpenAI's
+/// `text-embedding-3-small`; local chat with `embeddinggemma` via the same
+/// Ollama server. Both speak the OpenAI-compatible `/v1/embeddings` shape.
+fn resolve_embed(resolved: &ResolvedChat) -> embed::EmbedConfig {
+    match resolved.provider.as_str() {
+        "ollama" => embed::EmbedConfig {
+            provider: "ollama",
+            model: OLLAMA_EMBED_MODEL,
+            base_url: resolved.base_url.clone(),
+            api_key: None,
+        },
+        _ => embed::EmbedConfig {
+            provider: "openai",
+            model: OPENAI_EMBED_MODEL,
+            base_url: resolved.base_url.clone(),
+            api_key: resolved.api_key.clone(),
+        },
+    }
+}
+
+/// Embed a Note's not-yet-embedded chunks under the adapter's model and cache
+/// them (issue #48). Content-addressed, so only changed/new text embeds. Best-
+/// effort: any failure (model missing, API error) logs and returns — chat still
+/// works keyword-only. The DB lock is never held across the embed `.await`.
+pub(crate) async fn embed_note(
+    db: &Arc<Mutex<Connection>>,
+    adapter: &dyn EmbeddingAdapter,
+    note_id: &str,
+) {
+    let need = {
+        let conn = db.lock();
+        db::note_texts_needing_embedding(&conn, note_id, adapter.model_id()).unwrap_or_default()
+    };
+    if need.is_empty() {
+        return;
+    }
+    let texts: Vec<String> = need.iter().map(|(_, t)| t.clone()).collect();
+    match adapter.embed(&texts).await {
+        Ok(vectors) if vectors.len() == need.len() => {
+            let conn = db.lock();
+            for ((hash, _), vector) in need.iter().zip(vectors.iter()) {
+                let _ = db::store_embedding(&conn, hash, adapter.model_id(), vector);
+            }
+        }
+        Ok(vectors) => eprintln!(
+            "[chat] embed count mismatch for note {note_id}: {} vectors for {} chunks",
+            vectors.len(),
+            need.len()
+        ),
+        Err(e) => eprintln!("[chat] embed_note {note_id} failed (keyword-only): {e}"),
+    }
+}
+
+/// Resolve the embedding provider and embed a Note off the request path
+/// (content-settled checkpoint). Spawned fire-and-forget after a re-chunk so
+/// editing never blocks on embedding. No-op if no provider is configured.
+pub async fn embed_note_bg(app: AppHandle, note_id: String) {
+    let state: State<AppState> = app.state();
+    let key = super::read_provider_api_key(&state, "openai").ok().flatten();
+    let resolved = {
+        let conn = state.db.lock();
+        resolve_chat(&conn, key)
+    };
+    let Ok(resolved) = resolved else { return };
+    let adapter = resolve_embed(&resolved).adapter();
+    embed_note(&state.db, &adapter, &note_id).await;
+}
 
 /// Rebuild one Note's retrieval chunks from its current content. The single
 /// place body-HTML→text + `db::reindex_note` are combined, called from every
@@ -33,7 +106,7 @@ pub(crate) fn reindex_note_content(conn: &rusqlite::Connection, note_id: &str) {
 pub fn backfill_note_chunks(db: &std::sync::Arc<parking_lot::Mutex<rusqlite::Connection>>) {
     let ids = {
         let conn = db.lock();
-        db::note_ids_without_chunks(&conn).unwrap_or_default()
+        db::note_ids_needing_reindex(&conn).unwrap_or_default()
     };
     if ids.is_empty() {
         return;
@@ -47,11 +120,16 @@ pub fn backfill_note_chunks(db: &std::sync::Arc<parking_lot::Mutex<rusqlite::Con
 
 /// Rebuild a Note's retrieval index on demand — the frontend calls this when
 /// the Note view unmounts, so edits made without triggering summarize/diarize
-/// still land in search.
+/// still land in search. Re-chunks synchronously, then embeds off the request
+/// path (issue #48) so unmount stays snappy.
 #[tauri::command]
-pub fn chat_reindex_note(state: State<AppState>, note_id: String) -> Result<(), String> {
-    let conn = state.db.lock();
-    reindex_note_content(&conn, &note_id);
+pub fn chat_reindex_note(app: AppHandle, note_id: String) -> Result<(), String> {
+    {
+        let state: State<AppState> = app.state();
+        let conn = state.db.lock();
+        reindex_note_content(&conn, &note_id);
+    }
+    tauri::async_runtime::spawn(embed_note_bg(app, note_id));
     Ok(())
 }
 
@@ -215,6 +293,13 @@ pub async fn chat_send(
         (grounding, resolved, conversation.id, tool_scope, workspace)
     };
 
+    // Embed the anchor Note now (best-effort, cached) so semantic search works
+    // for the note the user is chatting about on the very first question. Other
+    // notes are embedded at their own checkpoints (issue #48).
+    let embed_cfg = resolve_embed(&resolved);
+    let embedder = embed_cfg.adapter();
+    embed_note(&state.db, &embedder, &note_id).await;
+
     let adapter = chat::build_chat_adapter(&resolved.provider);
     let conv_for_sink = conversation_id.clone();
     let app_for_sink = app.clone();
@@ -269,6 +354,7 @@ pub async fn chat_send(
         &grounding.text,
         &tool_scope,
         &workspace,
+        Some(&embedder as &dyn EmbeddingAdapter),
         &message,
         sink,
     )

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -118,6 +118,35 @@ pub fn backfill_note_chunks(db: &std::sync::Arc<parking_lot::Mutex<rusqlite::Con
     }
 }
 
+/// One-time embedding backfill (issue #48): after chunks exist, embed every
+/// Note that still lacks vectors under the current model, so semantic search
+/// covers the whole corpus on day one — not only notes touched since #48.
+/// Runs off the request path at startup, best-effort (a missing model / API
+/// error just leaves those notes keyword-only). Batched per Note + cached, so
+/// it's idempotent and cheap on reruns.
+pub async fn embed_backfill(app: AppHandle) {
+    let state: State<AppState> = app.state();
+    let key = super::read_provider_api_key(&state, "openai").ok().flatten();
+    let resolved = {
+        let conn = state.db.lock();
+        resolve_chat(&conn, key)
+    };
+    let Ok(resolved) = resolved else { return };
+    let adapter = resolve_embed(&resolved).adapter();
+    let ids = {
+        let conn = state.db.lock();
+        db::note_ids_needing_embedding(&conn, adapter.model_id()).unwrap_or_default()
+    };
+    if ids.is_empty() {
+        return;
+    }
+    eprintln!("[chat] embedding backfill: {} note(s) under {}", ids.len(), adapter.model_id());
+    for id in ids {
+        embed_note(&state.db, &adapter, &id).await;
+    }
+    eprintln!("[chat] embedding backfill complete");
+}
+
 /// Rebuild a Note's retrieval index on demand — the frontend calls this when
 /// the Note view unmounts, so edits made without triggering summarize/diarize
 /// still land in search. Re-chunks synchronously, then embeds off the request

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -177,6 +177,17 @@ fn resolve_scope(breadth: &str, note: &db::Note) -> ToolScope {
     }
 }
 
+/// Whether a model id is embedding-only (can't do chat completions). Mirrors
+/// the frontend `isEmbeddingModel` heuristic — matches embeddinggemma and the
+/// common embedding families.
+fn is_embedding_model(model: &str) -> bool {
+    let m = model.to_lowercase();
+    m.contains("embed")
+        || m.starts_with("bge-")
+        || m.starts_with("all-minilm")
+        || m.starts_with("paraphrase-")
+}
+
 // Resolved chat provider for a single call. Only "openai" (cloud, shared key)
 // and "ollama" (local) are valid — see issue #44.
 struct ResolvedChat {
@@ -211,6 +222,15 @@ fn resolve_chat(
             let model = model_setting.ok_or_else(|| {
                 anyhow::anyhow!("No chat model configured — pick one in Settings → Chat.")
             })?;
+            // Defence in depth: an embedding model (e.g. embeddinggemma, pulled
+            // for semantic search) can't do chat — Ollama 400s "does not support
+            // chat". The pickers now exclude it, but guard a stale setting too.
+            if is_embedding_model(&model) {
+                anyhow::bail!(
+                    "“{model}” is an embedding model and can't chat — pick a chat model in \
+                     Settings → Chat."
+                );
+            }
             Ok(ResolvedChat { provider, base_url, api_key: None, model, think })
         }
         _ => {
@@ -434,4 +454,31 @@ pub fn chat_history(state: State<AppState>, note_id: String) -> Result<Vec<ChatM
             created_at: m.created_at,
         })
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedding_models_are_recognised() {
+        for m in ["embeddinggemma", "embeddinggemma:latest", "nomic-embed-text", "mxbai-embed-large", "bge-m3", "all-minilm", "snowflake-arctic-embed2", "paraphrase-multilingual"] {
+            assert!(is_embedding_model(m), "expected embedding: {m}");
+        }
+        for m in ["gemma4:12b-mlx", "qwen3.5:4b", "llama3.2:3b", "gpt-5.4-mini"] {
+            assert!(!is_embedding_model(m), "expected chat-capable: {m}");
+        }
+    }
+
+    #[test]
+    fn resolve_chat_rejects_an_embedding_model_as_the_chat_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("t.sqlite")).unwrap();
+        db::set_setting(&conn, "chat_provider", "ollama").unwrap();
+        db::set_setting(&conn, "chat_model", "embeddinggemma:latest").unwrap();
+        let res = resolve_chat(&conn, None);
+        assert!(res.is_err());
+        let err = res.err().unwrap().to_string();
+        assert!(err.contains("embedding model"), "clear guidance, not a raw 400: {err}");
+    }
 }

--- a/src-tauri/src/commands/summary.rs
+++ b/src-tauri/src/commands/summary.rs
@@ -233,6 +233,8 @@ async fn run_summary(app: AppHandle, note_id: String) -> anyhow::Result<()> {
         // searchable material — refresh the Note's retrieval chunks.
         super::chat::reindex_note_content(&conn, &note_id);
     }
+    // Embed the refreshed chunks off the request path (issue #48).
+    tauri::async_runtime::spawn(super::chat::embed_note_bg(app.clone(), note_id.clone()));
     state.sync.note_upserted(&note_id); // AI summary written → enqueue a push
     let _ = app.emit("summary_ready", SummaryPayload { note_id, summary });
     Ok(())

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -182,15 +182,20 @@ pub fn open(path: &Path) -> Result<Connection> {
         -- semantic embeddings). `note_chunks` holds the structured rows (source
         -- + order + text) for citations; `note_chunks_fts` is the FTS5 index the
         -- search tool queries. The two are kept in lockstep by `reindex_note`.
+        -- `text_hash` (issue #48) content-addresses each chunk so its embedding
+        -- survives a reindex (which churns chunk ids): unchanged text keeps its
+        -- cached vector, only changed text re-embeds.
         CREATE TABLE IF NOT EXISTS note_chunks (
             id          TEXT PRIMARY KEY,
             note_id     TEXT NOT NULL,
             seq         INTEGER NOT NULL,
             source      TEXT NOT NULL,
             text        TEXT NOT NULL,
+            text_hash   TEXT NOT NULL DEFAULT '',
             created_at  INTEGER NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_note_chunks_note ON note_chunks(note_id);
+        CREATE INDEX IF NOT EXISTS idx_note_chunks_hash ON note_chunks(text_hash);
 
         -- Standalone FTS5 index (not external-content, so plain DELETE/INSERT
         -- keep it in sync without triggers). `chunk_id`/`note_id` ride along
@@ -202,8 +207,24 @@ pub fn open(path: &Path) -> Result<Connection> {
             note_id UNINDEXED,
             tokenize = 'unicode61 remove_diacritics 2'
         );
+
+        -- Content-addressed embedding cache (issue #48). Keyed by (text_hash,
+        -- model): one vector per distinct chunk text per embedding model. A
+        -- model switch just misses the cache and re-embeds under the new key
+        -- (fixed-dim-per-index — a query only ever reads one model's vectors).
+        -- Brute-force cosine in-process; no vector index.
+        CREATE TABLE IF NOT EXISTS chunk_embeddings (
+            text_hash   TEXT NOT NULL,
+            model       TEXT NOT NULL,
+            dims        INTEGER NOT NULL,
+            vector      BLOB NOT NULL,
+            created_at  INTEGER NOT NULL,
+            PRIMARY KEY (text_hash, model)
+        );
         "#,
     )?;
+    // #48: add text_hash to note_chunks created by the #47 schema.
+    let _ = conn.execute("ALTER TABLE note_chunks ADD COLUMN text_hash TEXT NOT NULL DEFAULT ''", []);
     // Idempotent migrations for older schemas. ALTER TABLE adds columns
     // that didn't exist in earlier versions; if they already exist, the
     // execute fails and we ignore.
@@ -1155,10 +1176,11 @@ pub fn reindex_note(
     let chunks = note_chunk_texts(body_text, transcript, summary);
     for (seq, (source, text)) in chunks.iter().enumerate() {
         let chunk_id = uuid::Uuid::new_v4().to_string();
+        let hash = text_hash(text);
         conn.execute(
-            "INSERT INTO note_chunks (id, note_id, seq, source, text, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![chunk_id, note_id, seq as i64, source, text, now],
+            "INSERT INTO note_chunks (id, note_id, seq, source, text, text_hash, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![chunk_id, note_id, seq as i64, source, text, hash, now],
         )?;
         conn.execute(
             "INSERT INTO note_chunks_fts (text, chunk_id, note_id) VALUES (?1, ?2, ?3)",
@@ -1166,6 +1188,19 @@ pub fn reindex_note(
         )?;
     }
     Ok(chunks.len())
+}
+
+/// Stable content hash for a chunk's text — the embedding cache key. FNV-1a
+/// (64-bit, hex): deterministic across runs/platforms, no dependency. Collision
+/// probability at personal scale (thousands of chunks) is negligible, and the
+/// only cost of one would be a single chunk borrowing another's vector.
+pub fn text_hash(text: &str) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in text.as_bytes() {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
 }
 
 /// Drop a Note's chunk + FTS rows (e.g. before a rebuild, or when a Note is
@@ -1176,12 +1211,16 @@ pub fn remove_note_chunks(conn: &Connection, note_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Ids of live notes that have no chunks yet — the work-list for the one-time
-/// startup backfill that makes pre-#47 notes searchable. Cheap anti-join.
-pub fn note_ids_without_chunks(conn: &Connection) -> Result<Vec<String>> {
+/// Ids of live notes needing a (re)index — the startup-backfill work-list.
+/// Covers notes with no chunks (pre-#47) AND notes whose chunks predate the
+/// #48 `text_hash` column (so re-chunking backfills the embedding key). Cheap
+/// anti-join / existence check.
+pub fn note_ids_needing_reindex(conn: &Connection) -> Result<Vec<String>> {
     let mut stmt = conn.prepare(
-        "SELECT id FROM notes WHERE deleted_at IS NULL \
-         AND id NOT IN (SELECT DISTINCT note_id FROM note_chunks)",
+        "SELECT id FROM notes WHERE deleted_at IS NULL AND ( \
+             id NOT IN (SELECT DISTINCT note_id FROM note_chunks) \
+             OR id IN (SELECT DISTINCT note_id FROM note_chunks WHERE text_hash = '') \
+         )",
     )?;
     let ids = stmt
         .query_map([], |r| r.get::<_, String>(0))?
@@ -1262,6 +1301,273 @@ pub fn search_chunks(
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows)
+}
+
+// ── Semantic retrieval: embedding cache + hybrid (RRF) search (issue #48) ────
+
+/// Encode an embedding vector as a little-endian f32 blob for storage.
+fn vec_to_blob(v: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(v.len() * 4);
+    for f in v {
+        out.extend_from_slice(&f.to_le_bytes());
+    }
+    out
+}
+
+/// Decode a stored little-endian f32 blob back to a vector. A blob whose length
+/// isn't a multiple of 4 (corrupt) decodes to what fits, ignoring the tail.
+fn blob_to_vec(b: &[u8]) -> Vec<f32> {
+    b.chunks_exact(4).map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect()
+}
+
+/// Distinct (text_hash, text) for a Note's chunks that have no embedding under
+/// `model` yet — the incremental re-embed work-list for a content-settled
+/// checkpoint. Only changed/new text (cache-missing hashes) comes back.
+pub fn note_texts_needing_embedding(
+    conn: &Connection,
+    note_id: &str,
+    model: &str,
+) -> Result<Vec<(String, String)>> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT c.text_hash, c.text FROM note_chunks c \
+         WHERE c.note_id = ?1 AND c.text_hash <> '' \
+         AND NOT EXISTS ( \
+            SELECT 1 FROM chunk_embeddings e \
+            WHERE e.text_hash = c.text_hash AND e.model = ?2 \
+         )",
+    )?;
+    let rows = stmt
+        .query_map(params![note_id, model], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// Store one chunk's embedding under (text_hash, model). Idempotent (REPLACE),
+/// so a re-embed of the same text overwrites rather than duplicates.
+pub fn store_embedding(conn: &Connection, text_hash: &str, model: &str, vector: &[f32]) -> Result<()> {
+    conn.execute(
+        "INSERT OR REPLACE INTO chunk_embeddings (text_hash, model, dims, vector, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![text_hash, model, vector.len() as i64, vec_to_blob(vector), now_ms()],
+    )?;
+    Ok(())
+}
+
+/// How many chunk embeddings exist for a model (telemetry / tests).
+pub fn count_embeddings(conn: &Connection, model: &str) -> Result<i64> {
+    Ok(conn.query_row(
+        "SELECT COUNT(*) FROM chunk_embeddings WHERE model = ?1",
+        params![model],
+        |r| r.get(0),
+    )?)
+}
+
+/// Cosine similarity of two equal-length vectors in [-1, 1]. Returns 0 for a
+/// length mismatch or a zero-magnitude vector (degenerate, not comparable).
+pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+/// Reciprocal Rank Fusion. Each input list is item ids in rank order (best
+/// first). An item's fused score is Σ 1/(k + rank+1) over the lists it appears
+/// in; higher = better. Returns ids with scores, best first. `k` damps the
+/// contribution of low ranks (60 is the standard default).
+pub fn rrf_fuse(lists: &[Vec<String>], k: f64) -> Vec<(String, f64)> {
+    use std::collections::HashMap;
+    let mut scores: HashMap<String, f64> = HashMap::new();
+    for list in lists {
+        for (rank, id) in list.iter().enumerate() {
+            *scores.entry(id.clone()).or_insert(0.0) += 1.0 / (k + (rank as f64) + 1.0);
+        }
+    }
+    let mut fused: Vec<(String, f64)> = scores.into_iter().collect();
+    // Sort by score desc; tie-break by id for determinism.
+    fused.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal).then(a.0.cmp(&b.0)));
+    fused
+}
+
+/// A chunk hit that carries its stable chunk id (for fusion) alongside the
+/// citation fields.
+struct IdentifiedHit {
+    chunk_id: String,
+    hit: ChunkHit,
+}
+
+/// Keyword-ranked chunks (bm25, best first) with their chunk ids — the FTS half
+/// of hybrid search. Mirrors `search_chunks`' filters.
+fn keyword_ranked(
+    conn: &Connection,
+    query: &str,
+    filter: NoteFilter<'_>,
+    workspace: &str,
+    limit: usize,
+) -> Result<Vec<IdentifiedHit>> {
+    let Some(match_expr) = fts_match_query(query) else {
+        return Ok(Vec::new());
+    };
+    use rusqlite::types::Value;
+    let mut sql = String::from(
+        "SELECT c.id, n.id, n.title, n.created_at, c.source, c.text, bm25(note_chunks_fts) AS rank \
+         FROM note_chunks_fts f \
+         JOIN note_chunks c ON c.id = f.chunk_id \
+         JOIN notes n ON n.id = c.note_id \
+         WHERE note_chunks_fts MATCH ?1 AND n.workspace_id = ?2 AND n.deleted_at IS NULL",
+    );
+    let mut args: Vec<Value> = vec![Value::Text(match_expr), Value::Text(workspace.to_string())];
+    push_note_filters(&mut sql, &mut args, filter, "n");
+    args.push(Value::Integer(limit as i64));
+    sql.push_str(&format!(" ORDER BY rank LIMIT ?{}", args.len()));
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(args), |row| {
+            Ok(IdentifiedHit {
+                chunk_id: row.get(0)?,
+                hit: ChunkHit {
+                    note_id: row.get(1)?,
+                    note_title: row.get(2)?,
+                    note_created_at: row.get(3)?,
+                    source: row.get(4)?,
+                    text: row.get(5)?,
+                    rank: row.get(6)?,
+                },
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// Semantic-ranked chunks (cosine vs `query_vec`, best first) for chunks that
+/// have an embedding under `model`. Brute-force over all in-scope chunks — no
+/// vector index (issue #48).
+fn semantic_ranked(
+    conn: &Connection,
+    query_vec: &[f32],
+    model: &str,
+    filter: NoteFilter<'_>,
+    workspace: &str,
+    limit: usize,
+) -> Result<Vec<IdentifiedHit>> {
+    use rusqlite::types::Value;
+    let mut sql = String::from(
+        "SELECT c.id, n.id, n.title, n.created_at, c.source, c.text, e.vector \
+         FROM note_chunks c \
+         JOIN chunk_embeddings e ON e.text_hash = c.text_hash AND e.model = ?1 \
+         JOIN notes n ON n.id = c.note_id \
+         WHERE n.workspace_id = ?2 AND n.deleted_at IS NULL",
+    );
+    let mut args: Vec<Value> = vec![Value::Text(model.to_string()), Value::Text(workspace.to_string())];
+    push_note_filters(&mut sql, &mut args, filter, "n");
+    let mut stmt = conn.prepare(&sql)?;
+    let mut scored: Vec<(f32, IdentifiedHit)> = stmt
+        .query_map(rusqlite::params_from_iter(args), |row| {
+            let blob: Vec<u8> = row.get(6)?;
+            let sim = cosine(query_vec, &blob_to_vec(&blob));
+            Ok((
+                sim,
+                IdentifiedHit {
+                    chunk_id: row.get(0)?,
+                    hit: ChunkHit {
+                        note_id: row.get(1)?,
+                        note_title: row.get(2)?,
+                        note_created_at: row.get(3)?,
+                        source: row.get(4)?,
+                        text: row.get(5)?,
+                        rank: 0.0,
+                    },
+                },
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(limit);
+    Ok(scored.into_iter().map(|(sim, mut ih)| {
+        ih.hit.rank = sim as f64; // carry the cosine similarity for reference
+        ih
+    }).collect())
+}
+
+/// Append the combinable note filters to a query being built, using positional
+/// params against alias `t`. Shared by keyword + semantic + list queries.
+fn push_note_filters(
+    sql: &mut String,
+    args: &mut Vec<rusqlite::types::Value>,
+    filter: NoteFilter<'_>,
+    t: &str,
+) {
+    use rusqlite::types::Value;
+    if let Some(id) = filter.note_id {
+        args.push(Value::Text(id.to_string()));
+        sql.push_str(&format!(" AND {t}.id = ?{}", args.len()));
+    }
+    if let Some(f) = filter.folder_id {
+        args.push(Value::Text(f.to_string()));
+        sql.push_str(&format!(" AND {t}.folder_id = ?{}", args.len()));
+    }
+    if let Some(cl) = filter.client_id {
+        args.push(Value::Text(cl.to_string()));
+        sql.push_str(&format!(" AND {t}.client_id = ?{}", args.len()));
+    }
+}
+
+/// The size of each per-signal candidate pool fused by RRF. Bigger than the
+/// final `limit` so a chunk ranked mid-pack by one signal can still win on the
+/// other.
+const HYBRID_POOL: usize = 20;
+/// RRF damping constant (standard default).
+const RRF_K: f64 = 60.0;
+
+/// Hybrid keyword+semantic search. With `query_vec = Some`, fuses BM25 and
+/// cosine rankings via RRF; with `None` (embedding unavailable), degrades to
+/// keyword-only so chat still works (issue #48 graceful degradation). Returns
+/// the top `limit` chunk hits.
+pub fn hybrid_search_chunks(
+    conn: &Connection,
+    query: &str,
+    query_vec: Option<&[f32]>,
+    model: &str,
+    filter: NoteFilter<'_>,
+    workspace: &str,
+    limit: usize,
+) -> Result<Vec<ChunkHit>> {
+    let keyword = keyword_ranked(conn, query, filter, workspace, HYBRID_POOL)?;
+    let Some(qv) = query_vec else {
+        // Keyword-only fallback.
+        return Ok(keyword.into_iter().take(limit).map(|ih| ih.hit).collect());
+    };
+    let semantic = semantic_ranked(conn, qv, model, filter, workspace, HYBRID_POOL)?;
+    if semantic.is_empty() {
+        // No vectors yet (e.g. not embedded) → keyword-only.
+        return Ok(keyword.into_iter().take(limit).map(|ih| ih.hit).collect());
+    }
+
+    // Fuse by chunk id; keep a lookup so the winners map back to their hits.
+    use std::collections::HashMap;
+    let mut hits: HashMap<String, ChunkHit> = HashMap::new();
+    let kw_ids: Vec<String> = keyword.into_iter().map(|ih| { hits.insert(ih.chunk_id.clone(), ih.hit); ih.chunk_id }).collect();
+    let sem_ids: Vec<String> = semantic.into_iter().map(|ih| { hits.entry(ih.chunk_id.clone()).or_insert(ih.hit); ih.chunk_id }).collect();
+    let fused = rrf_fuse(&[kw_ids, sem_ids], RRF_K);
+    Ok(fused
+        .into_iter()
+        .take(limit)
+        .filter_map(|(id, score)| hits.remove(&id).map(|mut h| {
+            h.rank = score; // fused RRF score (higher = better)
+            h
+        }))
+        .collect())
 }
 
 /// List live Notes in a workspace, optionally narrowed by folder and/or client,
@@ -2105,5 +2411,120 @@ mod tests {
         assert_eq!(list_notes_filtered(&conn, NoteFilter::default(), "", 10).unwrap().len(), 2);
         assert_eq!(list_notes_filtered(&conn, f_folder, "", 10).unwrap().len(), 1);
         assert_eq!(list_notes_filtered(&conn, f_client, "", 10).unwrap().len(), 1);
+    }
+
+    // ── Semantic retrieval: embeddings + hybrid RRF (issue #48) ──────────────
+
+    #[test]
+    fn cosine_handles_identical_orthogonal_and_mismatched() {
+        assert!((cosine(&[1.0, 0.0], &[1.0, 0.0]) - 1.0).abs() < 1e-6);
+        assert!(cosine(&[1.0, 0.0], &[0.0, 1.0]).abs() < 1e-6);
+        assert!((cosine(&[1.0, 2.0, 3.0], &[2.0, 4.0, 6.0]) - 1.0).abs() < 1e-6, "scale-invariant");
+        assert_eq!(cosine(&[1.0, 0.0], &[1.0, 0.0, 0.0]), 0.0, "length mismatch → 0");
+        assert_eq!(cosine(&[0.0, 0.0], &[1.0, 1.0]), 0.0, "zero vector → 0");
+    }
+
+    #[test]
+    fn rrf_ranks_items_strong_in_both_lists_highest() {
+        let kw = vec!["X".to_string(), "A".into(), "B".into()];
+        let sem = vec!["X".to_string(), "C".into(), "D".into()];
+        let fused = rrf_fuse(&[kw, sem], 60.0);
+        assert_eq!(fused[0].0, "X", "top-of-both wins");
+        // X's score is strictly greater than any single-list item's.
+        let x = fused[0].1;
+        assert!(fused[1..].iter().all(|(_, s)| *s < x));
+    }
+
+    #[test]
+    fn embedding_cache_is_incremental_across_reindex() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = open(&dir.path().join("embed.sqlite")).unwrap();
+        let n = create_note(&conn, "en", "meeting", "").unwrap();
+
+        // transcript + summary chunk independently → two chunks.
+        let write = |transcript: &str, summary: &str| {
+            update_note(
+                &conn,
+                &n.id,
+                &NotePatch {
+                    transcript: Some(transcript.into()),
+                    summary: Some(summary.into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            let fresh = get_note(&conn, &n.id).unwrap();
+            reindex_note(&conn, &n.id, &fresh.body, &fresh.transcript, &fresh.summary).unwrap();
+        };
+        write("transcript about budgets", "summary about hiring");
+
+        // Both chunks need embedding; embed them.
+        let need = note_texts_needing_embedding(&conn, &n.id, "m").unwrap();
+        assert_eq!(need.len(), 2);
+        for (hash, _text) in &need {
+            store_embedding(&conn, hash, "m", &[1.0, 0.0, 0.0]).unwrap();
+        }
+        assert!(note_texts_needing_embedding(&conn, &n.id, "m").unwrap().is_empty(), "all cached now");
+        assert_eq!(count_embeddings(&conn, "m").unwrap(), 2);
+
+        // Edit ONLY the summary; the transcript chunk is unchanged. Reindex
+        // churns chunk ids, but the content-addressed cache means only the
+        // changed text re-embeds.
+        write("transcript about budgets", "GAMMA totally new summary text");
+        let need2 = note_texts_needing_embedding(&conn, &n.id, "m").unwrap();
+        assert_eq!(need2.len(), 1, "only the changed chunk re-embeds");
+        assert!(need2[0].1.contains("GAMMA"));
+
+        // A different model misses the cache entirely (fixed-dim-per-index).
+        assert_eq!(note_texts_needing_embedding(&conn, &n.id, "other").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn hybrid_falls_back_to_keyword_without_a_query_vector() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = open(&dir.path().join("hybrid_kw.sqlite")).unwrap();
+        let a = create_note(&conn, "en", "meeting", "").unwrap();
+        update_note(&conn, &a.id, &NotePatch { transcript: Some("quarterly financial planning".into()), ..Default::default() }).unwrap();
+        let na = get_note(&conn, &a.id).unwrap();
+        reindex_note(&conn, &a.id, &na.body, &na.transcript, &na.summary).unwrap();
+
+        // No query vector → keyword-only, still finds the term.
+        let hits = hybrid_search_chunks(&conn, "financial", None, "m", NoteFilter::default(), "", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].note_id, a.id);
+    }
+
+    #[test]
+    fn hybrid_surfaces_a_semantic_only_match_via_rrf() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = open(&dir.path().join("hybrid_sem.sqlite")).unwrap();
+        // note A matches the keyword "budget"; note B does not, but is a near-
+        // synonym match by meaning (we give it a vector identical to the query).
+        let a = create_note(&conn, "en", "meeting", "").unwrap();
+        update_note(&conn, &a.id, &NotePatch { transcript: Some("the budget was approved".into()), ..Default::default() }).unwrap();
+        let b = create_note(&conn, "en", "meeting", "").unwrap();
+        update_note(&conn, &b.id, &NotePatch { transcript: Some("we discussed spending limits".into()), ..Default::default() }).unwrap();
+        for id in [&a.id, &b.id] {
+            let nn = get_note(&conn, id).unwrap();
+            reindex_note(&conn, id, &nn.body, &nn.transcript, &nn.summary).unwrap();
+        }
+
+        // Query vector = [1,0,0]. Give B's chunk that exact vector (cosine 1.0),
+        // A's an orthogonal one (cosine 0) — so semantic ranks B above A.
+        let embed = |note_id: &str, v: &[f32]| {
+            for (hash, _t) in note_texts_needing_embedding(&conn, note_id, "m").unwrap() {
+                store_embedding(&conn, &hash, "m", v).unwrap();
+            }
+        };
+        embed(&a.id, &[0.0, 1.0, 0.0]);
+        embed(&b.id, &[1.0, 0.0, 0.0]);
+
+        let qv = [1.0f32, 0.0, 0.0];
+        let hits = hybrid_search_chunks(&conn, "budget", Some(&qv), "m", NoteFilter::default(), "", 10).unwrap();
+        let note_ids: Vec<&str> = hits.iter().map(|h| h.note_id.as_str()).collect();
+        // Keyword finds A; semantic surfaces B. Hybrid returns BOTH — the
+        // semantic-only match B would be invisible to keyword search alone.
+        assert!(note_ids.contains(&a.id.as_str()), "keyword match present");
+        assert!(note_ids.contains(&b.id.as_str()), "semantic-only match surfaced by RRF");
     }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1248,61 +1248,6 @@ fn fts_match_query(query: &str) -> Option<String> {
     }
 }
 
-/// Keyword-search Note chunks in a workspace, optionally narrowed by folder
-/// and/or client (independent, combinable filters — never a nested taxonomy).
-/// Returns the top `limit` chunk hits ranked by bm25. An empty/uparseable query
-/// or no matches returns an empty vec (the tool layer turns that into a
-/// structured "no results" the model recovers from).
-pub fn search_chunks(
-    conn: &Connection,
-    query: &str,
-    filter: NoteFilter<'_>,
-    workspace: &str,
-    limit: usize,
-) -> Result<Vec<ChunkHit>> {
-    let Some(match_expr) = fts_match_query(query) else {
-        return Ok(Vec::new());
-    };
-    use rusqlite::types::Value;
-    let mut sql = String::from(
-        "SELECT n.id, n.title, n.created_at, c.source, c.text, bm25(note_chunks_fts) AS rank \
-         FROM note_chunks_fts f \
-         JOIN note_chunks c ON c.id = f.chunk_id \
-         JOIN notes n ON n.id = c.note_id \
-         WHERE note_chunks_fts MATCH ?1 AND n.workspace_id = ?2 AND n.deleted_at IS NULL",
-    );
-    let mut args: Vec<Value> = vec![Value::Text(match_expr), Value::Text(workspace.to_string())];
-    if let Some(id) = filter.note_id {
-        args.push(Value::Text(id.to_string()));
-        sql.push_str(&format!(" AND n.id = ?{}", args.len()));
-    }
-    if let Some(f) = filter.folder_id {
-        args.push(Value::Text(f.to_string()));
-        sql.push_str(&format!(" AND n.folder_id = ?{}", args.len()));
-    }
-    if let Some(cl) = filter.client_id {
-        args.push(Value::Text(cl.to_string()));
-        sql.push_str(&format!(" AND n.client_id = ?{}", args.len()));
-    }
-    args.push(Value::Integer(limit as i64));
-    sql.push_str(&format!(" ORDER BY rank LIMIT ?{}", args.len()));
-
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt
-        .query_map(rusqlite::params_from_iter(args), |row| {
-            Ok(ChunkHit {
-                note_id: row.get(0)?,
-                note_title: row.get(1)?,
-                note_created_at: row.get(2)?,
-                source: row.get(3)?,
-                text: row.get(4)?,
-                rank: row.get(5)?,
-            })
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    Ok(rows)
-}
-
 // ── Semantic retrieval: embedding cache + hybrid (RRF) search (issue #48) ────
 
 /// Encode an embedding vector as a little-endian f32 blob for storage.
@@ -1353,7 +1298,28 @@ pub fn store_embedding(conn: &Connection, text_hash: &str, model: &str, vector: 
     Ok(())
 }
 
-/// How many chunk embeddings exist for a model (telemetry / tests).
+/// Ids of live notes that have at least one chunk with no embedding under
+/// `model` — the work-list for the startup embed backfill, so cross-note
+/// semantic search works day-one rather than only for touched notes.
+pub fn note_ids_needing_embedding(conn: &Connection, model: &str) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT c.note_id FROM note_chunks c \
+         JOIN notes n ON n.id = c.note_id \
+         WHERE n.deleted_at IS NULL AND c.text_hash <> '' \
+         AND NOT EXISTS ( \
+            SELECT 1 FROM chunk_embeddings e \
+            WHERE e.text_hash = c.text_hash AND e.model = ?1 \
+         )",
+    )?;
+    let ids = stmt
+        .query_map(params![model], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(ids)
+}
+
+/// How many chunk embeddings exist for a model. Test-only for now (asserts the
+/// incremental cache); promote to `pub` if telemetry ever needs it.
+#[cfg(test)]
 pub fn count_embeddings(conn: &Connection, model: &str) -> Result<i64> {
     Ok(conn.query_row(
         "SELECT COUNT(*) FROM chunk_embeddings WHERE model = ?1",
@@ -1408,7 +1374,7 @@ struct IdentifiedHit {
 }
 
 /// Keyword-ranked chunks (bm25, best first) with their chunk ids — the FTS half
-/// of hybrid search. Mirrors `search_chunks`' filters.
+/// of hybrid search. Applies the same combinable note filters as the rest.
 fn keyword_ranked(
     conn: &Connection,
     query: &str,
@@ -2322,7 +2288,7 @@ mod tests {
         reindex_note(&conn, &a.id, &na.body, &na.transcript, &na.summary).unwrap();
         reindex_note(&conn, &b.id, &nb.body, &nb.transcript, &nb.summary).unwrap();
 
-        let hits = search_chunks(&conn, "budget", NoteFilter::default(), "", 10).unwrap();
+        let hits = hybrid_search_chunks(&conn, "budget", None, "", NoteFilter::default(), "", 10).unwrap();
         assert_eq!(hits.len(), 1, "only the budget note matches");
         assert_eq!(hits[0].note_id, a.id);
         assert_eq!(hits[0].note_title, "Budget planning");
@@ -2330,12 +2296,12 @@ mod tests {
 
         // Punctuation / operator chars in the query don't blow up FTS5.
         let safe =
-            search_chunks(&conn, "budget: \"marketing\" -foo*", NoteFilter::default(), "", 10).unwrap();
+            hybrid_search_chunks(&conn, "budget: \"marketing\" -foo*", None, "", NoteFilter::default(), "", 10).unwrap();
         assert!(!safe.is_empty(), "sanitised query still matches");
 
         // A gibberish query returns nothing rather than erroring.
-        assert!(search_chunks(&conn, "!!!@@@", NoteFilter::default(), "", 10).unwrap().is_empty());
-        assert!(search_chunks(&conn, "zzzzznope", NoteFilter::default(), "", 10).unwrap().is_empty());
+        assert!(hybrid_search_chunks(&conn, "!!!@@@", None, "", NoteFilter::default(), "", 10).unwrap().is_empty());
+        assert!(hybrid_search_chunks(&conn, "zzzzznope", None, "", NoteFilter::default(), "", 10).unwrap().is_empty());
     }
 
     #[test]
@@ -2353,10 +2319,10 @@ mod tests {
 
         // Old content is no longer findable after an edit; new content is.
         reindex_note(&conn, &n.id, "hello world", "", "").unwrap();
-        assert_eq!(search_chunks(&conn, "world", NoteFilter::default(), "", 10).unwrap().len(), 1);
+        assert_eq!(hybrid_search_chunks(&conn, "world", None, "", NoteFilter::default(), "", 10).unwrap().len(), 1);
         reindex_note(&conn, &n.id, "totally different", "", "").unwrap();
-        assert!(search_chunks(&conn, "world", NoteFilter::default(), "", 10).unwrap().is_empty());
-        assert_eq!(search_chunks(&conn, "different", NoteFilter::default(), "", 10).unwrap().len(), 1);
+        assert!(hybrid_search_chunks(&conn, "world", None, "", NoteFilter::default(), "", 10).unwrap().is_empty());
+        assert_eq!(hybrid_search_chunks(&conn, "different", None, "", NoteFilter::default(), "", 10).unwrap().len(), 1);
     }
 
     #[test]
@@ -2396,14 +2362,14 @@ mod tests {
             NoteFilter { folder_id: Some(&folder.id), client_id: Some(&client.id), ..Default::default() };
         let f_note = NoteFilter { note_id: Some(&outside.id), ..Default::default() };
 
-        assert_eq!(search_chunks(&conn, "keyword", NoteFilter::default(), "", 10).unwrap().len(), 2, "unfiltered sees both");
-        let by_folder = search_chunks(&conn, "keyword", f_folder, "", 10).unwrap();
+        assert_eq!(hybrid_search_chunks(&conn, "keyword", None, "", NoteFilter::default(), "", 10).unwrap().len(), 2, "unfiltered sees both");
+        let by_folder = hybrid_search_chunks(&conn, "keyword", None, "", f_folder, "", 10).unwrap();
         assert_eq!(by_folder.len(), 1);
         assert_eq!(by_folder[0].note_id, inside.id);
         // folder AND client combine (both narrow to the same single note).
-        assert_eq!(search_chunks(&conn, "keyword", f_both, "", 10).unwrap().len(), 1);
+        assert_eq!(hybrid_search_chunks(&conn, "keyword", None, "", f_both, "", 10).unwrap().len(), 1);
         // note_id clamp (the "this Note" breadth) pins search to one note.
-        let by_note = search_chunks(&conn, "keyword", f_note, "", 10).unwrap();
+        let by_note = hybrid_search_chunks(&conn, "keyword", None, "", f_note, "", 10).unwrap();
         assert_eq!(by_note.len(), 1);
         assert_eq!(by_note[0].note_id, outside.id);
 

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -1,0 +1,98 @@
+//! Embedding provider seam for semantic retrieval (issue #48). Mirrors the
+//! `chat::ChatAdapter` / `stt::BatchSttAdapter` pattern: one `EmbeddingAdapter`
+//! trait, so the retrieval pipeline is provider-agnostic. The embedding model
+//! is auto-derived from the chat provider — there is no user-facing embedding
+//! choice:
+//!   - chat provider `openai` → `text-embedding-3-small` (cloud API)
+//!   - chat provider `ollama` → `embeddinggemma` (local, via Ollama)
+//!
+//! Both providers speak the OpenAI-compatible `/v1/embeddings` shape, so the two
+//! concrete adapters differ only in config (model / base URL / key) — the wire
+//! call is shared in `openai::openai_embed`.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// Model id for the cloud (OpenAI) embedder. Native 1536 dims; stored untruncated.
+pub const OPENAI_EMBED_MODEL: &str = "text-embedding-3-small";
+/// Model id for the local (Ollama) embedder. The sole local embedder — no
+/// fallback model (see issue #48: tune retrieval, not the model).
+pub const OLLAMA_EMBED_MODEL: &str = "embeddinggemma";
+
+#[async_trait]
+pub trait EmbeddingAdapter: Send + Sync {
+    /// The embedding model id — also the index tag: switching it triggers a
+    /// full re-embed under the new key (fixed-dim-per-index).
+    fn model_id(&self) -> &str;
+
+    /// Embed a batch of texts, returning one vector per input in input order.
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>>;
+}
+
+/// The concrete HTTP embedder for both providers — they share the OpenAI-compat
+/// `/v1/embeddings` wire call and differ only in these fields.
+pub struct HttpEmbeddingAdapter {
+    model: String,
+    base_url: String,
+    api_key: Option<String>,
+}
+
+#[async_trait]
+impl EmbeddingAdapter for HttpEmbeddingAdapter {
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        crate::openai::openai_embed(&self.base_url, self.api_key.as_deref(), &self.model, texts).await
+    }
+}
+
+/// Resolved embedding config, auto-derived from the chat provider. `None` means
+/// no embedder is available (e.g. cloud chat with no API key) → retrieval
+/// degrades to keyword-only.
+pub struct EmbedConfig {
+    pub provider: &'static str,
+    pub model: &'static str,
+    pub base_url: String,
+    pub api_key: Option<String>,
+}
+
+impl EmbedConfig {
+    pub fn adapter(&self) -> HttpEmbeddingAdapter {
+        HttpEmbeddingAdapter {
+            model: self.model.to_string(),
+            base_url: self.base_url.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+pub struct FakeEmbeddingAdapter {
+    pub model: String,
+    /// Fixed dimensionality of the returned vectors.
+    pub dims: usize,
+}
+
+#[cfg(test)]
+#[async_trait]
+impl EmbeddingAdapter for FakeEmbeddingAdapter {
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        // Deterministic: a simple bag-of-chars projection so identical text →
+        // identical vector and different text → (usually) different vector.
+        Ok(texts
+            .iter()
+            .map(|t| {
+                let mut v = vec![0.0f32; self.dims];
+                for b in t.bytes() {
+                    v[(b as usize) % self.dims] += 1.0;
+                }
+                v
+            })
+            .collect())
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -246,8 +246,17 @@ where
                     let state: tauri::State<AppState> = app.state();
                     state.db.clone()
                 };
-                tauri::async_runtime::spawn_blocking(move || {
-                    commands::backfill_note_chunks(&db);
+                let app_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    // 1. Re-chunk (CPU-bound) off the async pool.
+                    let db2 = db.clone();
+                    let _ = tauri::async_runtime::spawn_blocking(move || {
+                        commands::backfill_note_chunks(&db2);
+                    })
+                    .await;
+                    // 2. Embed the (re)chunked notes so cross-note semantic
+                    //    search works day-one (issue #48). Best-effort + cached.
+                    commands::embed_backfill(app_handle).await;
                 });
             }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod sessions;
 mod commands;
 mod stt;
 mod chat;
+mod embed;
 pub mod sync;
 
 use std::sync::Arc;

--- a/src-tauri/src/openai.rs
+++ b/src-tauri/src/openai.rs
@@ -1250,6 +1250,75 @@ pub async fn list_models(base_url: &str) -> Result<Vec<String>> {
     Ok(body.data.into_iter().map(|m| m.id).collect())
 }
 
+// ── Embeddings (issue #48) ──────────────────────────────────────────────────
+// Cloud OpenAI and Ollama both serve the OpenAI-compatible `/v1/embeddings`
+// shape (`{model, input:[…]}` → `{data:[{embedding, index}]}`), so one function
+// covers both — base_url selects the target. Unlike chat, embeddings have no
+// thinking mode, so the "use Ollama's native /api/chat" caveat doesn't apply.
+
+#[derive(Serialize)]
+struct EmbedRequest<'a> {
+    model: &'a str,
+    input: &'a [String],
+}
+#[derive(Deserialize)]
+struct EmbedResponse {
+    data: Vec<EmbedDatum>,
+}
+#[derive(Deserialize)]
+struct EmbedDatum {
+    embedding: Vec<f32>,
+    #[serde(default)]
+    index: usize,
+}
+
+/// Embed a batch of texts via the OpenAI-compatible embeddings endpoint at
+/// `base_url`. `api_key` is sent as a bearer when present (cloud OpenAI); local
+/// servers ignore it. Returns one vector per input, in input order.
+pub(crate) async fn openai_embed(
+    base_url: &str,
+    api_key: Option<&str>,
+    model: &str,
+    inputs: &[String],
+) -> Result<Vec<Vec<f32>>> {
+    if inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+    let url = format!("{base_url}/embeddings");
+    let mut req = local_client().post(&url).json(&EmbedRequest { model, input: inputs });
+    if let Some(key) = api_key {
+        req = req.bearer_auth(key);
+    }
+    let r = req.send().await.map_err(|e| {
+        if e.is_timeout() {
+            anyhow!("Timed out waiting for embeddings from {url}.")
+        } else if e.is_connect() {
+            anyhow!("Couldn't reach {url} for embeddings.")
+        } else {
+            anyhow!("network error requesting embeddings from {url}: {}", error_chain(&e))
+        }
+    })?;
+    let status = r.status();
+    if !status.is_success() {
+        let body = r.text().await.unwrap_or_default();
+        return Err(anyhow!("HTTP {status} from {url}: {body}"));
+    }
+    let mut body: EmbedResponse = r
+        .json()
+        .await
+        .map_err(|e| anyhow!("could not parse embeddings response from {url}: {e}"))?;
+    if body.data.len() != inputs.len() {
+        return Err(anyhow!(
+            "embeddings response had {} vectors for {} inputs",
+            body.data.len(),
+            inputs.len()
+        ));
+    }
+    // Order by `index` so vectors line up with inputs regardless of wire order.
+    body.data.sort_by_key(|d| d.index);
+    Ok(body.data.into_iter().map(|d| d.embedding).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/components/provider/OllamaConnect.tsx
+++ b/src/components/provider/OllamaConnect.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { Select } from "../../pages/settings/components/Select";
+import { completionModels } from "../../lib/localModels";
 import { useOllamaProbe } from "./useOllamaProbe";
 
 // Local-LLM (Ollama / LM Studio / llama-server) connection surface for the
@@ -21,6 +22,11 @@ export function OllamaConnect({
 }) {
   const { reachable, installed } = useOllamaProbe(baseUrl, { pollMs });
 
+  // This is a completion-model picker (chat + summary), so embedding-only
+  // models (e.g. embeddinggemma, pulled for semantic search #48) must never be
+  // offered or auto-selected — Ollama 400s "does not support chat" for them.
+  const models = completionModels(installed);
+
   // Empty selection self-heals on contact: with no model set the dropdown
   // used to LOOK fine (HTML default fallback) while summaries failed with
   // "model not configured". A stored-but-missing model is NOT auto-switched
@@ -31,8 +37,9 @@ export function OllamaConnect({
   const onModelChangeRef = useRef(onModelChange);
   onModelChangeRef.current = onModelChange;
   useEffect(() => {
-    if (installed && installed.length > 0 && !modelRef.current) {
-      onModelChangeRef.current(installed[0]);
+    const usable = completionModels(installed);
+    if (usable.length > 0 && !modelRef.current) {
+      onModelChangeRef.current(usable[0]);
     }
   }, [installed]);
 
@@ -40,7 +47,7 @@ export function OllamaConnect({
     reachable === true &&
     installed !== null &&
     model !== "" &&
-    !installed.includes(model);
+    !models.includes(model);
 
   return (
     <div className="py-3.5 flex flex-col gap-3">
@@ -92,7 +99,7 @@ export function OllamaConnect({
                 ...(model === "" || modelMissing
                   ? [{ value: model, label: model === "" ? "Choose a model…" : model }]
                   : []),
-                ...(installed ?? []).map((m) => ({ value: m, label: m })),
+                ...models.map((m) => ({ value: m, label: m })),
               ]}
             />
           </div>

--- a/src/components/provider/useChatReadiness.ts
+++ b/src/components/provider/useChatReadiness.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { ipc } from "../../lib/ipc";
 import { DEFAULTS } from "../../pages/settings/types";
+import { isEmbeddingModel } from "../../lib/localModels";
 import { useOllamaProbe } from "./useOllamaProbe";
 import { useProviderKey } from "./useProviderKey";
 
@@ -50,6 +51,8 @@ export function useChatReadiness() {
   } else if (isOllama) {
     if (reachable === false) hint = "Start or install Ollama — it's detected automatically.";
     else if (!model) hint = "Choose a chat model in Settings → Chat.";
+    else if (isEmbeddingModel(model))
+      hint = `“${model}” is an embedding model — pick a chat model in Settings → Chat.`;
     else if (installed && !installed.includes(model))
       hint = `“${model}” isn't installed on the server — run ollama pull ${model}.`;
     else if (reachable === null) hint = "Checking the local server…";

--- a/src/lib/localModels.ts
+++ b/src/lib/localModels.ts
@@ -21,3 +21,24 @@ export function isModelInstalled(installed: string[] | null | undefined, model: 
   const base = model.split(":")[0];
   return installed.some((m) => m === model || m.split(":")[0] === base);
 }
+
+/// Whether a model is embedding-only and so must NOT appear in a chat/summary
+/// (completion) model picker — selecting one makes Ollama's /api/chat 400 with
+/// "does not support chat". Matches embeddinggemma plus the common embedding
+/// families a user might have pulled (nomic-embed, mxbai-embed, arctic-embed,
+/// granite-embedding, bge-*, all-minilm, paraphrase-*).
+export function isEmbeddingModel(name: string): boolean {
+  const n = name.toLowerCase();
+  return (
+    /embed/.test(n) ||
+    n.startsWith("bge-") ||
+    n.startsWith("all-minilm") ||
+    n.startsWith("paraphrase-")
+  );
+}
+
+/// The installed models usable for chat/summary completions — embedding-only
+/// models filtered out.
+export function completionModels(installed: string[] | null | undefined): string[] {
+  return (installed ?? []).filter((m) => !isEmbeddingModel(m));
+}

--- a/src/lib/localModels.ts
+++ b/src/lib/localModels.ts
@@ -8,3 +8,16 @@
 // the Qwen-tuned sampling profile in src-tauri/src/openai.rs). Recommend by tier.
 export const RECOMMENDED_OLLAMA_MODEL = "gemma4:12b-mlx";
 export const RECOMMENDED_OLLAMA_MODEL_16GB = "qwen3.5:4b";
+
+// The local embedding model for semantic chat retrieval (issue #48). Small
+// (~600 MB) and the sole local embedder — no fallback. Optional: without it,
+// local chat still works keyword-only (semantic search degrades gracefully).
+export const EMBEDDING_OLLAMA_MODEL = "embeddinggemma";
+
+/// Whether an Ollama-installed model list already includes a given model,
+/// tag-insensitively (Ollama reports names like "embeddinggemma:latest").
+export function isModelInstalled(installed: string[] | null | undefined, model: string): boolean {
+  if (!installed) return false;
+  const base = model.split(":")[0];
+  return installed.some((m) => m === model || m.split(":")[0] === base);
+}

--- a/src/pages/onboarding/steps/Summary.tsx
+++ b/src/pages/onboarding/steps/Summary.tsx
@@ -35,6 +35,7 @@ import {
   EMBEDDING_OLLAMA_MODEL,
   RECOMMENDED_OLLAMA_MODEL,
   RECOMMENDED_OLLAMA_MODEL_16GB,
+  completionModels,
   isModelInstalled,
 } from "../../../lib/localModels";
 
@@ -100,11 +101,13 @@ export function SummaryStep({ ctx }: { ctx: StepContext }) {
   // completes mid-wizard is picked up.
   useEffect(() => {
     if (!installed) return;
+    // Only completion models are valid picks — never embeddinggemma etc. (#48).
+    const usable = completionModels(installed);
     setSelectedModel((prev) => {
-      if (prev && installed.includes(prev)) return prev;
-      if (installed.includes(RECOMMENDED_OLLAMA_MODEL)) return RECOMMENDED_OLLAMA_MODEL;
-      if (installed.includes(RECOMMENDED_OLLAMA_MODEL_16GB)) return RECOMMENDED_OLLAMA_MODEL_16GB;
-      return installed[0] ?? "";
+      if (prev && usable.includes(prev)) return prev;
+      if (usable.includes(RECOMMENDED_OLLAMA_MODEL)) return RECOMMENDED_OLLAMA_MODEL;
+      if (usable.includes(RECOMMENDED_OLLAMA_MODEL_16GB)) return RECOMMENDED_OLLAMA_MODEL_16GB;
+      return usable[0] ?? "";
     });
   }, [installed]);
 
@@ -537,7 +540,7 @@ function ModelSelect({
         className="w-full px-3 py-2 rounded-md text-sm bg-[var(--color-input-bg)] border border-[var(--color-line)] focus:border-[var(--color-text-muted)]"
       >
         <option value="">— pick a model —</option>
-        {installed.map((m) => (
+        {completionModels(installed).map((m) => (
           <option key={m} value={m}>
             {m}
             {m === RECOMMENDED_OLLAMA_MODEL

--- a/src/pages/onboarding/steps/Summary.tsx
+++ b/src/pages/onboarding/steps/Summary.tsx
@@ -28,11 +28,14 @@ import { Sparkles, Cloud, Server, Check, Copy, ExternalLink } from "lucide-react
 import { ipc } from "../../../lib/ipc";
 import { useOllamaProbe } from "../../../components/provider/useOllamaProbe";
 import { useProviderKey } from "../../../components/provider/useProviderKey";
+import { CommandSnippet } from "../../../components/CommandSnippet";
 import type { StepContext } from "../types";
 import { StepShell } from "../StepShell";
 import {
+  EMBEDDING_OLLAMA_MODEL,
   RECOMMENDED_OLLAMA_MODEL,
   RECOMMENDED_OLLAMA_MODEL_16GB,
+  isModelInstalled,
 } from "../../../lib/localModels";
 
 // Mirrors Settings → Summary defaults (settings/types.ts DEFAULTS).
@@ -423,6 +426,30 @@ export function SummaryStep({ ctx }: { ctx: StepContext }) {
                           Using <code>{selectedModel}</code>.
                         </p>
                       )}
+                    </>
+                  )}
+                </div>
+              )}
+
+              {/* Optional embedding model for semantic chat (issue #48). Never
+                  blocks setup — chat works keyword-only without it. */}
+              {reachable === true && (
+                <div className="mt-3 pt-3 border-t border-[var(--color-line)] space-y-1.5">
+                  {isModelInstalled(installed, EMBEDDING_OLLAMA_MODEL) ? (
+                    <p className="text-xs text-[var(--color-success)] flex items-center gap-1.5">
+                      <Check size={13} strokeWidth={2.5} />
+                      Semantic chat search ready ({EMBEDDING_OLLAMA_MODEL})
+                    </p>
+                  ) : (
+                    <>
+                      <p className="text-xs text-[var(--color-text-muted)]">
+                        Optional: for AI chat that finds answers by meaning, pull the small
+                        embedding model too.
+                      </p>
+                      <CommandSnippet
+                        command={`ollama pull ${EMBEDDING_OLLAMA_MODEL}`}
+                        ariaLabel="Copy embedding-model pull command"
+                      />
                     </>
                   )}
                 </div>

--- a/src/pages/settings/tabs/Chat.test.tsx
+++ b/src/pages/settings/tabs/Chat.test.tsx
@@ -95,4 +95,28 @@ describe("ChatTab readiness", () => {
     // Tag-insensitive match: "embeddinggemma:latest" satisfies "embeddinggemma".
     expect(screen.queryByRole("button", { name: /Copy embedding-model pull command/ })).toBeNull();
   });
+
+  // Regression: an embedding model must never be usable as the chat model
+  // (Ollama 400s "does not support chat"). Surfaced by real pnpm tauri dev.
+  it("Ollama: flags an embedding model wrongly set as the chat model", async () => {
+    mockTauri({ local_llm_list_models: () => ["embeddinggemma:latest", "gemma4:12b-mlx"] });
+    render(
+      <ChatTab
+        s={settings({ chat_provider: "ollama", chat_model: "embeddinggemma:latest" })}
+        update={async () => {}}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("Setup needed")).toBeInTheDocument());
+    expect(screen.getByText(/is an embedding model/)).toBeInTheDocument();
+  });
+
+  it("Ollama: auto-selects a chat model, never the embedding model, when none is set", async () => {
+    const update = vi.fn();
+    // Embedding model listed FIRST (as Ollama does) — the old installed[0]
+    // auto-select would have picked it.
+    mockTauri({ local_llm_list_models: () => ["embeddinggemma:latest", "gemma4:12b-mlx"] });
+    render(<ChatTab s={settings({ chat_provider: "ollama", chat_model: "" })} update={update} />);
+    await waitFor(() => expect(update).toHaveBeenCalledWith("chat_model", "gemma4:12b-mlx"));
+    expect(update).not.toHaveBeenCalledWith("chat_model", "embeddinggemma:latest");
+  });
 });

--- a/src/pages/settings/tabs/Chat.test.tsx
+++ b/src/pages/settings/tabs/Chat.test.tsx
@@ -77,4 +77,22 @@ describe("ChatTab readiness", () => {
     fireEvent.click(screen.getByRole("button", { name: /Copy Ollama pull command/ }));
     expect(writeText).toHaveBeenCalledWith("ollama pull qwen3.5:4b");
   });
+
+  // Embedding model (issue #48) — a soft, non-blocking recommendation.
+  it("Ollama: prompts to pull embeddinggemma when it's missing, without blocking readiness", async () => {
+    mockTauri({ local_llm_list_models: () => ["qwen3.5:4b"] }); // chat model present, no embedder
+    render(<ChatTab s={settings({ chat_provider: "ollama", chat_model: "qwen3.5:4b" })} update={async () => {}} />);
+    // Still Ready — semantic is optional and degrades to keyword-only.
+    await waitFor(() => expect(screen.getByText("Ready ✓")).toBeInTheDocument());
+    expect(screen.getByText(/For semantic search/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Copy embedding-model pull command/ })).toBeInTheDocument();
+  });
+
+  it("Ollama: shows semantic search ready once embeddinggemma is installed", async () => {
+    mockTauri({ local_llm_list_models: () => ["qwen3.5:4b", "embeddinggemma:latest"] });
+    render(<ChatTab s={settings({ chat_provider: "ollama", chat_model: "qwen3.5:4b" })} update={async () => {}} />);
+    await waitFor(() => expect(screen.getByText(/Semantic search ready/)).toBeInTheDocument());
+    // Tag-insensitive match: "embeddinggemma:latest" satisfies "embeddinggemma".
+    expect(screen.queryByRole("button", { name: /Copy embedding-model pull command/ })).toBeNull();
+  });
 });

--- a/src/pages/settings/tabs/Chat.tsx
+++ b/src/pages/settings/tabs/Chat.tsx
@@ -7,7 +7,11 @@ import { CommandSnippet } from "../../../components/CommandSnippet";
 import { useOllamaProbe } from "../../../components/provider/useOllamaProbe";
 import { useProviderKey } from "../../../components/provider/useProviderKey";
 import { CHAT_PROVIDERS, SUMMARY_MODELS } from "../types";
-import { RECOMMENDED_OLLAMA_MODEL } from "../../../lib/localModels";
+import {
+  EMBEDDING_OLLAMA_MODEL,
+  RECOMMENDED_OLLAMA_MODEL,
+  isModelInstalled,
+} from "../../../lib/localModels";
 import type { SettingsHook } from "../useSettings";
 
 // AI Chat provider setting (issue #44). A dedicated provider choice, separate
@@ -103,6 +107,27 @@ export function ChatTab({ s, update }: Pick<SettingsHook, "s" | "update">) {
               command={`ollama pull ${s.chat_model || RECOMMENDED_OLLAMA_MODEL}`}
               ariaLabel="Copy Ollama pull command"
             />
+          </div>
+          {/* Embedding model for semantic retrieval (issue #48). Optional —
+              chat works keyword-only without it — so this never blocks the
+              readiness gate above; it's a soft recommendation. */}
+          <div className="py-3 space-y-2 border-t border-[var(--color-line)]">
+            {isModelInstalled(installed, EMBEDDING_OLLAMA_MODEL) ? (
+              <p className="text-xs text-[var(--color-success)]">
+                Semantic search ready ✓ — {EMBEDDING_OLLAMA_MODEL} is installed.
+              </p>
+            ) : (
+              <>
+                <p className="text-xs text-[var(--color-text-muted)]">
+                  For semantic search — finding answers by meaning, not just keywords — also pull
+                  the embedding model (~600 MB). Optional; chat works without it.
+                </p>
+                <CommandSnippet
+                  command={`ollama pull ${EMBEDDING_OLLAMA_MODEL}`}
+                  ariaLabel="Copy embedding-model pull command"
+                />
+              </>
+            )}
           </div>
         </>
       )}

--- a/src/pages/settings/tabs/Chat.tsx
+++ b/src/pages/settings/tabs/Chat.tsx
@@ -10,6 +10,7 @@ import { CHAT_PROVIDERS, SUMMARY_MODELS } from "../types";
 import {
   EMBEDDING_OLLAMA_MODEL,
   RECOMMENDED_OLLAMA_MODEL,
+  isEmbeddingModel,
   isModelInstalled,
 } from "../../../lib/localModels";
 import type { SettingsHook } from "../useSettings";
@@ -33,6 +34,8 @@ export function ChatTab({ s, update }: Pick<SettingsHook, "s" | "update">) {
   if (isOllama) {
     if (reachable === false) hint = "Start or install Ollama — it's detected automatically.";
     else if (!s.chat_model) hint = "Choose a chat model above.";
+    else if (isEmbeddingModel(s.chat_model))
+      hint = `“${s.chat_model}” is an embedding model — choose a chat model above.`;
     else if (installed && !installed.includes(s.chat_model))
       hint = `“${s.chat_model}” isn't installed on the server — run ollama pull ${s.chat_model}.`;
     else ready = true;


### PR DESCRIPTION
Closes #48.

Adds **semantic retrieval** on top of #47's keyword substrate — chat finds passages by *meaning*, not just literal terms — with a hybrid ranker. Purely additive: the chunks + freshness pipeline already exist; this slice adds vectors and RRF fusion.

## What's here

**Embedding cache** (`db.rs`) — content-addressed `chunk_embeddings(text_hash, model)`; `note_chunks` gained `text_hash` (FNV-1a) so a vector survives a reindex and **only changed text re-embeds**. Native dims, no truncation, f32 LE blob; a model switch re-embeds under the new key (fixed-dim-per-index). Brute-force cosine, no vector index.

**Hybrid search** (`db.rs`) — `cosine` + `rrf_fuse` (k=60, pool 20) + `hybrid_search_chunks`: fuses BM25 and cosine via **Reciprocal Rank Fusion**. `query_vec = None` (embedding unavailable) degrades to keyword-only — a missing vector never breaks chat.

**`EmbeddingAdapter`** (`embed.rs`) — mirrors the chat/STT seam; auto-derived from the chat provider (`text-embedding-3-small` cloud / `embeddinggemma` Ollama), no user choice. Both speak the OpenAI-compatible `/v1/embeddings` (one `openai::openai_embed`; embeddings have no thinking-mode hang, so the native-`/api/chat` caveat doesn't apply).

**Pipeline** — `embed_note` embeds a note's missing chunks (batched, cached, best-effort). Runs on the same content-settled checkpoints that re-chunk (summarize, diarize, unmount) off the request path, the chat anchor synchronously, and a **startup backfill** so cross-note semantic works day-one. The agentic loop embeds the search query before the DB lock (no guard across `.await`); embed failure → keyword-only.

**Frontend** — Settings + onboarding detect `embeddinggemma` and offer a copy-pull, **non-blocking** (semantic is optional). Embedding-only models are excluded from every completion (chat/summary) model picker + auto-select.

**Multilingual sanity check** — `docs/research/embed-48-multilingual/`: ran against `embeddinggemma` (768 dims), **6/6 pass** across en/nb/de/es + cross-lingual (en→nb). Norwegian margins thinnest but clean; verdict ship-as-is, no fallback model.

## Fix included
A bug found via real `pnpm tauri dev`: Ollama lists `embeddinggemma` first, and the shared model picker auto-selected `installed[0]`, making the embedding-only model the chat model → Ollama 400 "does not support chat". Now filtered from all completion pickers + auto-select, flagged in readiness, and rejected server-side.

## Two deliberate deviations
- **`/v1/embeddings` vs the AC's literal `/api/embed`** — same model, DRY one wire path, Context7-confirmed, no thinking-mode issue.
- **One `HttpEmbeddingAdapter` for both providers** vs one-struct-per-provider — both speak the identical OpenAI-compat shape; the trait seam + fake give the testability the AC wants.

## Testing
- **279 Rust tests** — incl. the three required (RRF ordering, incremental re-embed on checkpoint, keyword-only fallback), plus semantic-only-via-RRF, end-to-end graceful degradation, and the embedding-model guard.
- **183 frontend tests** + `tsc` — incl. embeddinggemma detection (non-blocking) and the picker/auto-select regression.
- Two-axis code review (concurrency PASS, all 8 ACs met); applied both findings (dead-code removal + startup embed backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)