### PR TITLE
fix(chat): persist breadth per conversation, pin chat to loaded workspace (#58)

### DIFF
--- a/src-tauri/src/chat/cloud.rs
+++ b/src-tauri/src/chat/cloud.rs
@@ -16,8 +16,15 @@ use serde_json::{json, Value};
 /// server's conversation record id (None/empty on the first turn → the server
 /// creates one and returns it). The anchor `note_id` is always sent inside
 /// `scope` for grounding; `folder_id` rides only when the breadth is folder.
-/// Mirrors the desktop breadth clamp: a folder-less note under "folder" breadth
-/// falls back to "note".
+///
+/// The breadth is threaded through *verbatim* — no silent clamp (issue #58).
+/// It's validated through the shared `super::validate_breadth` (the single owner
+/// of the "Unrecognized chat scope" message), so an unknown value errors there;
+/// a "folder" breadth without a folder_id is a distinct error (the desktop's
+/// `heal_and_read_breadth` heals the folder-less case to "note" upstream, so
+/// that arm is a strict guard that shouldn't fire in practice). This is what
+/// lets breadth "all" reach the server as `scope.breadth == "all"` instead of
+/// degrading to the anchor note.
 pub fn build_cloud_request(
     remote_conversation_id: Option<&str>,
     workspace_id: &str,
@@ -26,20 +33,33 @@ pub fn build_cloud_request(
     breadth: &str,
     note_id: &str,
     folder_id: Option<&str>,
-) -> Value {
-    // Default to the safe single-Note breadth; widen only on an explicit,
-    // well-formed request. `note_id` stays in every scope so the server can
-    // ground on the anchor Note regardless of breadth.
-    let mut scope = json!({ "breadth": "note", "note_id": note_id });
-    match breadth {
-        "all" => scope = json!({ "breadth": "all", "note_id": note_id }),
-        "folder" => {
-            if let Some(f) = folder_id.filter(|f| !f.is_empty()) {
-                scope = json!({ "breadth": "folder", "note_id": note_id, "folder_id": f });
+) -> Result<Value, String> {
+    // Reject an unknown breadth through the shared validator — one owner of the
+    // vocabulary and its error, no duplicated match/message here.
+    super::validate_breadth(breadth)?;
+    // `note_id` stays in every scope so the server can ground on the anchor
+    // Note regardless of breadth (under "all" the server ignores it by design).
+    let scope = match breadth {
+        "note" => json!({ "breadth": "note", "note_id": note_id }),
+        "all" => json!({ "breadth": "all", "note_id": note_id }),
+        "folder" => match folder_id.filter(|f| !f.is_empty()) {
+            Some(f) => json!({ "breadth": "folder", "note_id": note_id, "folder_id": f }),
+            None => {
+                return Err(
+                    "\"Folder\" scope needs a folder, but this note isn't in one.".into()
+                )
             }
+        },
+        // Every value `validate_breadth` accepts is handled above. A value that
+        // passes validation but lands here means the vocabulary grew without
+        // this builder keeping up — fail loudly (a distinct message, not the
+        // validator's), never `unreachable!()` that could mask the gap.
+        other => {
+            return Err(format!(
+                "chat scope {other:?} is valid but not handled by the cloud request builder"
+            ))
         }
-        _ => {}
-    }
+    };
     let mut body = json!({
         "workspace_id": workspace_id,
         "message": message,
@@ -51,7 +71,7 @@ pub fn build_cloud_request(
     if let Some(t) = title.filter(|s| !s.is_empty()) {
         body["title"] = json!(t);
     }
-    body
+    Ok(body)
 }
 
 /// Parse one SSE event block into `(event name, data payload)`. Matches the
@@ -158,7 +178,7 @@ mod tests {
 
     #[test]
     fn request_defaults_to_note_breadth_with_grounding_anchor() {
-        let b = build_cloud_request(None, "ws1", "hi", None, "note", "n1", None);
+        let b = build_cloud_request(None, "ws1", "hi", None, "note", "n1", None).unwrap();
         assert_eq!(b["workspace_id"], "ws1");
         assert_eq!(b["message"], "hi");
         assert_eq!(b["scope"], json!({ "breadth": "note", "note_id": "n1" }));
@@ -168,27 +188,43 @@ mod tests {
 
     #[test]
     fn request_carries_remote_id_and_title_when_present() {
-        let b = build_cloud_request(Some("srv123"), "ws1", "hi", Some("Kickoff"), "note", "n1", None);
+        let b =
+            build_cloud_request(Some("srv123"), "ws1", "hi", Some("Kickoff"), "note", "n1", None)
+                .unwrap();
         assert_eq!(b["conversation_id"], "srv123");
         assert_eq!(b["title"], "Kickoff");
         // Empty strings are dropped, not sent.
-        let b2 = build_cloud_request(Some(""), "ws1", "hi", Some(""), "note", "n1", None);
+        let b2 = build_cloud_request(Some(""), "ws1", "hi", Some(""), "note", "n1", None).unwrap();
         assert!(b2.get("conversation_id").is_none());
         assert!(b2.get("title").is_none());
     }
 
     #[test]
-    fn request_folder_breadth_needs_a_folder_else_falls_back_to_note() {
-        let with = build_cloud_request(None, "ws1", "hi", None, "folder", "n1", Some("f1"));
+    fn request_folder_breadth_carries_the_folder_id() {
+        let with =
+            build_cloud_request(None, "ws1", "hi", None, "folder", "n1", Some("f1")).unwrap();
         assert_eq!(with["scope"], json!({ "breadth": "folder", "note_id": "n1", "folder_id": "f1" }));
-        // A folder-less note under folder breadth clamps to note (no folder to widen to).
-        let without = build_cloud_request(None, "ws1", "hi", None, "folder", "n1", None);
-        assert_eq!(without["scope"], json!({ "breadth": "note", "note_id": "n1" }));
+    }
+
+    #[test]
+    fn request_folder_breadth_without_a_folder_is_an_error_not_a_clamp() {
+        // Issue #58: no silent degradation. The desktop heals the folder-less
+        // case to "note" upstream, so this strict guard shouldn't fire — but if
+        // it's reached it errors loudly rather than quietly narrowing to note.
+        let err = build_cloud_request(None, "ws1", "hi", None, "folder", "n1", None).unwrap_err();
+        assert!(err.to_lowercase().contains("folder"), "names the missing folder: {err}");
+    }
+
+    #[test]
+    fn request_unrecognized_breadth_is_an_error() {
+        // Issue #58: the former `_ => {}` fall-through silently clamped to note.
+        let err = build_cloud_request(None, "ws1", "hi", None, "everything", "n1", None).unwrap_err();
+        assert!(err.contains("everything"), "the offending value is surfaced: {err}");
     }
 
     #[test]
     fn request_all_breadth_keeps_the_grounding_anchor() {
-        let b = build_cloud_request(None, "ws1", "hi", None, "all", "n1", None);
+        let b = build_cloud_request(None, "ws1", "hi", None, "all", "n1", None).unwrap();
         assert_eq!(b["scope"], json!({ "breadth": "all", "note_id": "n1" }));
     }
 

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -26,6 +26,23 @@ use crate::db;
 
 type Db = Arc<Mutex<Connection>>;
 
+/// The three valid retrieval breadths (issue #58) — the vocabulary shared by the
+/// conversation row, the Scope chip, and both request builders. Any other value
+/// is a bug (a stale DB row, a bad IPC arg, a future value an older client
+/// doesn't know) and must surface loudly, never silently clamp to note (the
+/// class of bug the issue is about). This is the single validation point: the
+/// write command (`chat_set_breadth`), the local scope resolver, and the cloud
+/// request builder (`cloud::build_cloud_request`) all funnel through it, so the
+/// "Unrecognized chat scope" message exists in exactly one place.
+pub fn validate_breadth(breadth: &str) -> Result<&str, String> {
+    match breadth {
+        "note" | "folder" | "all" => Ok(breadth),
+        other => Err(format!(
+            "Unrecognized chat scope {other:?} — expected \"note\", \"folder\" or \"all\"."
+        )),
+    }
+}
+
 // ── Typed message parts ─────────────────────────────────────────────────────
 // `messages.content` is a JSON array of these, ordered by the row's `seq`. Only
 // `Text` exists in this slice; `reasoning` / `tool` variants (see the wire
@@ -472,6 +489,19 @@ fn ctx_ref<'a>(ctx: &ChatCtx<'a>) -> ChatCtx<'a> {
 mod tests {
     use super::adapter::{ChatStep, ToolCall};
     use super::*;
+
+    #[test]
+    fn validate_breadth_accepts_the_vocabulary_and_rejects_garbage() {
+        for b in ["note", "folder", "all"] {
+            assert_eq!(validate_breadth(b).unwrap(), b);
+        }
+        // Issue #58: garbage is a loud error naming the offending value, never a
+        // silent clamp to note. This is the single owner of that error message.
+        for bad in ["", "everything", "Note", "all_notes", "workspace"] {
+            let err = validate_breadth(bad).unwrap_err();
+            assert!(err.contains(&format!("{bad:?}")), "surfaces the bad value: {err}");
+        }
+    }
 
     #[test]
     fn grounding_labels_blank_sections_and_frames_as_reference() {

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -162,18 +162,46 @@ pub fn chat_reindex_note(app: AppHandle, note_id: String) -> Result<(), String> 
     Ok(())
 }
 
-/// Resolve the retrieval breadth the user picked in the Scope popover into a
-/// server-enforced `ToolScope`. "folder" resolves to the anchor Note's folder;
-/// a folder-less Note falls back to Note breadth (there's no folder to widen
-/// to). Anything unrecognised is treated as the safe single-Note breadth.
-fn resolve_scope(breadth: &str, note: &db::Note) -> ToolScope {
-    match breadth {
-        "all" => ToolScope::All,
+/// Whether a Note currently sits in a (non-empty) folder.
+fn note_has_folder(note: &db::Note) -> bool {
+    note.folder_id.as_deref().is_some_and(|f| !f.is_empty())
+}
+
+/// Read the breadth a turn runs at, self-healing a stale value as a side effect
+/// (issue #58). The name says `heal_and_read` because this MUTATES: a stored
+/// "folder" breadth on a Note that no longer has a folder is reset to "note"
+/// (persisted here) so the stored value, the request scope, and the Scope chip
+/// never diverge. The folder-edge policy for this issue is auto-heal, not a
+/// request-time error, so removing a Note's folder never breaks chat behind the
+/// user's back. Errors loudly on an unrecognised stored value rather than
+/// clamping — a corrupt row is a bug, not a note-scope turn.
+fn heal_and_read_breadth(
+    conn: &rusqlite::Connection,
+    conversation_id: &str,
+    stored: &str,
+    note: &db::Note,
+) -> Result<String, String> {
+    let breadth = chat::validate_breadth(stored)?;
+    if breadth == "folder" && !note_has_folder(note) {
+        db::set_conversation_breadth(conn, conversation_id, "note").map_err(|e| e.to_string())?;
+        return Ok("note".into());
+    }
+    Ok(breadth.to_string())
+}
+
+/// Resolve an (already-effective) breadth into a server-enforced `ToolScope`.
+/// "folder" resolves to the anchor Note's folder. Unrecognised breadths and a
+/// folder breadth without a folder are loud errors (issue #58) rather than a
+/// silent clamp to Note — in practice `heal_and_read_breadth` heals the
+/// folder-less case upstream, so those arms are belt-and-suspenders.
+fn resolve_scope(breadth: &str, note: &db::Note) -> Result<ToolScope, String> {
+    match chat::validate_breadth(breadth)? {
+        "all" => Ok(ToolScope::All),
         "folder" => match note.folder_id.as_deref() {
-            Some(folder_id) if !folder_id.is_empty() => ToolScope::Folder(folder_id.to_string()),
-            _ => ToolScope::Note(note.id.clone()),
+            Some(folder_id) if !folder_id.is_empty() => Ok(ToolScope::Folder(folder_id.to_string())),
+            _ => Err("This note isn't in a folder, so \"Folder\" scope isn't available.".into()),
         },
-        _ => ToolScope::Note(note.id.clone()),
+        _ => Ok(ToolScope::Note(note.id.clone())),
     }
 }
 
@@ -309,14 +337,85 @@ pub struct ChatSendResult {
     truncated: bool,
 }
 
-/// The chat tenant a turn runs in (issue #50). `"personal"` (default) is the
-/// on-device, never-gated path; `"workspace"` delegates to the humla-cloud
-/// endpoint for the currently-selected workspace. The frontend only ever sends
-/// these two values — it can't name a *different* workspace — so the no-cross-
-/// tenant invariant (story 5/19) is enforced by always resolving "workspace" to
-/// the active workspace server-side.
-fn is_workspace_tenant(tenant: &Option<String>) -> bool {
-    tenant.as_deref() == Some("workspace")
+/// The loaded chat context (issue #58): Personal (on-device) or one specific
+/// workspace (Teams/cloud). This type is the SINGLE owner of the "active
+/// workspace, else Personal" rule — every chat command derives its context via
+/// `ChatContext::load` instead of re-checking `active_workspace` emptiness
+/// itself. There is no user-chosen tenant; it follows the sidebar workspace.
+enum ChatContext {
+    Personal,
+    Workspace(String),
+}
+
+impl ChatContext {
+    /// Derive the context from the active workspace setting — the one place the
+    /// rule lives.
+    fn load(conn: &rusqlite::Connection) -> Self {
+        let workspace = super::cloud::active_workspace(conn);
+        if workspace.is_empty() {
+            ChatContext::Personal
+        } else {
+            ChatContext::Workspace(workspace)
+        }
+    }
+
+    /// The `conversations.tenant` string for this context.
+    fn tenant(&self) -> &str {
+        match self {
+            ChatContext::Personal => CHAT_TENANT_PERSONAL,
+            ChatContext::Workspace(id) => id,
+        }
+    }
+
+    /// The workspace id when this is a workspace context, else None. Presence of
+    /// a workspace is what routes a turn to the cloud (Teams) path.
+    fn workspace(&self) -> Option<&str> {
+        match self {
+            ChatContext::Personal => None,
+            ChatContext::Workspace(id) => Some(id),
+        }
+    }
+}
+
+/// Persist the Scope chip's breadth on the current context's conversation
+/// (issue #58) — the single source of truth for retrieval breadth. Validates
+/// the value loudly (garbage → Err), then get-or-creates the conversation for
+/// the loaded context (Personal or the active workspace) and writes the column.
+#[tauri::command]
+pub fn chat_set_breadth(
+    app: AppHandle,
+    note_id: String,
+    breadth: String,
+) -> Result<(), String> {
+    chat::validate_breadth(&breadth)?;
+    let state: State<AppState> = app.state();
+    let conn = state.db.lock();
+    let ctx = ChatContext::load(&conn);
+    let conversation =
+        db::get_or_create_conversation(&conn, ctx.tenant(), CHAT_SCOPE_NOTE, &note_id)
+            .map_err(|e| e.to_string())?;
+    db::set_conversation_breadth(&conn, &conversation.id, &breadth).map_err(|e| e.to_string())
+}
+
+/// Read the persisted breadth for the current context's conversation so the
+/// Scope chip initialises from the backend in one round trip (issue #58).
+/// Returns the safe "note" default when no conversation exists yet. NOTE: this
+/// read may PERSIST a heal — a stale "folder" breadth (the Note's folder was
+/// since removed) is reset to "note" via `heal_and_read_breadth` so the chip
+/// shows the corrected value; the heal-on-read is intentional.
+#[tauri::command]
+pub fn chat_get_breadth(app: AppHandle, note_id: String) -> Result<String, String> {
+    let state: State<AppState> = app.state();
+    let conn = state.db.lock();
+    let ctx = ChatContext::load(&conn);
+    let Some(conversation) =
+        db::get_conversation(&conn, ctx.tenant(), CHAT_SCOPE_NOTE, &note_id)
+            .map_err(|e| e.to_string())?
+    else {
+        return Ok("note".into());
+    };
+    let note = db::get_note(&conn, &note_id).map_err(|e| e.to_string())?;
+    heal_and_read_breadth(&conn, &conversation.id, &conversation.breadth, &note)
 }
 
 #[tauri::command]
@@ -324,17 +423,19 @@ pub async fn chat_send(
     app: AppHandle,
     note_id: String,
     message: String,
-    scope: Option<String>,
-    tenant: Option<String>,
 ) -> Result<ChatSendResult, String> {
-    let breadth = scope.unwrap_or_else(|| "note".into());
-    // Workspace (Teams) chat delegates to the cloud endpoint (issue #50);
-    // Personal chat stays fully on-device below.
-    if is_workspace_tenant(&tenant) {
-        return chat_send_cloud(app, note_id, message, breadth).await;
+    let state: State<AppState> = app.state();
+    // Chat is pinned to the loaded context (issue #58): a loaded workspace →
+    // the Teams (cloud) path; Personal (no workspace) → the on-device path
+    // below. There is no user-chosen tenant — it follows the sidebar workspace.
+    let in_workspace = {
+        let conn = state.db.lock();
+        ChatContext::load(&conn).workspace().is_some()
+    };
+    if in_workspace {
+        return chat_send_cloud(app, note_id, message).await;
     }
 
-    let state: State<AppState> = app.state();
     // Keychain read out of band — not inside the DB lock. Chat reuses the
     // shared OpenAI key (issue #44).
     let openai_api_key = super::read_provider_api_key(&state, "openai")?;
@@ -342,10 +443,12 @@ pub async fn chat_send(
     let (grounding, resolved, conversation_id, tool_scope, workspace) = {
         let conn = state.db.lock();
         let note = db::get_note(&conn, &note_id).map_err(|e| e.to_string())?;
-        let workspace = super::cloud::active_workspace(&conn);
+        // We branched to the Personal path above (no active workspace), so the
+        // tenant is Personal and there's no workspace to scope tools to.
+        let workspace = String::new();
         let resolved = resolve_chat(&conn, openai_api_key).map_err(|e| e.to_string())?;
-        // Conversation is keyed by the anchor Note; breadth is a live filter
-        // within it, not a new conversation (issue #47).
+        // Conversation is keyed by the anchor Note; breadth is a persisted live
+        // filter within it, not a new conversation (issues #47/#58).
         let conversation =
             db::get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note_id)
                 .map_err(|e| e.to_string())?;
@@ -354,7 +457,11 @@ pub async fn chat_send(
         // if a content-settled checkpoint hasn't fired yet.
         let body_text = crate::html_text::html_to_text(&note.body);
         let _ = db::reindex_note(&conn, &note.id, &body_text, &note.transcript, &note.summary);
-        let tool_scope = resolve_scope(&breadth, &note);
+        // Breadth is read from the conversation row (single source of truth),
+        // self-healed against the Note's current folder.
+        let breadth =
+            heal_and_read_breadth(&conn, &conversation.id, &conversation.breadth, &note)?;
+        let tool_scope = resolve_scope(&breadth, &note)?;
         let grounding = chat::build_grounding(&body_text, &note.transcript, &note.summary);
         (grounding, resolved, conversation.id, tool_scope, workspace)
     };
@@ -460,20 +567,23 @@ async fn chat_send_cloud(
     app: AppHandle,
     note_id: String,
     message: String,
-    breadth: String,
 ) -> Result<ChatSendResult, String> {
     let state: State<AppState> = app.state();
-    let (workspace, folder_id, title, conversation) = {
+    let (workspace, folder_id, title, conversation, breadth) = {
         let conn = state.db.lock();
-        let workspace = super::cloud::active_workspace(&conn);
-        if workspace.is_empty() {
+        let ctx = ChatContext::load(&conn);
+        let Some(workspace) = ctx.workspace() else {
             return Err("No workspace selected — switch to a workspace to use Team chat.".into());
-        }
+        };
         let note = db::get_note(&conn, &note_id).map_err(|e| e.to_string())?;
         let conversation =
-            db::get_or_create_conversation(&conn, &workspace, CHAT_SCOPE_NOTE, &note_id)
+            db::get_or_create_conversation(&conn, workspace, CHAT_SCOPE_NOTE, &note_id)
                 .map_err(|e| e.to_string())?;
-        (workspace, note.folder_id.clone(), note.title.clone(), conversation)
+        // Breadth is read from the (workspace) conversation row and self-healed
+        // against the Note's folder, exactly like the Personal path (issue #58).
+        let breadth =
+            heal_and_read_breadth(&conn, &conversation.id, &conversation.breadth, &note)?;
+        (workspace.to_string(), note.folder_id.clone(), note.title.clone(), conversation, breadth)
     };
 
     let body = chat::cloud::build_cloud_request(
@@ -484,7 +594,7 @@ async fn chat_send_cloud(
         &breadth,
         &note_id,
         folder_id.as_deref(),
-    );
+    )?;
 
     // Stream the turn, retrying once after a 401 (a stale cached token → forget
     // it and re-authenticate from stored credentials, mirroring cloud.rs).
@@ -648,19 +758,20 @@ pub struct ChatMessageDto {
 pub async fn chat_history(
     app: AppHandle,
     note_id: String,
-    tenant: Option<String>,
 ) -> Result<Vec<ChatMessageDto>, String> {
     let state: State<AppState> = app.state();
-    if is_workspace_tenant(&tenant) {
+    // Chat follows the loaded context (issue #58): a loaded workspace reads its
+    // server-authoritative conversation; Personal reads the local table.
+    let ctx = {
+        let conn = state.db.lock();
+        ChatContext::load(&conn)
+    };
+    if let Some(workspace) = ctx.workspace() {
         // Resolve the workspace conversation's server id, then read its messages
         // through PocketBase (the source of truth for shared conversations).
         let remote_id = {
             let conn = state.db.lock();
-            let workspace = super::cloud::active_workspace(&conn);
-            if workspace.is_empty() {
-                return Ok(Vec::new());
-            }
-            db::get_conversation(&conn, &workspace, CHAT_SCOPE_NOTE, &note_id)
+            db::get_conversation(&conn, workspace, CHAT_SCOPE_NOTE, &note_id)
                 .map_err(|e| e.to_string())?
                 .and_then(|c| c.remote_id)
         };
@@ -709,6 +820,78 @@ fn map_remote_message(rec: &serde_json::Value) -> Option<ChatMessageDto> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Insert a Note with an explicit folder assignment, for scope tests.
+    fn note_in_folder(conn: &rusqlite::Connection, folder: Option<&str>) -> db::Note {
+        let note = db::create_note(conn, "en", "meeting", "").unwrap();
+        if let Some(f) = folder {
+            db::move_note(conn, &note.id, Some(f)).unwrap();
+        }
+        db::get_note(conn, &note.id).unwrap()
+    }
+
+    #[test]
+    fn resolve_scope_maps_valid_breadths_and_errors_on_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("scope.sqlite")).unwrap();
+        let folder = db::create_folder(&conn, "Team", "").unwrap();
+        let with_folder = note_in_folder(&conn, Some(&folder.id));
+        let no_folder = note_in_folder(&conn, None);
+
+        assert!(matches!(resolve_scope("all", &no_folder).unwrap(), ToolScope::All));
+        assert!(matches!(resolve_scope("note", &no_folder).unwrap(), ToolScope::Note(_)));
+        match resolve_scope("folder", &with_folder).unwrap() {
+            ToolScope::Folder(id) => assert_eq!(id, folder.id),
+            other => panic!("expected Folder scope, got {other:?}"),
+        }
+        // Unknown breadth is loud (issue #58) — the old `_ => Note` clamp is gone.
+        assert!(resolve_scope("everything", &no_folder).is_err());
+        // Folder breadth on a folder-less note errors rather than clamping.
+        assert!(resolve_scope("folder", &no_folder).is_err());
+    }
+
+    #[test]
+    fn heal_and_read_breadth_self_heals_a_stale_folder_breadth_to_note() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("heal.sqlite")).unwrap();
+        let note = note_in_folder(&conn, None); // no folder
+        let conv =
+            db::get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note.id)
+                .unwrap();
+        // Simulate a breadth stored while the note still had a folder, then lost it.
+        db::set_conversation_breadth(&conn, &conv.id, "folder").unwrap();
+
+        let effective = heal_and_read_breadth(&conn, &conv.id, "folder", &note).unwrap();
+        assert_eq!(effective, "note", "stale folder breadth heals to note");
+        // The heal is persisted, so the chip and the request never diverge.
+        let reloaded =
+            db::get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note.id)
+                .unwrap()
+                .unwrap();
+        assert_eq!(reloaded.breadth, "note");
+    }
+
+    #[test]
+    fn heal_and_read_breadth_keeps_a_valid_breadth_and_errors_on_garbage() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("eff.sqlite")).unwrap();
+        let folder = db::create_folder(&conn, "Team", "").unwrap();
+        let note = note_in_folder(&conn, Some(&folder.id));
+        let conv =
+            db::get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note.id)
+                .unwrap();
+        assert_eq!(
+            heal_and_read_breadth(&conn, &conv.id, "folder", &note).unwrap(),
+            "folder",
+            "folder breadth survives when the folder is present"
+        );
+        assert_eq!(
+            heal_and_read_breadth(&conn, &conv.id, "all", &note).unwrap(),
+            "all"
+        );
+        // A corrupt stored value errors, never silently clamps to note.
+        assert!(heal_and_read_breadth(&conn, &conv.id, "bogus", &note).is_err());
+    }
 
     #[test]
     fn embedding_models_are_recognised() {
@@ -775,7 +958,8 @@ mod tests {
             "all",
             "roundtrip-anchor",
             None,
-        );
+        )
+        .expect("all-breadth request builds");
         let resp = client
             .post(format!("{}/api/chat", chat.trim_end_matches('/')))
             .bearer_auth(token)

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -283,6 +283,16 @@ pub fn open(path: &Path) -> Result<Connection> {
     // conversations never set it. Its messages live server-side (read-through),
     // never in the local `messages` table.
     let _ = conn.execute("ALTER TABLE conversations ADD COLUMN remote_id TEXT", []);
+    // Persisted retrieval breadth per conversation (issue #58). The Scope chip
+    // ("This note" / "Folder: X" / "All notes") used to be component-local UI
+    // state that silently reset on note-change, tenant switch and panel remount;
+    // storing it on the conversation makes the backend the single source of
+    // truth so the chosen breadth survives turns, tab switches and restarts.
+    // NOT NULL DEFAULT 'note' back-fills existing rows with the safe breadth.
+    let _ = conn.execute(
+        "ALTER TABLE conversations ADD COLUMN breadth TEXT NOT NULL DEFAULT 'note'",
+        [],
+    );
     // Index is created AFTER the ALTERs so it's safe on both fresh DBs and
     // older DBs that needed the column added.
     conn.execute(
@@ -914,6 +924,10 @@ pub struct Conversation {
     /// (issue #50); NULL for Personal conversations and until the first
     /// workspace turn creates the server record.
     pub remote_id: Option<String>,
+    /// Persisted retrieval breadth (issue #58): "note" | "folder" | "all". The
+    /// single source of truth for the Scope chip; a live filter on retrieval
+    /// within the conversation, not a conversation-identity dimension.
+    pub breadth: String,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -938,12 +952,14 @@ fn map_conversation(row: &rusqlite::Row) -> rusqlite::Result<Conversation> {
         scope_id: row.get(2)?,
         tenant: row.get(3)?,
         remote_id: row.get(4)?,
-        created_at: row.get(5)?,
-        updated_at: row.get(6)?,
+        breadth: row.get(5)?,
+        created_at: row.get(6)?,
+        updated_at: row.get(7)?,
     })
 }
 
-const CONVERSATION_COLS: &str = "id, scope, scope_id, tenant, remote_id, created_at, updated_at";
+const CONVERSATION_COLS: &str =
+    "id, scope, scope_id, tenant, remote_id, breadth, created_at, updated_at";
 
 /// The existing conversation for a scope, or None. Used to reload history
 /// without creating an empty conversation just for opening the Chat tab.
@@ -994,6 +1010,17 @@ pub fn set_conversation_remote_id(conn: &Connection, id: &str, remote_id: &str) 
     conn.execute(
         "UPDATE conversations SET remote_id = ?1 WHERE id = ?2",
         params![remote_id, id],
+    )?;
+    Ok(())
+}
+
+/// Persist a conversation's retrieval breadth (issue #58). The command layer
+/// validates the value against the {note, folder, all} vocabulary before
+/// calling this, so db.rs stays agnostic and just stores the string.
+pub fn set_conversation_breadth(conn: &Connection, id: &str, breadth: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE conversations SET breadth = ?1 WHERE id = ?2",
+        params![breadth, id],
     )?;
     Ok(())
 }
@@ -1849,6 +1876,38 @@ mod tests {
         // The personal conversation is untouched by the workspace one's remote id.
         let personal_reload = get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1").unwrap().unwrap();
         assert!(personal_reload.remote_id.is_none());
+    }
+
+    /// A conversation defaults to "note" breadth and the stored value survives a
+    /// reload (issue #58). Re-running `open()` on the same file is idempotent —
+    /// the breadth ALTER is a no-op the second time and the persisted value is
+    /// intact (proving the column back-fills without clobbering existing rows).
+    #[test]
+    fn conversation_breadth_defaults_and_persists_idempotently() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("breadth.sqlite");
+        let conv_id = {
+            let conn = open(&path).unwrap();
+            let conv =
+                get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1")
+                    .unwrap();
+            assert_eq!(conv.breadth, "note", "new conversations default to note breadth");
+            set_conversation_breadth(&conn, &conv.id, "all").unwrap();
+            let reloaded =
+                get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1")
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(reloaded.breadth, "all", "the stored breadth round-trips");
+            conv.id
+        };
+        // Re-open the same DB file: migrations must be idempotent and the stored
+        // breadth must not be reset by the (repeated) ALTER TABLE.
+        let conn = open(&path).unwrap();
+        let reloaded = get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(reloaded.id, conv_id);
+        assert_eq!(reloaded.breadth, "all", "breadth survives a re-open (idempotent migration)");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -353,6 +353,8 @@ where
             commands::summarize_note,
             commands::chat_send,
             commands::chat_history,
+            commands::chat_set_breadth,
+            commands::chat_get_breadth,
             commands::chat_reindex_note,
             commands::permissions_status,
             commands::permissions_request,

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -143,49 +143,62 @@ describe("ChatPanel retrieval UI (#47)", () => {
   });
 });
 
-describe("ChatPanel Teams tenant (#50)", () => {
-  it("hides the tenant row when signed out of the cloud", async () => {
+describe("ChatPanel context pinning (#58)", () => {
+  it("renders no tenant picker — chat is pinned to the loaded context", async () => {
     mockTauri({ provider_key_get: () => "sk-test", chat_history: () => [] });
+    signIntoWorkspace("Acme Team");
     renderPanel();
     await screen.findByPlaceholderText(/Ask about your notes/);
-    // Personal is implicit — no tenant selector is shown at all.
+    // The old Personal/Workspace selector is gone entirely.
     expect(screen.queryByRole("button", { name: "Chat tenant" })).toBeNull();
   });
 
-  it("offers Personal + the active workspace once signed in", async () => {
+  it("shows the workspace name as a non-interactive context indicator", async () => {
     mockTauri({ provider_key_get: () => "sk-test", chat_history: () => [] });
     signIntoWorkspace("Acme Team");
     renderPanel();
-    const trigger = await screen.findByRole("button", { name: "Chat tenant" });
-    // Closed, the trigger shows the current tenant (Personal).
-    expect(trigger).toHaveTextContent("Personal");
-    fireEvent.click(trigger);
-    // Open, it offers the workspace you're in — the only one it can (no cross-tenant).
-    await waitFor(() => expect(screen.getByText("Acme Team")).toBeInTheDocument());
-    expect(screen.getAllByText("Personal").length).toBeGreaterThanOrEqual(1);
+    // The indicator shows where chat goes; it is not a button (no popover).
+    const indicator = await screen.findByLabelText("Chat context");
+    expect(indicator).toHaveTextContent("Acme Team");
+    expect(indicator.tagName).not.toBe("BUTTON");
   });
 
-  it("sends with the workspace tenant after switching to it", async () => {
-    let sentTenant: string | undefined;
+  it("shows Personal as the context indicator when signed out", async () => {
+    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => [] });
+    renderPanel();
+    const indicator = await screen.findByLabelText("Chat context");
+    expect(indicator).toHaveTextContent("Personal");
+  });
+});
+
+describe("ChatPanel scope breadth (#58)", () => {
+  it("initialises the scope chip from the persisted breadth", async () => {
     mockTauri({
       provider_key_get: () => "sk-test",
       chat_history: () => [],
-      chat_send: (args) => {
-        sentTenant = (args as { tenant?: string }).tenant;
-        return { conversationId: "c1", truncated: false };
+      chat_get_breadth: () => "all",
+    });
+    renderPanel();
+    // The chip reflects the backend's persisted breadth, not the "note" default.
+    const trigger = await screen.findByRole("button", { name: "Chat scope" });
+    await waitFor(() => expect(trigger).toHaveTextContent("All notes"));
+  });
+
+  it("persists a breadth change via chatSetBreadth", async () => {
+    let setArgs: { noteId?: string; breadth?: string } | undefined;
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => [],
+      chat_get_breadth: () => "note",
+      chat_set_breadth: (args) => {
+        setArgs = args as { noteId?: string; breadth?: string };
+        return undefined;
       },
     });
-    signIntoWorkspace("Acme Team");
     renderPanel();
-
-    // Switch the tenant to the workspace.
-    fireEvent.click(await screen.findByRole("button", { name: "Chat tenant" }));
-    fireEvent.click(await screen.findByText("Acme Team"));
-
-    const input = await screen.findByPlaceholderText(/Ask about your notes/);
-    fireEvent.change(input, { target: { value: "what did the team decide?" } });
-    fireEvent.click(screen.getByRole("button", { name: "Send" }));
-
-    await waitFor(() => expect(sentTenant).toBe("workspace"));
+    fireEvent.click(await screen.findByRole("button", { name: "Chat scope" }));
+    fireEvent.click(await screen.findByText("All notes"));
+    await waitFor(() => expect(setArgs?.breadth).toBe("all"));
+    expect(setArgs?.noteId).toBe("n1");
   });
 });

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -13,7 +13,6 @@ import {
   type ChatCitation,
   type ChatMessageDto,
   type ChatScope,
-  type ChatTenant,
 } from "../lib/ipc";
 import { useNotesStore } from "../lib/store";
 import { useCloudStore } from "../lib/cloud";
@@ -80,8 +79,9 @@ export function ChatPanel({ noteId }: { noteId: string }) {
   const [liveCitations, setLiveCitations] = useState<ChatCitation[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [truncated, setTruncated] = useState(false);
+  // Scope chip breadth. Display state only — the backend conversation row is the
+  // source of truth (issue #58); this mirrors it and is (re)initialised from it.
   const [scope, setScope] = useState<ChatScope>("note");
-  const [tenant, setTenant] = useState<ChatTenant>("personal");
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const sendingRef = useRef(false);
 
@@ -92,16 +92,23 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     return fid ? s.folders.find((f) => f.id === fid) ?? null : null;
   });
 
-  // Team (workspace) chat is offered only when signed into a cloud workspace
-  // (issue #50). The tenant row can never name a *different* workspace than the
-  // active one — so a conversation can't cross tenants (story 5/19).
+  // Chat is pinned to the loaded context (issue #58). The chat follows the
+  // active workspace (Personal when none) — there's no tenant picker; the
+  // sidebar WorkspaceSwitcher is the only way to change where chat goes. We read
+  // the current workspace id to re-key the load effect (a switch reloads the
+  // other context's conversation) and the name for the context indicator.
   const workspaceName = useCloudStore((s) =>
     s.status.logged_in ? s.status.current_workspace?.name ?? null : null,
   );
+  const workspaceId = useCloudStore((s) =>
+    s.status.logged_in ? s.status.current_workspace?.id ?? null : null,
+  );
 
-  // Load persisted history on mount / note change, and clear transient state.
-  // On unmount / note change, rebuild the note's retrieval index so edits made
-  // in this session are searchable next time (content-settled checkpoint).
+  // Load persisted history + breadth on mount, note change, and workspace
+  // switch, clearing transient state. Keying on the workspace id makes a context
+  // switch reload the right conversation — this replaces the old per-tenant
+  // reset that lived in `changeTenant`. On unmount / change, rebuild the note's
+  // retrieval index so edits made this session are searchable next time.
   useEffect(() => {
     let cancelled = false;
     setInput("");
@@ -111,48 +118,36 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     setError(null);
     setTruncated(false);
     setSending(false);
-    setScope("note");
-    setTenant("personal");
     sendingRef.current = false;
     ipc
-      .chatHistory(noteId, "personal")
+      .chatHistory(noteId)
       .then((h) => {
         if (!cancelled) setMessages(h);
       })
       .catch(() => {
         if (!cancelled) setMessages([]);
       });
+    // Initialise the chip from the backend's persisted breadth in one round
+    // trip; fall back to "note" if it can't be read.
+    ipc
+      .chatGetBreadth(noteId)
+      .then((b) => {
+        if (!cancelled && b) setScope(b);
+      })
+      .catch(() => {
+        if (!cancelled) setScope("note");
+      });
     return () => {
       cancelled = true;
       void ipc.chatReindexNote(noteId).catch(() => {});
     };
-  }, [noteId]);
+  }, [noteId, workspaceId]);
 
-  // If the workspace goes away (sign-out / switch) while a Team conversation is
-  // open, fall back to Personal so we never send to a stale tenant.
-  useEffect(() => {
-    if (tenant === "workspace" && !workspaceName) changeTenant("personal");
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaceName]);
-
-  // Switching tenant starts a fresh conversation in that tenant (issue #50):
-  // reset transient state and read-through that tenant's history.
-  function changeTenant(next: ChatTenant) {
-    if (next === tenant) return;
-    setTenant(next);
-    setStreaming("");
-    setActivity(null);
-    setLiveCitations([]);
-    setError(null);
-    setTruncated(false);
-    setInput("");
-    setScope("note");
-    setSending(false);
-    sendingRef.current = false;
-    ipc
-      .chatHistory(noteId, next)
-      .then(setMessages)
-      .catch(() => setMessages([]));
+  // Persist a breadth change to the conversation (issue #58): update the chip
+  // optimistically, then write it through so the next turn reads the new value.
+  function selectBreadth(next: ChatScope) {
+    setScope(next);
+    void ipc.chatSetBreadth(noteId, next).catch((e) => setError(String(e)));
   }
 
   // Stream subscription. Bound once; cancelled-flag + claim keeps it StrictMode-
@@ -215,13 +210,13 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     };
     setMessages((m) => [...m, optimistic]);
     try {
-      const result = await ipc.chatSend(noteId, text, scope, tenant);
-      setMessages(await ipc.chatHistory(noteId, tenant));
+      const result = await ipc.chatSend(noteId, text);
+      setMessages(await ipc.chatHistory(noteId));
       setTruncated(result.truncated);
     } catch (e) {
       setError((prev) => prev ?? String(e));
       try {
-        setMessages(await ipc.chatHistory(noteId, tenant));
+        setMessages(await ipc.chatHistory(noteId));
       } catch {
         /* keep the optimistic view */
       }
@@ -277,10 +272,8 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     <div className="flex-1 min-h-0 flex flex-col">
       <ScopeBar
         scope={scope}
-        onScope={setScope}
+        onScope={selectBreadth}
         folderName={folder?.name ?? null}
-        tenant={tenant}
-        onTenant={changeTenant}
         workspaceName={workspaceName}
       />
 
@@ -352,23 +345,21 @@ export function ChatPanel({ noteId }: { noteId: string }) {
   );
 }
 
-// Tenant + breadth selectors at the top of the chat. The tenant row (Personal /
-// the active workspace) only appears when signed into a workspace (issue #50);
+// Context indicator + breadth selector at the top of the chat. The chat is
+// pinned to the loaded context (issue #58): a non-interactive indicator shows
+// where chat goes (the active workspace name, or "Personal") — there is no
+// tenant picker, since the sidebar WorkspaceSwitcher is the source of truth.
 // "This folder" only appears when the note has a folder (nothing to widen to
 // otherwise).
 function ScopeBar({
   scope,
   onScope,
   folderName,
-  tenant,
-  onTenant,
   workspaceName,
 }: {
   scope: ChatScope;
   onScope: (s: ChatScope) => void;
   folderName: string | null;
-  tenant: ChatTenant;
-  onTenant: (t: ChatTenant) => void;
   workspaceName: string | null;
 }) {
   const items: PopoverItem[] = [
@@ -380,32 +371,20 @@ function ScopeBar({
   const activeId = scope === "folder" && !folderName ? "note" : scope;
   const label = items.find((i) => i.id === activeId)?.label ?? "This note";
 
-  const tenantItems: PopoverItem[] = [
-    { id: "personal", label: "Personal" },
-    ...(workspaceName ? [{ id: "workspace", label: workspaceName }] : []),
-  ];
-  const activeTenant = tenant === "workspace" && !workspaceName ? "personal" : tenant;
-  const tenantLabel =
-    tenantItems.find((i) => i.id === activeTenant)?.label ?? "Personal";
-
   return (
     <div className="shrink-0 flex items-center gap-2 px-4 py-2 border-b border-[var(--color-line)]">
-      {workspaceName && (
-        <>
-          <SelectablePopover
-            ariaLabel="Chat tenant"
-            items={tenantItems}
-            activeId={activeTenant}
-            onSelect={(id) => onTenant((id as ChatTenant) ?? "personal")}
-            trigger={
-              <span className="nd-chip inline-flex items-center gap-1 text-xs cursor-pointer">
-                {tenantLabel}
-              </span>
-            }
-          />
-          <span className="text-xs text-[var(--color-text-disabled)]">·</span>
-        </>
-      )}
+      <span
+        aria-label="Chat context"
+        title={
+          workspaceName
+            ? `Chatting in ${workspaceName} — follows the workspace loaded in the sidebar`
+            : "Chatting in Personal (on-device)"
+        }
+        className="nd-chip inline-flex items-center gap-1 text-xs"
+      >
+        {workspaceName ?? "Personal"}
+      </span>
+      <span className="text-xs text-[var(--color-text-disabled)]">·</span>
       <span className="text-xs text-[var(--color-text-disabled)]">Search</span>
       <SelectablePopover
         ariaLabel="Chat scope"

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -388,18 +388,21 @@ export const ipc = {
   // streamed completion — the answer arrives via chat_* events, so the
   // resolved promise only carries the conversation id + a truncation flag.
   // `chatHistory` reloads a Note's persisted conversation after restart.
-  // `scope` is the Scope-popover breadth ("note" | "folder" | "all"), a live
-  // filter on retrieval within the same conversation (issue #47). `tenant`
-  // (issue #50) selects Personal (on-device) vs the active Workspace (Teams,
-  // delegated to the cloud endpoint); switching it is a different conversation.
-  chatSend: (
-    noteId: string,
-    message: string,
-    scope: ChatScope = "note",
-    tenant: ChatTenant = "personal",
-  ) => invoke<ChatSendResult>("chat_send", { noteId, message, scope, tenant }),
-  chatHistory: (noteId: string, tenant: ChatTenant = "personal") =>
-    invoke<ChatMessageDto[]>("chat_history", { noteId, tenant }),
+  //
+  // Chat is pinned to the loaded context (issue #58): the backend derives the
+  // tenant from the active workspace (Personal when none), so neither call
+  // takes a tenant. Retrieval breadth ("note" | "folder" | "all") is persisted
+  // on the conversation server-side — `chatSetBreadth` writes it, `chatGetBreadth`
+  // reads it back to initialise the Scope chip. `chatSend` no longer carries a
+  // scope: it reads the persisted breadth, so the UI can never diverge from it.
+  chatSend: (noteId: string, message: string) =>
+    invoke<ChatSendResult>("chat_send", { noteId, message }),
+  chatHistory: (noteId: string) => invoke<ChatMessageDto[]>("chat_history", { noteId }),
+  // Persist / read the Scope chip's breadth on the current context's
+  // conversation (issue #58). The single source of truth for retrieval breadth.
+  chatSetBreadth: (noteId: string, breadth: ChatScope) =>
+    invoke<void>("chat_set_breadth", { noteId, breadth }),
+  chatGetBreadth: (noteId: string) => invoke<ChatScope>("chat_get_breadth", { noteId }),
   // Rebuild a Note's retrieval index — called on Note-view unmount so edits
   // that didn't trigger summarize/diarize still land in search.
   chatReindexNote: (noteId: string) => invoke<void>("chat_reindex_note", { noteId }),
@@ -444,12 +447,9 @@ export type ChatMessageDto = {
   createdAt: number;
 };
 export type ChatSendResult = { conversationId: string; truncated: boolean };
-// Retrieval breadth chosen in the Scope popover (issue #47).
+// Retrieval breadth chosen in the Scope popover (issue #47), persisted per
+// conversation on the backend (issue #58).
 export type ChatScope = "note" | "folder" | "all";
-// Chat tenant chosen in the Scope popover (issue #50). "personal" runs on-device
-// and is never gated; "workspace" delegates to the cloud endpoint for the
-// currently-selected workspace (the only workspace it can ever reach).
-export type ChatTenant = "personal" | "workspace";
 
 // Streaming events (the #46 wire contract + #47 tool/citation events).
 export type ChatTextDeltaEvent = {

--- a/src/test/tauri.ts
+++ b/src/test/tauri.ts
@@ -34,6 +34,8 @@ export function mockTauri(handlers: Record<string, Handler> = {}) {
         return [];
       case "recording_state":
         return "idle";
+      case "chat_get_breadth":
+        return "note";
       case "permissions_status":
         return { microphone: "granted", screen: "granted" };
       case "cloud_status":


### PR DESCRIPTION
Addresses #58 (both bugs + the locked design decision from the charting session; leaving the issue open for the live Visitech re-probe).

## What changed

- **Breadth persists per conversation** — new `breadth` column on `conversations` (idempotent migration). The backend owns the value: `chat_set_breadth` / `chat_get_breadth` commands, and `chat_send` reads the stored breadth instead of a per-call param. The scope chip initializes from the DB on mount, note change, and workspace switch — the selection survives turns, tab switches, and app restarts. The old component-state resets are structurally gone.
- **Unrecognized breadth errors loudly** — a single `validate_breadth` in `chat/mod.rs` owns the vocabulary, shared by the write command, local `resolve_scope`, and cloud `build_cloud_request`; no path silently clamps to note scope anymore. A stale "folder" breadth on a folderless note self-heals to "note" and persists (`heal_and_read_breadth`), with hard errors as backstop in both request builders.
- **Chat pinned to the loaded context** — the Personal/Workspace picker is removed; a `ChatContext` enum (`Personal` / `Workspace(id)`) is the single derivation point for "active workspace, else Personal" across all chat commands. A non-interactive indicator in the scope bar shows where the chat goes. Existing conversation rows stay valid; no data migration.

## Verification

- 302 Rust tests, 188 frontend tests, `tsc -b` clean.
- New coverage: breadth validation + persistence (db), scope mapping + loud-error paths (local and cloud builders), folder self-heal, chip-initializes-from-DB, breadth-change persistence, no-tenant-picker + context indicator (ChatPanel).
- Two-axis review: Spec clean (all acceptance criteria traced end-to-end); Standards findings fixed (shared breadth vocabulary, honest naming for the healing read, unified context derivation).

Outstanding after merge: re-run the live "All notes" Visitech probe against sync.humla.team to confirm multi-note synthesis end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)