### PR TITLE
feat(chat): workspace (Teams) chat — delegate to cloud, same UI (#50)

### DIFF
--- a/src-tauri/src/chat/cloud.rs
+++ b/src-tauri/src/chat/cloud.rs
@@ -1,0 +1,215 @@
+//! Cloud (Teams) chat wiring (issue #50). For a WORKSPACE-tenant conversation
+//! the desktop delegates the turn to the deployed humla-cloud `POST /api/chat`
+//! endpoint, streams its SSE response, and re-emits it onto the SAME `chat_*`
+//! events the local loop uses — so the Chat UI is identical across tenants
+//! (story 18). Workspace conversations are server-authoritative; the desktop
+//! only displays what the server returns.
+//!
+//! This module holds the Tauri-free pieces — request-body assembly, SSE frame
+//! parsing, the server→`chat_*` event-name mapping, and the reason-code →
+//! user-message mapping — so they're unit-testable. The streaming orchestration
+//! (reqwest + emit + remote-id persistence) lives in `commands::chat`.
+
+use serde_json::{json, Value};
+
+/// Build the JSON body for `POST /api/chat`. `remote_conversation_id` is the
+/// server's conversation record id (None/empty on the first turn → the server
+/// creates one and returns it). The anchor `note_id` is always sent inside
+/// `scope` for grounding; `folder_id` rides only when the breadth is folder.
+/// Mirrors the desktop breadth clamp: a folder-less note under "folder" breadth
+/// falls back to "note".
+pub fn build_cloud_request(
+    remote_conversation_id: Option<&str>,
+    workspace_id: &str,
+    message: &str,
+    title: Option<&str>,
+    breadth: &str,
+    note_id: &str,
+    folder_id: Option<&str>,
+) -> Value {
+    // Default to the safe single-Note breadth; widen only on an explicit,
+    // well-formed request. `note_id` stays in every scope so the server can
+    // ground on the anchor Note regardless of breadth.
+    let mut scope = json!({ "breadth": "note", "note_id": note_id });
+    match breadth {
+        "all" => scope = json!({ "breadth": "all", "note_id": note_id }),
+        "folder" => {
+            if let Some(f) = folder_id.filter(|f| !f.is_empty()) {
+                scope = json!({ "breadth": "folder", "note_id": note_id, "folder_id": f });
+            }
+        }
+        _ => {}
+    }
+    let mut body = json!({
+        "workspace_id": workspace_id,
+        "message": message,
+        "scope": scope,
+    });
+    if let Some(id) = remote_conversation_id.filter(|s| !s.is_empty()) {
+        body["conversation_id"] = json!(id);
+    }
+    if let Some(t) = title.filter(|s| !s.is_empty()) {
+        body["title"] = json!(t);
+    }
+    body
+}
+
+/// Parse one SSE event block into `(event name, data payload)`. Matches the
+/// framing hono's `streamSSE` emits — `event: <name>\ndata: <json>` — tolerating
+/// an optional single space after each colon and multi-line `data:` folds.
+/// Returns None for a block with no `event:` line (e.g. a lone comment/keepalive).
+pub fn parse_sse_frame(block: &str) -> Option<(String, String)> {
+    let mut event = None;
+    let mut data = String::new();
+    for line in block.lines() {
+        if let Some(v) = line.strip_prefix("event:") {
+            event = Some(v.trim().to_string());
+        } else if let Some(v) = line.strip_prefix("data:") {
+            data.push_str(v.strip_prefix(' ').unwrap_or(v));
+        }
+    }
+    event.map(|e| (e, data))
+}
+
+/// Byte index + length of the first SSE event terminator (`\n\n` or `\r\n\r\n`)
+/// in `buf`, or None if no complete event has arrived yet. Picks whichever
+/// terminator appears first, so a proxy that rewrites line endings still frames
+/// correctly. The caller drains `idx + len` bytes and parses `buf[..idx]`.
+pub fn find_event_end(buf: &str) -> Option<(usize, usize)> {
+    let lf = buf.find("\n\n").map(|i| (i, 2));
+    let crlf = buf.find("\r\n\r\n").map(|i| (i, 4));
+    match (lf, crlf) {
+        (Some(a), Some(b)) => Some(if a.0 <= b.0 { a } else { b }),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+/// Map a server SSE event name to the Tauri `chat_*` event the frontend already
+/// listens on. Unknown names are ignored (None) so a future server event can't
+/// crash an older client.
+pub fn tauri_event_for(server_event: &str) -> Option<&'static str> {
+    match server_event {
+        "text_delta" => Some("chat_text_delta"),
+        "tool_activity" => Some("chat_tool_activity"),
+        "citations" => Some("chat_citations"),
+        "done" => Some("chat_done"),
+        "error" => Some("chat_error"),
+        _ => None,
+    }
+}
+
+/// Turn a cloud preflight error (`{reason, error}`) into a clear user-facing
+/// message. Subscription/quota blocks name the upgrade path (stories 21/22):
+/// a lapsed subscription points at resubscribing, an exhausted quota at the
+/// chat-capacity add-on. Everything else passes the server's own message
+/// through, falling back to a generic line when it's empty.
+pub fn cloud_chat_error_message(reason: &str, server_message: &str) -> String {
+    match reason {
+        "subscription_lapsed" => {
+            "This workspace needs an active subscription to use Team chat — ask the workspace \
+             owner to resubscribe. (Personal chat stays free.)"
+                .to_string()
+        }
+        "quota_exhausted" => {
+            "This workspace has used its Team chat allowance for the billing period. The \
+             chat-capacity add-on raises the limit."
+                .to_string()
+        }
+        "not_a_member" => "You're not a member of this workspace.".to_string(),
+        "chat_disabled" | "chat_unavailable" | "index_unavailable" => {
+            "Team chat isn't available on this server.".to_string()
+        }
+        _ => {
+            let m = server_message.trim();
+            if m.is_empty() {
+                "Team chat failed — please try again.".to_string()
+            } else {
+                m.to_string()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_defaults_to_note_breadth_with_grounding_anchor() {
+        let b = build_cloud_request(None, "ws1", "hi", None, "note", "n1", None);
+        assert_eq!(b["workspace_id"], "ws1");
+        assert_eq!(b["message"], "hi");
+        assert_eq!(b["scope"], json!({ "breadth": "note", "note_id": "n1" }));
+        assert!(b.get("conversation_id").is_none(), "no remote id on the first turn");
+        assert!(b.get("title").is_none());
+    }
+
+    #[test]
+    fn request_carries_remote_id_and_title_when_present() {
+        let b = build_cloud_request(Some("srv123"), "ws1", "hi", Some("Kickoff"), "note", "n1", None);
+        assert_eq!(b["conversation_id"], "srv123");
+        assert_eq!(b["title"], "Kickoff");
+        // Empty strings are dropped, not sent.
+        let b2 = build_cloud_request(Some(""), "ws1", "hi", Some(""), "note", "n1", None);
+        assert!(b2.get("conversation_id").is_none());
+        assert!(b2.get("title").is_none());
+    }
+
+    #[test]
+    fn request_folder_breadth_needs_a_folder_else_falls_back_to_note() {
+        let with = build_cloud_request(None, "ws1", "hi", None, "folder", "n1", Some("f1"));
+        assert_eq!(with["scope"], json!({ "breadth": "folder", "note_id": "n1", "folder_id": "f1" }));
+        // A folder-less note under folder breadth clamps to note (no folder to widen to).
+        let without = build_cloud_request(None, "ws1", "hi", None, "folder", "n1", None);
+        assert_eq!(without["scope"], json!({ "breadth": "note", "note_id": "n1" }));
+    }
+
+    #[test]
+    fn request_all_breadth_keeps_the_grounding_anchor() {
+        let b = build_cloud_request(None, "ws1", "hi", None, "all", "n1", None);
+        assert_eq!(b["scope"], json!({ "breadth": "all", "note_id": "n1" }));
+    }
+
+    #[test]
+    fn parses_sse_event_and_data() {
+        let (ev, data) = parse_sse_frame("event: text_delta\ndata: {\"delta\":\"hi\"}").unwrap();
+        assert_eq!(ev, "text_delta");
+        assert_eq!(data, "{\"delta\":\"hi\"}");
+    }
+
+    #[test]
+    fn sse_block_without_event_is_ignored() {
+        assert!(parse_sse_frame(": keepalive comment").is_none());
+        assert!(parse_sse_frame("data: {\"x\":1}").is_none());
+    }
+
+    #[test]
+    fn finds_the_first_event_terminator() {
+        assert_eq!(find_event_end("event: a\ndata: 1\n\nrest"), Some((16, 2)));
+        // CRLF framing.
+        assert_eq!(find_event_end("event: a\r\ndata: 1\r\n\r\nrest"), Some((17, 4)));
+        // Incomplete — no blank line yet.
+        assert_eq!(find_event_end("event: a\ndata: 1\n"), None);
+    }
+
+    #[test]
+    fn maps_server_events_to_chat_events() {
+        assert_eq!(tauri_event_for("text_delta"), Some("chat_text_delta"));
+        assert_eq!(tauri_event_for("tool_activity"), Some("chat_tool_activity"));
+        assert_eq!(tauri_event_for("citations"), Some("chat_citations"));
+        assert_eq!(tauri_event_for("done"), Some("chat_done"));
+        assert_eq!(tauri_event_for("error"), Some("chat_error"));
+        assert_eq!(tauri_event_for("PB_CONNECT"), None);
+    }
+
+    #[test]
+    fn error_messages_name_the_upgrade_path() {
+        assert!(cloud_chat_error_message("subscription_lapsed", "x").contains("subscription"));
+        let q = cloud_chat_error_message("quota_exhausted", "x");
+        assert!(q.contains("add-on"), "quota block names the chat add-on: {q}");
+        assert_eq!(cloud_chat_error_message("weird_reason", "raw server text"), "raw server text");
+        assert!(!cloud_chat_error_message("weird_reason", "  ").is_empty());
+    }
+}

--- a/src-tauri/src/chat/cloud.rs
+++ b/src-tauri/src/chat/cloud.rs
@@ -74,16 +74,36 @@ pub fn parse_sse_frame(block: &str) -> Option<(String, String)> {
 /// Byte index + length of the first SSE event terminator (`\n\n` or `\r\n\r\n`)
 /// in `buf`, or None if no complete event has arrived yet. Picks whichever
 /// terminator appears first, so a proxy that rewrites line endings still frames
-/// correctly. The caller drains `idx + len` bytes and parses `buf[..idx]`.
-pub fn find_event_end(buf: &str) -> Option<(usize, usize)> {
-    let lf = buf.find("\n\n").map(|i| (i, 2));
-    let crlf = buf.find("\r\n\r\n").map(|i| (i, 4));
+/// correctly. Operates on BYTES (not `&str`) so the caller can buffer raw
+/// network chunks and decode only *complete* frames — a multibyte codepoint
+/// split across two chunks is never lossily decoded mid-character. The caller
+/// drains `idx + len` bytes and decodes `buf[..idx]`.
+pub fn find_event_end(buf: &[u8]) -> Option<(usize, usize)> {
+    let lf = buf.windows(2).position(|w| w == b"\n\n").map(|i| (i, 2));
+    let crlf = buf.windows(4).position(|w| w == b"\r\n\r\n").map(|i| (i, 4));
     match (lf, crlf) {
         (Some(a), Some(b)) => Some(if a.0 <= b.0 { a } else { b }),
         (Some(a), None) => Some(a),
         (None, Some(b)) => Some(b),
         (None, None) => None,
     }
+}
+
+/// Extract a human answer from a non-streamed whole-turn body (the AC2 degraded
+/// fallback, when a 2xx response isn't an SSE stream). Tries the obvious text
+/// fields, then falls back to the raw body so the UI shows *something* and
+/// completes rather than hanging on a stream that never frames.
+pub fn whole_turn_answer(body: &str) -> String {
+    if let Ok(v) = serde_json::from_str::<Value>(body) {
+        for key in ["answer", "message", "text", "content"] {
+            if let Some(s) = v.get(key).and_then(|x| x.as_str()) {
+                if !s.trim().is_empty() {
+                    return s.to_string();
+                }
+            }
+        }
+    }
+    body.trim().to_string()
 }
 
 /// Map a server SSE event name to the Tauri `chat_*` event the frontend already
@@ -187,11 +207,37 @@ mod tests {
 
     #[test]
     fn finds_the_first_event_terminator() {
-        assert_eq!(find_event_end("event: a\ndata: 1\n\nrest"), Some((16, 2)));
+        assert_eq!(find_event_end(b"event: a\ndata: 1\n\nrest"), Some((16, 2)));
         // CRLF framing.
-        assert_eq!(find_event_end("event: a\r\ndata: 1\r\n\r\nrest"), Some((17, 4)));
+        assert_eq!(find_event_end(b"event: a\r\ndata: 1\r\n\r\nrest"), Some((17, 4)));
         // Incomplete — no blank line yet.
-        assert_eq!(find_event_end("event: a\ndata: 1\n"), None);
+        assert_eq!(find_event_end(b"event: a\ndata: 1\n"), None);
+    }
+
+    #[test]
+    fn only_complete_frames_are_decoded_so_split_utf8_survives() {
+        // A Norwegian "å" (0xC3 0xA5) split across two network chunks. Framing on
+        // bytes means we only decode once the whole frame (and codepoint) arrived.
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice("event: text_delta\ndata: {\"delta\":\"m\u{00e5}".as_bytes());
+        let split = buf.len() - 1; // land mid-codepoint
+        let (head, tail) = buf.split_at(split);
+        assert!(find_event_end(head).is_none(), "no complete frame yet");
+        let mut acc = head.to_vec();
+        acc.extend_from_slice(tail);
+        acc.extend_from_slice("te\"}\n\n".as_bytes());
+        let (idx, delim) = find_event_end(&acc).expect("frame complete");
+        let text = String::from_utf8_lossy(&acc[..idx]);
+        let (_, data) = parse_sse_frame(&text).unwrap();
+        assert!(data.contains("m\u{00e5}te"), "å survived the chunk split: {data}");
+        assert_eq!(delim, 2);
+    }
+
+    #[test]
+    fn whole_turn_answer_prefers_a_text_field_then_falls_back_to_raw() {
+        assert_eq!(whole_turn_answer(r#"{"answer":"hi there"}"#), "hi there");
+        assert_eq!(whole_turn_answer(r#"{"message":"yo"}"#), "yo");
+        assert_eq!(whole_turn_answer("plain text body"), "plain text body");
     }
 
     #[test]

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -5,6 +5,7 @@
 //! `commands::chat`; everything here is Tauri-free so it's unit-testable.
 
 mod adapter;
+pub mod cloud;
 mod providers;
 mod tools;
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -565,16 +565,48 @@ async fn stream_cloud_turn(
         });
     }
 
+    // Degraded fallback (AC2): if a 2xx response isn't an SSE stream, treat it as
+    // a non-streamed whole-turn — emit the answer as one chunk + done, so the UI
+    // completes rather than hanging on a stream that never frames.
+    let is_sse = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|ct| ct.contains("text/event-stream"))
+        .unwrap_or(false);
+    if !is_sse {
+        let body = resp.text().await.unwrap_or_default();
+        let answer = chat::cloud::whole_turn_answer(&body);
+        let message_id = uuid::Uuid::new_v4().to_string();
+        let _ = app.emit(
+            "chat_text_delta",
+            serde_json::json!({
+                "conversationId": local_conversation_id,
+                "messageId": message_id,
+                "blockId": uuid::Uuid::new_v4().to_string(),
+                "delta": answer,
+            }),
+        );
+        let _ = app.emit(
+            "chat_done",
+            serde_json::json!({ "conversationId": local_conversation_id, "messageId": message_id }),
+        );
+        return Ok(CloudTurn { preflight: None, server_conversation_id: None });
+    }
+
+    // Buffer raw bytes and frame on the byte terminator, decoding only COMPLETE
+    // frames — so a multibyte codepoint split across two network chunks (e.g. a
+    // Norwegian å in a streamed delta) is never mangled by a mid-character decode.
     let mut byte_stream = resp.bytes_stream();
-    let mut buf = String::new();
+    let mut buf: Vec<u8> = Vec::new();
     let mut server_conversation_id: Option<String> = None;
     while let Some(chunk) = byte_stream.next().await {
         let bytes = chunk.map_err(|e| format!("Team chat stream error: {e}"))?;
-        buf.push_str(&String::from_utf8_lossy(&bytes));
+        buf.extend_from_slice(&bytes);
         while let Some((idx, delim)) = chat::cloud::find_event_end(&buf) {
-            let frame: String = buf.drain(..idx + delim).collect();
-            let block = &frame[..idx];
-            let Some((event, data)) = chat::cloud::parse_sse_frame(block) else { continue };
+            let frame: Vec<u8> = buf.drain(..idx + delim).collect();
+            let text = String::from_utf8_lossy(&frame[..idx]);
+            let Some((event, data)) = chat::cloud::parse_sse_frame(&text) else { continue };
             let Ok(mut payload) = serde_json::from_str::<serde_json::Value>(&data) else { continue };
             if server_conversation_id.is_none() {
                 if let Some(sid) = payload.get("conversationId").and_then(|c| c.as_str()) {
@@ -755,14 +787,15 @@ mod tests {
 
         // 3. Pump the SSE stream with the production helpers; assert we reach `done`.
         let mut stream = resp.bytes_stream();
-        let mut buf = String::new();
+        let mut buf: Vec<u8> = Vec::new();
         let mut conversation_id: Option<String> = None;
         let mut saw_done = false;
         while let Some(chunk) = stream.next().await {
-            buf.push_str(&String::from_utf8_lossy(&chunk.expect("chunk")));
+            buf.extend_from_slice(&chunk.expect("chunk"));
             while let Some((idx, delim)) = chat::cloud::find_event_end(&buf) {
-                let frame: String = buf.drain(..idx + delim).collect();
-                let Some((event, data)) = chat::cloud::parse_sse_frame(&frame[..idx]) else { continue };
+                let frame: Vec<u8> = buf.drain(..idx + delim).collect();
+                let text = String::from_utf8_lossy(&frame[..idx]);
+                let Some((event, data)) = chat::cloud::parse_sse_frame(&text) else { continue };
                 if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
                     if let Some(id) = v.get("conversationId").and_then(|c| c.as_str()) {
                         conversation_id.get_or_insert_with(|| id.to_string());

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -309,18 +309,35 @@ pub struct ChatSendResult {
     truncated: bool,
 }
 
+/// The chat tenant a turn runs in (issue #50). `"personal"` (default) is the
+/// on-device, never-gated path; `"workspace"` delegates to the humla-cloud
+/// endpoint for the currently-selected workspace. The frontend only ever sends
+/// these two values — it can't name a *different* workspace — so the no-cross-
+/// tenant invariant (story 5/19) is enforced by always resolving "workspace" to
+/// the active workspace server-side.
+fn is_workspace_tenant(tenant: &Option<String>) -> bool {
+    tenant.as_deref() == Some("workspace")
+}
+
 #[tauri::command]
 pub async fn chat_send(
     app: AppHandle,
     note_id: String,
     message: String,
     scope: Option<String>,
+    tenant: Option<String>,
 ) -> Result<ChatSendResult, String> {
+    let breadth = scope.unwrap_or_else(|| "note".into());
+    // Workspace (Teams) chat delegates to the cloud endpoint (issue #50);
+    // Personal chat stays fully on-device below.
+    if is_workspace_tenant(&tenant) {
+        return chat_send_cloud(app, note_id, message, breadth).await;
+    }
+
     let state: State<AppState> = app.state();
     // Keychain read out of band — not inside the DB lock. Chat reuses the
     // shared OpenAI key (issue #44).
     let openai_api_key = super::read_provider_api_key(&state, "openai")?;
-    let breadth = scope.unwrap_or_else(|| "note".into());
 
     let (grounding, resolved, conversation_id, tool_scope, workspace) = {
         let conn = state.db.lock();
@@ -422,20 +439,204 @@ pub async fn chat_send(
     }
 }
 
+/// Result of one streamed workspace turn against the cloud endpoint.
+struct CloudTurn {
+    /// A non-2xx preflight response `(status, reason, error)` — the turn never
+    /// streamed (blocked or malformed). None once the SSE stream opened.
+    preflight: Option<(u16, String, String)>,
+    /// The server's conversation record id, learned from the streamed events —
+    /// persisted as the local conversation's `remote_id` so later turns resume.
+    server_conversation_id: Option<String>,
+}
+
+/// Workspace (Teams) chat turn (issue #50): delegate to the deployed humla-cloud
+/// `POST /api/chat`, stream the SSE response, and re-emit it on the SAME `chat_*`
+/// events the local loop uses (story 18). The conversation is server-
+/// authoritative — its messages live in the cloud (read-through via
+/// `chat_history`); locally we keep only a handle row whose `remote_id` maps to
+/// the server conversation. `"workspace"` always resolves to the *active*
+/// workspace, so a turn can never reach a different tenant (story 5/19).
+async fn chat_send_cloud(
+    app: AppHandle,
+    note_id: String,
+    message: String,
+    breadth: String,
+) -> Result<ChatSendResult, String> {
+    let state: State<AppState> = app.state();
+    let (workspace, folder_id, title, conversation) = {
+        let conn = state.db.lock();
+        let workspace = super::cloud::active_workspace(&conn);
+        if workspace.is_empty() {
+            return Err("No workspace selected — switch to a workspace to use Team chat.".into());
+        }
+        let note = db::get_note(&conn, &note_id).map_err(|e| e.to_string())?;
+        let conversation =
+            db::get_or_create_conversation(&conn, &workspace, CHAT_SCOPE_NOTE, &note_id)
+                .map_err(|e| e.to_string())?;
+        (workspace, note.folder_id.clone(), note.title.clone(), conversation)
+    };
+
+    let body = chat::cloud::build_cloud_request(
+        conversation.remote_id.as_deref(),
+        &workspace,
+        &message,
+        Some(&title),
+        &breadth,
+        &note_id,
+        folder_id.as_deref(),
+    );
+
+    // Stream the turn, retrying once after a 401 (a stale cached token → forget
+    // it and re-authenticate from stored credentials, mirroring cloud.rs).
+    let mut attempt = 0u8;
+    let outcome = loop {
+        let (base, token) = super::cloud::cloud_session(&state).await?;
+        let turn = stream_cloud_turn(&app, &base, &token, &body, &conversation.id).await;
+        match turn {
+            Ok(t) => {
+                if matches!(&t.preflight, Some((401, _, _))) && attempt == 0 {
+                    super::cloud::forget_session();
+                    attempt += 1;
+                    continue;
+                }
+                break t;
+            }
+            Err(e) => {
+                let _ = app.emit(
+                    "chat_error",
+                    ChatErrorPayload { conversation_id: conversation.id.clone(), message: e.clone() },
+                );
+                return Err(e);
+            }
+        }
+    };
+
+    if let Some((_, reason, server_msg)) = outcome.preflight {
+        let text = chat::cloud::cloud_chat_error_message(&reason, &server_msg);
+        let _ = app.emit(
+            "chat_error",
+            ChatErrorPayload { conversation_id: conversation.id.clone(), message: text.clone() },
+        );
+        return Err(text);
+    }
+
+    // Remember the server conversation id for resume + read-through history.
+    if let Some(server_id) = outcome.server_conversation_id {
+        if conversation.remote_id.as_deref() != Some(server_id.as_str()) {
+            let conn = state.db.lock();
+            let _ = db::set_conversation_remote_id(&conn, &conversation.id, &server_id);
+        }
+    }
+
+    // Truncation is a server concern for workspace turns; the client just relays.
+    Ok(ChatSendResult { conversation_id: conversation.id, truncated: false })
+}
+
+/// POST the turn and pump the SSE response, re-emitting each event on the
+/// matching `chat_*` Tauri event. Server event payloads already carry the
+/// frontend-shaped camelCase fields; we only re-stamp `conversationId` to the
+/// LOCAL conversation id (so the UI keys turns the same across tenants) and
+/// capture the server's id to persist. A non-2xx response is returned as a
+/// structured preflight error instead of a stream.
+async fn stream_cloud_turn(
+    app: &AppHandle,
+    base: &str,
+    token: &str,
+    body: &serde_json::Value,
+    local_conversation_id: &str,
+) -> Result<CloudTurn, String> {
+    use futures_util::StreamExt;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/api/chat", base.trim_end_matches('/')))
+        .bearer_auth(token)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| format!("Couldn't reach Team chat: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let val: serde_json::Value = resp.json().await.unwrap_or_default();
+        let reason = val.get("reason").and_then(|r| r.as_str()).unwrap_or_default().to_string();
+        let server_msg = val.get("error").and_then(|m| m.as_str()).unwrap_or_default().to_string();
+        return Ok(CloudTurn {
+            preflight: Some((status.as_u16(), reason, server_msg)),
+            server_conversation_id: None,
+        });
+    }
+
+    let mut byte_stream = resp.bytes_stream();
+    let mut buf = String::new();
+    let mut server_conversation_id: Option<String> = None;
+    while let Some(chunk) = byte_stream.next().await {
+        let bytes = chunk.map_err(|e| format!("Team chat stream error: {e}"))?;
+        buf.push_str(&String::from_utf8_lossy(&bytes));
+        while let Some((idx, delim)) = chat::cloud::find_event_end(&buf) {
+            let frame: String = buf.drain(..idx + delim).collect();
+            let block = &frame[..idx];
+            let Some((event, data)) = chat::cloud::parse_sse_frame(block) else { continue };
+            let Ok(mut payload) = serde_json::from_str::<serde_json::Value>(&data) else { continue };
+            if server_conversation_id.is_none() {
+                if let Some(sid) = payload.get("conversationId").and_then(|c| c.as_str()) {
+                    if !sid.is_empty() {
+                        server_conversation_id = Some(sid.to_string());
+                    }
+                }
+            }
+            if let Some(obj) = payload.as_object_mut() {
+                obj.insert("conversationId".into(), serde_json::json!(local_conversation_id));
+            }
+            if let Some(tauri_event) = chat::cloud::tauri_event_for(&event) {
+                let _ = app.emit(tauri_event, payload);
+            }
+        }
+    }
+    Ok(CloudTurn { preflight: None, server_conversation_id })
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatMessageDto {
     id: String,
     role: String,
     seq: i64,
-    parts: Vec<chat::Part>,
+    /// Raw opencode-v2 parts JSON. Passed through verbatim: the local path
+    /// serialises its `Vec<chat::Part>` into this value; the workspace read-
+    /// through passes PocketBase's stored parts straight through (already the
+    /// frontend-shaped camelCase), so tool/citation parts render either way.
+    parts: serde_json::Value,
     created_at: i64,
 }
 
 /// Reload a Note's conversation (empty if none exists yet). Drives history
-/// restore when the Chat tab opens or after an app restart.
+/// restore when the Chat tab opens or after an app restart. For a workspace
+/// tenant (issue #50) this is a read-through of the server-authoritative
+/// conversation — messages live in the cloud, not the local `messages` table.
 #[tauri::command]
-pub fn chat_history(state: State<AppState>, note_id: String) -> Result<Vec<ChatMessageDto>, String> {
+pub async fn chat_history(
+    app: AppHandle,
+    note_id: String,
+    tenant: Option<String>,
+) -> Result<Vec<ChatMessageDto>, String> {
+    let state: State<AppState> = app.state();
+    if is_workspace_tenant(&tenant) {
+        // Resolve the workspace conversation's server id, then read its messages
+        // through PocketBase (the source of truth for shared conversations).
+        let remote_id = {
+            let conn = state.db.lock();
+            let workspace = super::cloud::active_workspace(&conn);
+            if workspace.is_empty() {
+                return Ok(Vec::new());
+            }
+            db::get_conversation(&conn, &workspace, CHAT_SCOPE_NOTE, &note_id)
+                .map_err(|e| e.to_string())?
+                .and_then(|c| c.remote_id)
+        };
+        let Some(remote_id) = remote_id else { return Ok(Vec::new()) };
+        let records = super::cloud::fetch_chat_messages(&state, &remote_id).await?;
+        return Ok(records.iter().filter_map(map_remote_message).collect());
+    }
+
     let conn = state.db.lock();
     let Some(conversation) =
         db::get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note_id)
@@ -450,10 +651,27 @@ pub fn chat_history(state: State<AppState>, note_id: String) -> Result<Vec<ChatM
             id: m.id,
             role: m.role,
             seq: m.seq,
-            parts: chat::parse_parts(&m.content),
+            parts: serde_json::to_value(chat::parse_parts(&m.content)).unwrap_or_default(),
             created_at: m.created_at,
         })
         .collect())
+}
+
+/// Map one PocketBase `chat_messages` record (read-through) to the UI DTO. Its
+/// `parts` are already the frontend-shaped opencode-v2 JSON, so they pass
+/// through untouched; `created` (RFC3339 autodate) becomes epoch-ms.
+fn map_remote_message(rec: &serde_json::Value) -> Option<ChatMessageDto> {
+    let id = rec.get("id")?.as_str()?.to_string();
+    let role = rec.get("role").and_then(|r| r.as_str()).unwrap_or("assistant").to_string();
+    let seq = rec.get("seq").and_then(|s| s.as_i64()).unwrap_or(0);
+    let parts = rec.get("parts").cloned().unwrap_or_else(|| serde_json::json!([]));
+    let created_at = rec
+        .get("created")
+        .and_then(|c| c.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.timestamp_millis())
+        .unwrap_or(0);
+    Some(ChatMessageDto { id, role, seq, parts, created_at })
 }
 
 #[cfg(test)]
@@ -480,5 +698,83 @@ mod tests {
         assert!(res.is_err());
         let err = res.err().unwrap().to_string();
         assert!(err.contains("embedding model"), "clear guidance, not a raw 400: {err}");
+    }
+
+    /// Cross-repo round-trip of a real workspace `chat_send` against a live
+    /// humla-cloud stack (issue #50, AC6), matching the env-gated shape of the
+    /// cloud-sync roundtrips: skipped unless the HUMLA_TEST_* vars point at a
+    /// booted server (PocketBase + chat-service + an LLM key). It authenticates,
+    /// POSTs `/api/chat`, and pumps the SSE stream through the SAME pure helpers
+    /// `stream_cloud_turn` uses — asserting the turn reaches a terminal `done`
+    /// and carries a conversation id. Plain `cargo test` (no env) skips it.
+    #[tokio::test]
+    async fn cloud_chat_roundtrip() {
+        use futures_util::StreamExt;
+        let (Ok(pb), Ok(chat), Ok(email), Ok(pass), Ok(ws)) = (
+            std::env::var("HUMLA_TEST_PB_URL"),
+            std::env::var("HUMLA_TEST_CHAT_URL"),
+            std::env::var("HUMLA_TEST_EMAIL"),
+            std::env::var("HUMLA_TEST_PASSWORD"),
+            std::env::var("HUMLA_TEST_WORKSPACE"),
+        ) else {
+            eprintln!("cloud_chat_roundtrip: skipped (set HUMLA_TEST_PB_URL/CHAT_URL/EMAIL/PASSWORD/WORKSPACE)");
+            return;
+        };
+        let client = reqwest::Client::new();
+
+        // 1. Authenticate against PocketBase for a real user token.
+        let auth: serde_json::Value = client
+            .post(format!("{pb}/api/collections/users/auth-with-password"))
+            .json(&serde_json::json!({ "identity": email, "password": pass }))
+            .send()
+            .await
+            .expect("auth send")
+            .json()
+            .await
+            .expect("auth json");
+        let token = auth.get("token").and_then(|t| t.as_str()).expect("token");
+
+        // 2. POST a workspace turn, built by the same request assembler the app uses.
+        let body = chat::cloud::build_cloud_request(
+            None,
+            &ws,
+            "In one sentence, what is this workspace about?",
+            Some("roundtrip test"),
+            "all",
+            "roundtrip-anchor",
+            None,
+        );
+        let resp = client
+            .post(format!("{}/api/chat", chat.trim_end_matches('/')))
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await
+            .expect("chat send");
+        assert!(resp.status().is_success(), "chat endpoint returned {}", resp.status());
+
+        // 3. Pump the SSE stream with the production helpers; assert we reach `done`.
+        let mut stream = resp.bytes_stream();
+        let mut buf = String::new();
+        let mut conversation_id: Option<String> = None;
+        let mut saw_done = false;
+        while let Some(chunk) = stream.next().await {
+            buf.push_str(&String::from_utf8_lossy(&chunk.expect("chunk")));
+            while let Some((idx, delim)) = chat::cloud::find_event_end(&buf) {
+                let frame: String = buf.drain(..idx + delim).collect();
+                let Some((event, data)) = chat::cloud::parse_sse_frame(&frame[..idx]) else { continue };
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if let Some(id) = v.get("conversationId").and_then(|c| c.as_str()) {
+                        conversation_id.get_or_insert_with(|| id.to_string());
+                    }
+                }
+                if event == "done" {
+                    saw_done = true;
+                }
+                assert_ne!(event, "error", "server streamed an error: {data}");
+            }
+        }
+        assert!(saw_done, "the turn never reached a terminal `done` event");
+        assert!(conversation_id.is_some(), "no conversation id was streamed");
     }
 }

--- a/src-tauri/src/commands/cloud.rs
+++ b/src-tauri/src/commands/cloud.rs
@@ -320,6 +320,45 @@ async fn ensure_session(state: &State<'_, AppState>) -> Result<(String, Session)
     Ok((base, session))
 }
 
+/// Cloud `(base_url, auth token)` for a command that calls the server directly
+/// (Teams chat, issue #50). Reuses the cached session and the auto-login-from-
+/// Keychain path. The token may be stale — a 401 from the endpoint should call
+/// [`forget_session`] and retry once, mirroring `pb_json`'s reactive refresh.
+pub(crate) async fn cloud_session(state: &State<'_, AppState>) -> Result<(String, String), String> {
+    let (base, session) = ensure_session(state).await?;
+    Ok((base, session.token))
+}
+
+/// Drop the cached session so the next [`cloud_session`] re-authenticates from
+/// stored credentials — call after a 401 from a direct endpoint call.
+pub(crate) fn forget_session() {
+    *SESSION.lock().unwrap() = None;
+}
+
+/// Read-through fetch of a workspace conversation's messages (issue #50).
+/// Workspace chat is server-authoritative: history lives in PocketBase's
+/// member-readable `chat_messages`, scoped by the caller's token. Returns the
+/// raw records sorted by `seq`; the chat command maps them to the UI DTO.
+pub(crate) async fn fetch_chat_messages(
+    state: &State<'_, AppState>,
+    conversation_id: &str,
+) -> Result<Vec<serde_json::Value>, String> {
+    let (base, session) = ensure_session(state).await?;
+    let filter = format!("conversation=\"{conversation_id}\"");
+    let val = authed_get(
+        &base,
+        &session.token,
+        "/api/collections/chat_messages/records",
+        &[("filter", filter.as_str()), ("sort", "seq"), ("perPage", "200")],
+    )
+    .await?;
+    Ok(val
+        .get("items")
+        .and_then(|i| i.as_array())
+        .cloned()
+        .unwrap_or_default())
+}
+
 // ---- role / relation helpers -----------------------------------------------
 
 fn ids(val: &serde_json::Value, field: &str) -> Vec<String> {

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -276,6 +276,13 @@ pub fn open(path: &Path) -> Result<Connection> {
     // instead of dropping the row so it's recoverable; remote tombstones land
     // here too. Note lists filter `deleted_at IS NULL`.
     let _ = conn.execute("ALTER TABLE notes ADD COLUMN deleted_at INTEGER", []);
+    // Workspace (Teams) chat (issue #50). A workspace conversation is
+    // server-authoritative: the local row is just a (tenant, scope, scope_id)
+    // handle whose `remote_id` maps to the humla-cloud conversation record id.
+    // NULL until the first turn creates the server conversation. Personal
+    // conversations never set it. Its messages live server-side (read-through),
+    // never in the local `messages` table.
+    let _ = conn.execute("ALTER TABLE conversations ADD COLUMN remote_id TEXT", []);
     // Index is created AFTER the ALTERs so it's safe on both fresh DBs and
     // older DBs that needed the column added.
     conn.execute(
@@ -903,6 +910,10 @@ pub struct Conversation {
     pub scope: String,
     pub scope_id: String,
     pub tenant: String,
+    /// humla-cloud conversation record id for a workspace (Teams) conversation
+    /// (issue #50); NULL for Personal conversations and until the first
+    /// workspace turn creates the server record.
+    pub remote_id: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -926,12 +937,13 @@ fn map_conversation(row: &rusqlite::Row) -> rusqlite::Result<Conversation> {
         scope: row.get(1)?,
         scope_id: row.get(2)?,
         tenant: row.get(3)?,
-        created_at: row.get(4)?,
-        updated_at: row.get(5)?,
+        remote_id: row.get(4)?,
+        created_at: row.get(5)?,
+        updated_at: row.get(6)?,
     })
 }
 
-const CONVERSATION_COLS: &str = "id, scope, scope_id, tenant, created_at, updated_at";
+const CONVERSATION_COLS: &str = "id, scope, scope_id, tenant, remote_id, created_at, updated_at";
 
 /// The existing conversation for a scope, or None. Used to reload history
 /// without creating an empty conversation just for opening the Chat tab.
@@ -973,6 +985,17 @@ pub fn get_or_create_conversation(
     )?;
     get_conversation(conn, tenant, scope, scope_id)?
         .ok_or_else(|| anyhow::anyhow!("conversation vanished after insert"))
+}
+
+/// Record the humla-cloud conversation record id for a workspace conversation
+/// (issue #50), so later turns resume it and read-through history can find it.
+/// Idempotent — a repeat with the same id is a no-op write.
+pub fn set_conversation_remote_id(conn: &Connection, id: &str, remote_id: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE conversations SET remote_id = ?1 WHERE id = ?2",
+        params![remote_id, id],
+    )?;
+    Ok(())
 }
 
 fn map_chat_message(row: &rusqlite::Row) -> rusqlite::Result<ChatMessage> {
@@ -1805,6 +1828,27 @@ mod tests {
         assert_eq!(list_folders(&conn, "wsA").unwrap().len(), 1);
         assert_eq!(list_folders(&conn, "").unwrap().len(), 1);
         assert_eq!(list_folders(&conn, "wsB").unwrap().len(), 0);
+    }
+
+    /// A workspace (Teams) conversation is keyed by tenant and carries a
+    /// remote_id once the server creates it (issue #50). Personal and workspace
+    /// conversations for the same Note are distinct rows; remote_id starts NULL.
+    #[test]
+    fn conversation_remote_id_round_trips_and_tenant_scopes() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = open(&dir.path().join("conv.sqlite")).unwrap();
+
+        let personal = get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1").unwrap();
+        let workspace = get_or_create_conversation(&conn, "wsA", CHAT_SCOPE_NOTE, "note1").unwrap();
+        assert_ne!(personal.id, workspace.id, "same Note, different tenant → distinct conversations");
+        assert!(workspace.remote_id.is_none(), "no server id until the first turn");
+
+        set_conversation_remote_id(&conn, &workspace.id, "srvConv123").unwrap();
+        let reloaded = get_conversation(&conn, "wsA", CHAT_SCOPE_NOTE, "note1").unwrap().unwrap();
+        assert_eq!(reloaded.remote_id.as_deref(), Some("srvConv123"));
+        // The personal conversation is untouched by the workspace one's remote id.
+        let personal_reload = get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1").unwrap().unwrap();
+        assert!(personal_reload.remote_id.is_none());
     }
 
     #[test]

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -4,6 +4,23 @@ import { MemoryRouter } from "react-router-dom";
 import { ChatPanel } from "./ChatPanel";
 import { mockTauri } from "../test/tauri";
 import type { ChatMessageDto } from "../lib/ipc";
+import { useCloudStore, DISCONNECTED } from "../lib/cloud";
+
+// Populate the cloud store as if signed into a workspace, so the Teams tenant
+// row appears (issue #50).
+function signIntoWorkspace(name = "Acme Team") {
+  const ws = { id: "ws1", name, role: "owner" as const, plan_status: "active" as const };
+  useCloudStore.setState({
+    status: {
+      ...DISCONNECTED,
+      configured: true,
+      logged_in: true,
+      base_url: "https://sync.humla.team",
+      current_workspace: ws,
+      workspaces: [ws],
+    },
+  });
+}
 
 function userMsg(text: string): ChatMessageDto {
   return { id: "u1", role: "user", seq: 0, parts: [{ type: "text", id: "b0", text }], createdAt: 1 };
@@ -41,6 +58,8 @@ function renderPanel(noteId = "n1") {
 
 beforeEach(() => {
   mockTauri();
+  // Default: signed out, so Personal is the only tenant unless a test opts in.
+  useCloudStore.setState({ status: DISCONNECTED });
 });
 
 describe("ChatPanel readiness", () => {
@@ -121,5 +140,52 @@ describe("ChatPanel retrieval UI (#47)", () => {
     await waitFor(() => expect(screen.getByText("All notes")).toBeInTheDocument());
     // No folder on the anchor note → no "this folder" option.
     expect(screen.queryByText(/^Folder:/)).toBeNull();
+  });
+});
+
+describe("ChatPanel Teams tenant (#50)", () => {
+  it("hides the tenant row when signed out of the cloud", async () => {
+    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => [] });
+    renderPanel();
+    await screen.findByPlaceholderText(/Ask about your notes/);
+    // Personal is implicit — no tenant selector is shown at all.
+    expect(screen.queryByRole("button", { name: "Chat tenant" })).toBeNull();
+  });
+
+  it("offers Personal + the active workspace once signed in", async () => {
+    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => [] });
+    signIntoWorkspace("Acme Team");
+    renderPanel();
+    const trigger = await screen.findByRole("button", { name: "Chat tenant" });
+    // Closed, the trigger shows the current tenant (Personal).
+    expect(trigger).toHaveTextContent("Personal");
+    fireEvent.click(trigger);
+    // Open, it offers the workspace you're in — the only one it can (no cross-tenant).
+    await waitFor(() => expect(screen.getByText("Acme Team")).toBeInTheDocument());
+    expect(screen.getAllByText("Personal").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("sends with the workspace tenant after switching to it", async () => {
+    let sentTenant: string | undefined;
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => [],
+      chat_send: (args) => {
+        sentTenant = (args as { tenant?: string }).tenant;
+        return { conversationId: "c1", truncated: false };
+      },
+    });
+    signIntoWorkspace("Acme Team");
+    renderPanel();
+
+    // Switch the tenant to the workspace.
+    fireEvent.click(await screen.findByRole("button", { name: "Chat tenant" }));
+    fireEvent.click(await screen.findByText("Acme Team"));
+
+    const input = await screen.findByPlaceholderText(/Ask about your notes/);
+    fireEvent.change(input, { target: { value: "what did the team decide?" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(sentTenant).toBe("workspace"));
   });
 });

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -13,8 +13,10 @@ import {
   type ChatCitation,
   type ChatMessageDto,
   type ChatScope,
+  type ChatTenant,
 } from "../lib/ipc";
 import { useNotesStore } from "../lib/store";
+import { useCloudStore } from "../lib/cloud";
 import { useChatReadiness } from "./provider/useChatReadiness";
 import { SelectablePopover, type PopoverItem } from "./SelectablePopover";
 import { RECOMMENDED_OLLAMA_MODEL } from "../lib/localModels";
@@ -79,6 +81,7 @@ export function ChatPanel({ noteId }: { noteId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [truncated, setTruncated] = useState(false);
   const [scope, setScope] = useState<ChatScope>("note");
+  const [tenant, setTenant] = useState<ChatTenant>("personal");
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const sendingRef = useRef(false);
 
@@ -88,6 +91,13 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     const fid = note?.folder_id;
     return fid ? s.folders.find((f) => f.id === fid) ?? null : null;
   });
+
+  // Team (workspace) chat is offered only when signed into a cloud workspace
+  // (issue #50). The tenant row can never name a *different* workspace than the
+  // active one — so a conversation can't cross tenants (story 5/19).
+  const workspaceName = useCloudStore((s) =>
+    s.status.logged_in ? s.status.current_workspace?.name ?? null : null,
+  );
 
   // Load persisted history on mount / note change, and clear transient state.
   // On unmount / note change, rebuild the note's retrieval index so edits made
@@ -102,9 +112,10 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     setTruncated(false);
     setSending(false);
     setScope("note");
+    setTenant("personal");
     sendingRef.current = false;
     ipc
-      .chatHistory(noteId)
+      .chatHistory(noteId, "personal")
       .then((h) => {
         if (!cancelled) setMessages(h);
       })
@@ -116,6 +127,33 @@ export function ChatPanel({ noteId }: { noteId: string }) {
       void ipc.chatReindexNote(noteId).catch(() => {});
     };
   }, [noteId]);
+
+  // If the workspace goes away (sign-out / switch) while a Team conversation is
+  // open, fall back to Personal so we never send to a stale tenant.
+  useEffect(() => {
+    if (tenant === "workspace" && !workspaceName) changeTenant("personal");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceName]);
+
+  // Switching tenant starts a fresh conversation in that tenant (issue #50):
+  // reset transient state and read-through that tenant's history.
+  function changeTenant(next: ChatTenant) {
+    if (next === tenant) return;
+    setTenant(next);
+    setStreaming("");
+    setActivity(null);
+    setLiveCitations([]);
+    setError(null);
+    setTruncated(false);
+    setInput("");
+    setScope("note");
+    setSending(false);
+    sendingRef.current = false;
+    ipc
+      .chatHistory(noteId, next)
+      .then(setMessages)
+      .catch(() => setMessages([]));
+  }
 
   // Stream subscription. Bound once; cancelled-flag + claim keeps it StrictMode-
   // and async-listen-safe. Deltas/activity accepted only while our send is live.
@@ -177,13 +215,13 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     };
     setMessages((m) => [...m, optimistic]);
     try {
-      const result = await ipc.chatSend(noteId, text, scope);
-      setMessages(await ipc.chatHistory(noteId));
+      const result = await ipc.chatSend(noteId, text, scope, tenant);
+      setMessages(await ipc.chatHistory(noteId, tenant));
       setTruncated(result.truncated);
     } catch (e) {
       setError((prev) => prev ?? String(e));
       try {
-        setMessages(await ipc.chatHistory(noteId));
+        setMessages(await ipc.chatHistory(noteId, tenant));
       } catch {
         /* keep the optimistic view */
       }
@@ -237,7 +275,14 @@ export function ChatPanel({ noteId }: { noteId: string }) {
 
   return (
     <div className="flex-1 min-h-0 flex flex-col">
-      <ScopeBar scope={scope} onScope={setScope} folderName={folder?.name ?? null} />
+      <ScopeBar
+        scope={scope}
+        onScope={setScope}
+        folderName={folder?.name ?? null}
+        tenant={tenant}
+        onTenant={changeTenant}
+        workspaceName={workspaceName}
+      />
 
       <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-4 py-4 flex flex-col gap-3">
         {messages.length === 0 && !sending ? (
@@ -307,16 +352,24 @@ export function ChatPanel({ noteId }: { noteId: string }) {
   );
 }
 
-// Breadth selector at the top of the chat. "This folder" only appears when the
-// note actually has a folder (there's nothing to widen to otherwise).
+// Tenant + breadth selectors at the top of the chat. The tenant row (Personal /
+// the active workspace) only appears when signed into a workspace (issue #50);
+// "This folder" only appears when the note has a folder (nothing to widen to
+// otherwise).
 function ScopeBar({
   scope,
   onScope,
   folderName,
+  tenant,
+  onTenant,
+  workspaceName,
 }: {
   scope: ChatScope;
   onScope: (s: ChatScope) => void;
   folderName: string | null;
+  tenant: ChatTenant;
+  onTenant: (t: ChatTenant) => void;
+  workspaceName: string | null;
 }) {
   const items: PopoverItem[] = [
     { id: "note", label: "This note" },
@@ -327,8 +380,32 @@ function ScopeBar({
   const activeId = scope === "folder" && !folderName ? "note" : scope;
   const label = items.find((i) => i.id === activeId)?.label ?? "This note";
 
+  const tenantItems: PopoverItem[] = [
+    { id: "personal", label: "Personal" },
+    ...(workspaceName ? [{ id: "workspace", label: workspaceName }] : []),
+  ];
+  const activeTenant = tenant === "workspace" && !workspaceName ? "personal" : tenant;
+  const tenantLabel =
+    tenantItems.find((i) => i.id === activeTenant)?.label ?? "Personal";
+
   return (
     <div className="shrink-0 flex items-center gap-2 px-4 py-2 border-b border-[var(--color-line)]">
+      {workspaceName && (
+        <>
+          <SelectablePopover
+            ariaLabel="Chat tenant"
+            items={tenantItems}
+            activeId={activeTenant}
+            onSelect={(id) => onTenant((id as ChatTenant) ?? "personal")}
+            trigger={
+              <span className="nd-chip inline-flex items-center gap-1 text-xs cursor-pointer">
+                {tenantLabel}
+              </span>
+            }
+          />
+          <span className="text-xs text-[var(--color-text-disabled)]">·</span>
+        </>
+      )}
       <span className="text-xs text-[var(--color-text-disabled)]">Search</span>
       <SelectablePopover
         ariaLabel="Chat scope"

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -389,10 +389,17 @@ export const ipc = {
   // resolved promise only carries the conversation id + a truncation flag.
   // `chatHistory` reloads a Note's persisted conversation after restart.
   // `scope` is the Scope-popover breadth ("note" | "folder" | "all"), a live
-  // filter on retrieval within the same conversation (issue #47).
-  chatSend: (noteId: string, message: string, scope: ChatScope = "note") =>
-    invoke<ChatSendResult>("chat_send", { noteId, message, scope }),
-  chatHistory: (noteId: string) => invoke<ChatMessageDto[]>("chat_history", { noteId }),
+  // filter on retrieval within the same conversation (issue #47). `tenant`
+  // (issue #50) selects Personal (on-device) vs the active Workspace (Teams,
+  // delegated to the cloud endpoint); switching it is a different conversation.
+  chatSend: (
+    noteId: string,
+    message: string,
+    scope: ChatScope = "note",
+    tenant: ChatTenant = "personal",
+  ) => invoke<ChatSendResult>("chat_send", { noteId, message, scope, tenant }),
+  chatHistory: (noteId: string, tenant: ChatTenant = "personal") =>
+    invoke<ChatMessageDto[]>("chat_history", { noteId, tenant }),
   // Rebuild a Note's retrieval index — called on Note-view unmount so edits
   // that didn't trigger summarize/diarize still land in search.
   chatReindexNote: (noteId: string) => invoke<void>("chat_reindex_note", { noteId }),
@@ -439,6 +446,10 @@ export type ChatMessageDto = {
 export type ChatSendResult = { conversationId: string; truncated: boolean };
 // Retrieval breadth chosen in the Scope popover (issue #47).
 export type ChatScope = "note" | "folder" | "all";
+// Chat tenant chosen in the Scope popover (issue #50). "personal" runs on-device
+// and is never gated; "workspace" delegates to the cloud endpoint for the
+// currently-selected workspace (the only workspace it can ever reach).
+export type ChatTenant = "personal" | "workspace";
 
 // Streaming events (the #46 wire contract + #47 tool/citation events).
 export type ChatTextDeltaEvent = {


### PR DESCRIPTION
Closes #50. The client side of Teams chat — wires the desktop into the already-deployed humla-cloud `/api/chat` endpoint. This is the **last child of PRD #42**.

## What changed
- **Tenant row** in the Scope popover (Personal / the active workspace), shown only when signed into a workspace. Tenant is fixed per conversation, so switching it starts a fresh conversation; the row can only ever name the workspace you're already in, and the backend resolves `"workspace"` to the *active* workspace — a conversation can never cross tenants (stories 5/19).
- **`chat_send` → cloud**: a workspace turn POSTs to `/api/chat` over the cloud session the app already holds, streams the SSE response, and re-emits it on the **same `chat_*` events** the local loop uses, so the Chat UI is identical across tenants (story 18). 401 → forget session + retry once.
- **Server-authoritative** (story 20): workspace messages live in the cloud. The local conversation row is just a handle whose new `conversations.remote_id` maps to the server conversation; `chat_history` reads workspace turns through PocketBase (read-through cache), never the local `messages` table.
- **Monetization reflection**: a blocked turn's server reason code becomes a clear message naming the upgrade path — resubscribe for `subscription_lapsed` (story 21), the chat-capacity add-on for `quota_exhausted` (story 22). The client never tracks quota or infers entitlement.
- **Personal chat unchanged and never gated** (story 23).

Tauri-free helpers (request assembly, **byte-framed** SSE parsing, event mapping, reason→message, whole-turn fallback) live in `chat/cloud.rs`, unit-tested. New `cloud.rs` accessors (`cloud_session`/`forget_session`/`fetch_chat_messages`) reuse the existing auth path — no re-implemented auth. `db`: `conversations.remote_id` (idempotent migration, NULL for Personal).

## Review fixes (2-axis, applied)
- **Correctness**: the SSE reader framed on bytes and decodes only complete frames, so a multibyte codepoint split across network chunks (Norwegian `æøå` in a streamed delta) can't be mangled.
- **AC2**: added the degraded non-streamed whole-turn fallback so a non-SSE 2xx completes instead of hanging.

## Tests
`chat::cloud` pure helpers (incl. split-`å` framing + whole-turn fallback); `conversations.remote_id` round-trip; ChatPanel tenant-row rendering + workspace-tenant send; env-gated cross-repo `cloud_chat_roundtrip` (skipped without `HUMLA_TEST_*` + a live endpoint). **292 Rust + 186 FE green; tsc clean.**

Note: no companion cloud change — the endpoint (humla-cloud #7 / #9–#13) is already deployed. Live Teams-chat visual QA (`pnpm tauri dev` with a signed-in workspace) still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)