### PR TITLE
feat(chat): sessions data model — multiple conversations per note (#61)

### DIFF
--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -90,6 +90,42 @@ pub fn parse_parts(content: &str) -> Vec<Part> {
     serde_json::from_str(content).unwrap_or_default()
 }
 
+/// Flatten a stored `messages.content` (parts JSON) to its plain text. The
+/// conversation-title backfill uses this to read a message's text without
+/// db.rs needing to know the parts shape.
+pub fn parts_plain_text(content: &str) -> String {
+    parts_to_text(&parse_parts(content))
+}
+
+/// Longest conversation title we keep (chars, not bytes). Long enough to be a
+/// recognisable label, short enough for a session list row.
+pub const TITLE_MAX_CHARS: usize = 40;
+
+/// Derive a conversation title (issue #61). Given the first user message's text
+/// (if any) and the conversation's `created_at` for the empty-conversation
+/// fallback: collapse all whitespace/newline runs to single spaces, trim, and
+/// truncate to `TITLE_MAX_CHARS` on a Rust `char` boundary — appending "…" when
+/// truncated (so Norwegian text and emoji never panic or split mid-codepoint).
+/// A conversation with no user message (or blank text) falls back to
+/// "Chat YYYY-MM-DD" from `created_at` (UTC, for a deterministic label).
+pub fn derive_title(first_user_text: Option<&str>, created_at_ms: i64) -> String {
+    if let Some(text) = first_user_text {
+        let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        if !collapsed.is_empty() {
+            return if collapsed.chars().count() > TITLE_MAX_CHARS {
+                let kept: String = collapsed.chars().take(TITLE_MAX_CHARS).collect();
+                format!("{kept}…")
+            } else {
+                collapsed
+            };
+        }
+    }
+    let date = chrono::DateTime::from_timestamp_millis(created_at_ms)
+        .map(|d| d.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    format!("Chat {date}")
+}
+
 /// Flatten a parts array to plain text (concatenate text parts; tool parts are
 /// not replayed to the model as history — only the final answer text is). Used
 /// to feed prior turns back into the prompt.
@@ -491,6 +527,45 @@ mod tests {
     use super::*;
 
     #[test]
+    fn derive_title_collapses_whitespace_and_trims() {
+        assert_eq!(derive_title(Some("  hello   world \n foo "), 0), "hello world foo");
+        assert_eq!(derive_title(Some("single"), 0), "single");
+    }
+
+    #[test]
+    fn derive_title_truncates_on_a_char_boundary_with_an_ellipsis() {
+        let forty = "a".repeat(TITLE_MAX_CHARS);
+        assert_eq!(derive_title(Some(&forty), 0), forty, "exactly 40 chars is kept verbatim");
+        let forty_one = "a".repeat(TITLE_MAX_CHARS + 1);
+        assert_eq!(derive_title(Some(&forty_one), 0), format!("{}…", "a".repeat(TITLE_MAX_CHARS)));
+    }
+
+    #[test]
+    fn derive_title_never_splits_multibyte_chars() {
+        // Norwegian + emoji: truncation must land on a char boundary, never panic.
+        let emoji = "😀".repeat(50);
+        let t = derive_title(Some(&emoji), 0);
+        assert_eq!(t.chars().count(), TITLE_MAX_CHARS + 1, "40 emoji + the ellipsis");
+        let nordic = "æ ø å ".repeat(20);
+        let t = derive_title(Some(&nordic), 0);
+        assert!(t.chars().count() <= TITLE_MAX_CHARS + 1);
+    }
+
+    #[test]
+    fn derive_title_falls_back_to_a_date_for_empty_conversations() {
+        assert_eq!(derive_title(None, 0), "Chat 1970-01-01");
+        assert_eq!(derive_title(Some("   \n\t  "), 0), "Chat 1970-01-01", "blank text is no title");
+    }
+
+    #[test]
+    fn parts_plain_text_reads_a_stored_message_body() {
+        let json = text_parts_json("b0", "the meeting body");
+        assert_eq!(parts_plain_text(&json), "the meeting body");
+        // A legacy/garbage row yields empty text rather than erroring.
+        assert_eq!(parts_plain_text("not json"), "");
+    }
+
+    #[test]
     fn validate_breadth_accepts_the_vocabulary_and_rejects_garbage() {
         for b in ["note", "folder", "all"] {
             assert_eq!(validate_breadth(b).unwrap(), b);
@@ -604,7 +679,7 @@ mod tests {
 
     fn conv(dbh: &Db, scope_id: &str) -> String {
         let conn = dbh.lock();
-        db::get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, scope_id)
+        db::create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, scope_id, "note")
             .unwrap()
             .id
     }
@@ -660,7 +735,7 @@ mod tests {
         }
         let path = dir.path().join("notes.sqlite");
         let conn = db::open(&path).unwrap();
-        let reloaded = db::get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1")
+        let reloaded = db::latest_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1")
             .unwrap()
             .expect("conversation survives restart");
         assert_eq!(reloaded.id, conv_id);
@@ -670,15 +745,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn one_conversation_per_note() {
+    async fn latest_conversation_tracks_the_most_recently_updated_session() {
+        // Sessions (issue #61): a Note can have several conversations; the active
+        // one resolved by `latest_conversation` is whichever was updated last, and
+        // a message append is what bumps `updated_at`.
         let dir = tempfile::tempdir().unwrap();
         let (dbh, _path) = temp_db(&dir);
         let conn = dbh.lock();
         let a =
-            db::get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1").unwrap();
+            db::create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1", "note").unwrap();
         let b =
-            db::get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1").unwrap();
-        assert_eq!(a.id, b.id, "same Note reuses its single conversation");
+            db::create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1", "note").unwrap();
+        assert_ne!(a.id, b.id, "each call creates a distinct session");
+        // Sleep so the append lands on a strictly-later millisecond than either
+        // creation (timestamps are ms-resolution), keeping the assertion stable.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        db::insert_chat_message(&conn, &a.id, "user", &text_parts_json("blk", "hi")).unwrap();
+        let bumped = db::get_conversation_by_id(&conn, &a.id).unwrap().unwrap();
+        assert!(bumped.updated_at > a.updated_at, "a message append bumps updated_at");
+        let latest =
+            db::latest_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1").unwrap().unwrap();
+        assert_eq!(latest.id, a.id, "the just-updated session is the active one");
+        assert_eq!(
+            db::list_conversations(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1").unwrap().len(),
+            2
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -377,14 +377,200 @@ impl ChatContext {
     }
 }
 
-/// Persist the Scope chip's breadth on the current context's conversation
-/// (issue #58) — the single source of truth for retrieval breadth. Validates
-/// the value loudly (garbage → Err), then get-or-creates the conversation for
-/// the loaded context (Personal or the active workspace) and writes the column.
+// ── Chat sessions (issue #61) ───────────────────────────────────────────────
+// Multiple conversations ("sessions") per Note. The active session is the most-
+// recently-updated one; an explicit command creates a fresh one. There is no
+// deletion command — a deliberate v1 decision.
+
+/// One row in the session list. `id` is always the LOCAL conversation id (for a
+/// workspace session that's the handle row, its `remote_id` mapping to the
+/// server record), so `chat_history` / `chat_send` / breadth all key on the
+/// same id across tenants. `title` is resolved (stored title, else a date
+/// fallback) so a not-yet-titled session still shows something.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationMeta {
+    id: String,
+    title: String,
+    breadth: String,
+    updated_at: i64,
+    message_count: i64,
+}
+
+/// `chat_history` result (issue #61): the messages plus the conversation they
+/// were resolved to, so the panel learns which session it's on. `conversation_id`
+/// is None when the Note has no session yet (opening the tab creates nothing).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatHistoryResult {
+    conversation_id: Option<String>,
+    messages: Vec<ChatMessageDto>,
+}
+
+/// A conversation's display title: its stored title, else a derived date label
+/// (an untitled session — e.g. one just created — still reads sensibly).
+fn resolved_title(c: &db::Conversation) -> String {
+    match c.title.as_deref() {
+        Some(t) if !t.trim().is_empty() => t.to_string(),
+        _ => chat::derive_title(None, c.created_at),
+    }
+}
+
+/// Whether a conversation has no stored title yet — the first user message
+/// should set it (issue #61).
+fn resolved_title_is_unset(c: &db::Conversation) -> bool {
+    c.title.as_deref().map_or(true, |t| t.trim().is_empty())
+}
+
+/// Build a session-list entry for a local (personal or workspace-handle) row.
+fn conversation_meta(
+    conn: &rusqlite::Connection,
+    c: &db::Conversation,
+) -> Result<ConversationMeta, String> {
+    let message_count =
+        db::conversation_message_count(conn, &c.id).map_err(|e| e.to_string())?;
+    Ok(ConversationMeta {
+        id: c.id.clone(),
+        title: resolved_title(c),
+        breadth: c.breadth.clone(),
+        updated_at: c.updated_at,
+        message_count,
+    })
+}
+
+/// The breadth a new session inherits (issue #61): the Note's most-recent
+/// session's breadth, or "note" for the Note's first-ever session.
+fn inherited_breadth(conn: &rusqlite::Connection, tenant: &str, note_id: &str) -> String {
+    db::latest_conversation(conn, tenant, CHAT_SCOPE_NOTE, note_id)
+        .ok()
+        .flatten()
+        .map(|c| c.breadth)
+        .unwrap_or_else(|| "note".to_string())
+}
+
+/// Resolve the session a command targets WITHOUT creating one (None when the
+/// Note has no session yet). `explicit` targets a specific session; otherwise
+/// the most-recently-updated one is the active session.
+///
+/// An explicit id is validated to belong to the expected (tenant, note) scope —
+/// a mismatched id is a clean error, never a silent cross-scope operation (which
+/// would, e.g., heal breadth against the wrong Note). A not-found explicit id is
+/// treated as "no session" (None) so the caller falls back to the active one.
+fn resolve_existing(
+    conn: &rusqlite::Connection,
+    tenant: &str,
+    note_id: &str,
+    explicit: Option<&str>,
+) -> Result<Option<db::Conversation>, String> {
+    if let Some(id) = explicit {
+        let Some(c) = db::get_conversation_by_id(conn, id).map_err(|e| e.to_string())? else {
+            return Ok(None);
+        };
+        if c.tenant != tenant || c.scope != CHAT_SCOPE_NOTE || c.scope_id != note_id {
+            return Err("That chat session doesn't belong to this note.".into());
+        }
+        return Ok(Some(c));
+    }
+    db::latest_conversation(conn, tenant, CHAT_SCOPE_NOTE, note_id).map_err(|e| e.to_string())
+}
+
+/// Resolve the active session, lazily creating the Note's FIRST session when
+/// none exists (breadth defaults to "note"). Used by send + set-breadth so the
+/// first turn / first breadth write materialises the session on demand.
+fn resolve_or_create(
+    conn: &rusqlite::Connection,
+    tenant: &str,
+    note_id: &str,
+    explicit: Option<&str>,
+) -> Result<db::Conversation, String> {
+    if let Some(c) = resolve_existing(conn, tenant, note_id, explicit)? {
+        return Ok(c);
+    }
+    let breadth = inherited_breadth(conn, tenant, note_id);
+    db::create_conversation(conn, tenant, CHAT_SCOPE_NOTE, note_id, &breadth)
+        .map_err(|e| e.to_string())
+}
+
+/// Resolve the "new session" for a Note in the personal scope (issue #61),
+/// honoring the no-op guard: if the most-recent session has no messages, reuse
+/// it instead of piling up empty sessions; otherwise create a fresh one that
+/// inherits breadth from the most-recent session.
+fn new_personal_conversation(
+    conn: &rusqlite::Connection,
+    note_id: &str,
+) -> Result<db::Conversation, String> {
+    if let Some(latest) =
+        db::latest_conversation(conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, note_id)
+            .map_err(|e| e.to_string())?
+    {
+        if db::conversation_message_count(conn, &latest.id).map_err(|e| e.to_string())? == 0 {
+            return Ok(latest);
+        }
+    }
+    let breadth = inherited_breadth(conn, CHAT_TENANT_PERSONAL, note_id);
+    db::create_conversation(conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, note_id, &breadth)
+        .map_err(|e| e.to_string())
+}
+
+/// List a Note's chat sessions, most-recently-updated first (issue #61).
+/// Personal reads local SQLite; a workspace reads the server-authoritative list
+/// (see [`list_conversations_cloud`]). Opening/listing creates nothing.
+#[tauri::command]
+pub async fn chat_list_conversations(
+    app: AppHandle,
+    note_id: String,
+) -> Result<Vec<ConversationMeta>, String> {
+    let state: State<AppState> = app.state();
+    let ctx = {
+        let conn = state.db.lock();
+        ChatContext::load(&conn)
+    };
+    match ctx.workspace() {
+        None => {
+            let conn = state.db.lock();
+            let convs =
+                db::list_conversations(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note_id)
+                    .map_err(|e| e.to_string())?;
+            convs.iter().map(|c| conversation_meta(&conn, c)).collect()
+        }
+        Some(ws) => list_conversations_cloud(&state, ws, &note_id).await,
+    }
+}
+
+/// Create a fresh chat session for a Note (issue #61). Personal creates a local
+/// row (with the no-op guard reusing an empty most-recent session); a workspace
+/// delegates to the server (see [`new_conversation_cloud`]).
+#[tauri::command]
+pub async fn chat_new_conversation(
+    app: AppHandle,
+    note_id: String,
+) -> Result<ConversationMeta, String> {
+    let state: State<AppState> = app.state();
+    let ctx = {
+        let conn = state.db.lock();
+        ChatContext::load(&conn)
+    };
+    match ctx.workspace() {
+        None => {
+            let conn = state.db.lock();
+            let conv = new_personal_conversation(&conn, &note_id)?;
+            conversation_meta(&conn, &conv)
+        }
+        Some(ws) => new_conversation_cloud(&state, ws, &note_id).await,
+    }
+}
+
+/// Persist the Scope chip's breadth on a conversation (issue #58) — the single
+/// source of truth for retrieval breadth. Validates the value loudly (garbage →
+/// Err), resolves the target session (`conversation_id` when the panel has one,
+/// else the active/most-recent session, lazily creating the Note's first
+/// session so a breadth chosen before the first turn survives — issue #61), and
+/// writes the column.
 #[tauri::command]
 pub fn chat_set_breadth(
     app: AppHandle,
     note_id: String,
+    conversation_id: Option<String>,
     breadth: String,
 ) -> Result<(), String> {
     chat::validate_breadth(&breadth)?;
@@ -392,26 +578,34 @@ pub fn chat_set_breadth(
     let conn = state.db.lock();
     let ctx = ChatContext::load(&conn);
     let conversation =
-        db::get_or_create_conversation(&conn, ctx.tenant(), CHAT_SCOPE_NOTE, &note_id)
-            .map_err(|e| e.to_string())?;
+        resolve_or_create(&conn, ctx.tenant(), &note_id, conversation_id.as_deref())?;
     db::set_conversation_breadth(&conn, &conversation.id, &breadth).map_err(|e| e.to_string())
 }
 
-/// Read the persisted breadth for the current context's conversation so the
-/// Scope chip initialises from the backend in one round trip (issue #58).
-/// Returns the safe "note" default when no conversation exists yet. NOTE: this
-/// read may PERSIST a heal — a stale "folder" breadth (the Note's folder was
-/// since removed) is reset to "note" via `heal_and_read_breadth` so the chip
-/// shows the corrected value; the heal-on-read is intentional.
+/// Read the persisted breadth for a conversation so the Scope chip initialises
+/// from the backend in one round trip (issue #58). Resolves `conversation_id`
+/// when the panel has one, else the active/most-recent session; when the Note
+/// has no session yet it returns the would-be-inherited default (issue #61) so
+/// the chip shows something sane WITHOUT creating a row. NOTE: this read may
+/// PERSIST a heal — a stale "folder" breadth (the Note's folder was since
+/// removed) is reset to "note" via `heal_and_read_breadth`; the heal-on-read is
+/// intentional.
 #[tauri::command]
-pub fn chat_get_breadth(app: AppHandle, note_id: String) -> Result<String, String> {
+pub fn chat_get_breadth(
+    app: AppHandle,
+    note_id: String,
+    conversation_id: Option<String>,
+) -> Result<String, String> {
     let state: State<AppState> = app.state();
     let conn = state.db.lock();
     let ctx = ChatContext::load(&conn);
     let Some(conversation) =
-        db::get_conversation(&conn, ctx.tenant(), CHAT_SCOPE_NOTE, &note_id)
-            .map_err(|e| e.to_string())?
+        resolve_existing(&conn, ctx.tenant(), &note_id, conversation_id.as_deref())?
     else {
+        // No session yet → the Note's first conversation defaults to "note",
+        // which is also what `inherited_breadth` returns here (its
+        // `latest_conversation` read would be redundant — `resolve_existing`
+        // just established there's no session).
         return Ok("note".into());
     };
     let note = db::get_note(&conn, &note_id).map_err(|e| e.to_string())?;
@@ -422,6 +616,7 @@ pub fn chat_get_breadth(app: AppHandle, note_id: String) -> Result<String, Strin
 pub async fn chat_send(
     app: AppHandle,
     note_id: String,
+    conversation_id: Option<String>,
     message: String,
 ) -> Result<ChatSendResult, String> {
     let state: State<AppState> = app.state();
@@ -433,7 +628,7 @@ pub async fn chat_send(
         ChatContext::load(&conn).workspace().is_some()
     };
     if in_workspace {
-        return chat_send_cloud(app, note_id, message).await;
+        return chat_send_cloud(app, note_id, conversation_id, message).await;
     }
 
     // Keychain read out of band — not inside the DB lock. Chat reuses the
@@ -447,11 +642,17 @@ pub async fn chat_send(
         // tenant is Personal and there's no workspace to scope tools to.
         let workspace = String::new();
         let resolved = resolve_chat(&conn, openai_api_key).map_err(|e| e.to_string())?;
-        // Conversation is keyed by the anchor Note; breadth is a persisted live
-        // filter within it, not a new conversation (issues #47/#58).
+        // Resolve the target session (issue #61): an explicit id, else the
+        // active/most-recent one, lazily creating the Note's first session on
+        // the first send. Breadth is a persisted live filter within it.
         let conversation =
-            db::get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note_id)
-                .map_err(|e| e.to_string())?;
+            resolve_or_create(&conn, CHAT_TENANT_PERSONAL, &note_id, conversation_id.as_deref())?;
+        // Set the personal session's title once, from its first user message
+        // (issue #61). Guarded on an empty title so later turns never rewrite it.
+        if resolved_title_is_unset(&conversation) {
+            let title = chat::derive_title(Some(&message), conversation.created_at);
+            let _ = db::set_conversation_title(&conn, &conversation.id, &title);
+        }
         // Keep the anchor Note searchable — reindex it now so "this Note" and
         // any broader search always find the note the user is looking at, even
         // if a content-settled checkpoint hasn't fired yet.
@@ -566,6 +767,7 @@ struct CloudTurn {
 async fn chat_send_cloud(
     app: AppHandle,
     note_id: String,
+    conversation_id: Option<String>,
     message: String,
 ) -> Result<ChatSendResult, String> {
     let state: State<AppState> = app.state();
@@ -576,9 +778,10 @@ async fn chat_send_cloud(
             return Err("No workspace selected — switch to a workspace to use Team chat.".into());
         };
         let note = db::get_note(&conn, &note_id).map_err(|e| e.to_string())?;
-        let conversation =
-            db::get_or_create_conversation(&conn, workspace, CHAT_SCOPE_NOTE, &note_id)
-                .map_err(|e| e.to_string())?;
+        // Resolve the target workspace-handle session (issue #61): an explicit
+        // id, else the active/most-recent handle, lazily creating one (remote_id
+        // filled from the server's response below) on the first turn.
+        let conversation = resolve_or_create(&conn, workspace, &note_id, conversation_id.as_deref())?;
         // Breadth is read from the (workspace) conversation row and self-healed
         // against the Note's folder, exactly like the Personal path (issue #58).
         let breadth =
@@ -750,15 +953,20 @@ pub struct ChatMessageDto {
     created_at: i64,
 }
 
-/// Reload a Note's conversation (empty if none exists yet). Drives history
-/// restore when the Chat tab opens or after an app restart. For a workspace
-/// tenant (issue #50) this is a read-through of the server-authoritative
-/// conversation — messages live in the cloud, not the local `messages` table.
+/// Reload a Note's conversation and report which session it resolved to (issue
+/// #61). `conversation_id` targets a specific session; None resolves the
+/// active/most-recent one (this is what keeps the single-thread panel working).
+/// When the Note has no session yet, returns empty messages + `conversationId:
+/// None` WITHOUT creating a row — merely opening the Chat tab must persist
+/// nothing. For a workspace tenant (issue #50) the messages are a read-through
+/// of the server-authoritative conversation (via the handle's `remote_id`);
+/// they never live in the local `messages` table.
 #[tauri::command]
 pub async fn chat_history(
     app: AppHandle,
     note_id: String,
-) -> Result<Vec<ChatMessageDto>, String> {
+    conversation_id: Option<String>,
+) -> Result<ChatHistoryResult, String> {
     let state: State<AppState> = app.state();
     // Chat follows the loaded context (issue #58): a loaded workspace reads its
     // server-authoritative conversation; Personal reads the local table.
@@ -766,29 +974,36 @@ pub async fn chat_history(
         let conn = state.db.lock();
         ChatContext::load(&conn)
     };
+
     if let Some(workspace) = ctx.workspace() {
-        // Resolve the workspace conversation's server id, then read its messages
-        // through PocketBase (the source of truth for shared conversations).
-        let remote_id = {
+        // Resolve the target workspace handle (explicit id, else most-recent),
+        // then read its messages through PocketBase (source of truth for shared
+        // conversations). No handle → nothing persisted yet, so empty + None.
+        let handle = {
             let conn = state.db.lock();
-            db::get_conversation(&conn, workspace, CHAT_SCOPE_NOTE, &note_id)
-                .map_err(|e| e.to_string())?
-                .and_then(|c| c.remote_id)
+            resolve_existing(&conn, workspace, &note_id, conversation_id.as_deref())?
         };
-        let Some(remote_id) = remote_id else { return Ok(Vec::new()) };
-        let records = super::cloud::fetch_chat_messages(&state, &remote_id).await?;
-        return Ok(records.iter().filter_map(map_remote_message).collect());
+        let Some(handle) = handle else {
+            return Ok(ChatHistoryResult { conversation_id: None, messages: Vec::new() });
+        };
+        let messages = match handle.remote_id.as_deref() {
+            Some(remote_id) => {
+                let records = super::cloud::fetch_chat_messages(&state, remote_id).await?;
+                records.iter().filter_map(map_remote_message).collect()
+            }
+            None => Vec::new(),
+        };
+        return Ok(ChatHistoryResult { conversation_id: Some(handle.id), messages });
     }
 
     let conn = state.db.lock();
     let Some(conversation) =
-        db::get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note_id)
-            .map_err(|e| e.to_string())?
+        resolve_existing(&conn, CHAT_TENANT_PERSONAL, &note_id, conversation_id.as_deref())?
     else {
-        return Ok(Vec::new());
+        return Ok(ChatHistoryResult { conversation_id: None, messages: Vec::new() });
     };
     let messages = db::list_chat_messages(&conn, &conversation.id).map_err(|e| e.to_string())?;
-    Ok(messages
+    let messages = messages
         .into_iter()
         .map(|m| ChatMessageDto {
             id: m.id,
@@ -797,7 +1012,8 @@ pub async fn chat_history(
             parts: serde_json::to_value(chat::parse_parts(&m.content)).unwrap_or_default(),
             created_at: m.created_at,
         })
-        .collect())
+        .collect();
+    Ok(ChatHistoryResult { conversation_id: Some(conversation.id), messages })
 }
 
 /// Map one PocketBase `chat_messages` record (read-through) to the UI DTO. Its
@@ -815,6 +1031,314 @@ fn map_remote_message(rec: &serde_json::Value) -> Option<ChatMessageDto> {
         .map(|d| d.timestamp_millis())
         .unwrap_or(0);
     Some(ChatMessageDto { id, role, seq, parts, created_at })
+}
+
+// ── Workspace (Teams) session list/create — humla-cloud#19 contract ──────────
+//
+// Workspace conversations are server-authoritative (issue #50); the desktop
+// keeps a local handle row per server conversation, whose `remote_id` maps to
+// the server record. The two routes below are PocketBase HOOKS under `/api/humla`
+// (NOT the chat service `/api/chat*`, which the prod Caddyfile routes to a
+// separate service that has no such route). PocketBase bearer token, JSON
+// bodies. Timestamps are PocketBase-native `created` / `updated`, parsed the
+// same way as the `chat_messages` read-through (`map_remote_message`).
+//
+//   GET /api/humla/chat/conversations?workspace_id=<ws>&note_id=<note>
+//     Authorization: Bearer <pb_token>
+//     → 200 { "conversations": [ {
+//           "id":            <server conversation record id>,
+//           "title":         <string, may be empty>,
+//           "breadth":       "note" | "folder" | "all",
+//           "created":       <PB datetime>,
+//           "updated":       <PB datetime>,
+//           "message_count": <int>,
+//           "created_by":    <pb user id>
+//         }, … ] }          // ordered most-recently-updated first (-updated)
+//     Membership is enforced by the token; a non-member → 403 { reason:"not_a_member", error }.
+//
+//   POST /api/humla/chat/conversations
+//     Authorization: Bearer <pb_token>
+//     Content-Type: application/json
+//     { "workspace_id": <ws>, "note_id": <note>, "breadth": "note"|"folder"|"all" }
+//     → 200 <conversation>          // FLAT object, same shape as a GET list item;
+//                                   // there is NO { "conversation": … } wrapper.
+//     The server is a DUMB creator: it creates unconditionally and honors the
+//     POST `breadth`. The no-op guard is therefore CLIENT-side (see
+//     `new_conversation_cloud`): list first, and if the most-recent session has
+//     zero messages, reuse it instead of POSTing. Errors mirror `/api/chat`'s
+//     preflight shape { reason, error }.
+//
+// Legacy merge (pre-#19): conversations that predate #19 have NO server-side note
+// association, so the per-note GET omits them until one "adopting turn" — the
+// persist route stamps `note` one-way from the send scope's note_id, only when
+// currently empty. The client therefore UNIONS the server list with local handle
+// rows for (tenant=workspace, scope_id=note) whose `remote_id` is absent from the
+// server response (dedup by remote_id — `unlisted_legacy_handles`), using the
+// local row's breadth/updated_at (title may be empty this slice). Resolving the
+// most-recent session needs no extra work: those legacy threads already exist as
+// local handle rows, so `latest_conversation` surfaces them — a legacy-only note
+// still resolves its thread, `chat_history` reads it through by `remote_id`, and
+// the first send continues it (after which the server adopts it into the list).
+//
+// Identity: metas returned to the frontend use the LOCAL handle id (reconciled by
+// `remote_id`), so history/send/breadth all key on the same id across tenants.
+//
+// 404 fallback: a self-hosted server without these routes degrades to the legacy
+// single-conversation read-through (`legacy_workspace_sessions`).
+
+/// Get-or-create the LOCAL handle row for a server conversation (issue #61),
+/// matched by `remote_id`. A new handle adopts the server's breadth; an existing
+/// one is returned untouched. Keeps server conversations from being duplicated
+/// locally as the session list reconciles them.
+fn ensure_workspace_handle(
+    conn: &rusqlite::Connection,
+    workspace: &str,
+    note_id: &str,
+    remote_id: &str,
+    breadth: &str,
+) -> Result<db::Conversation, String> {
+    if let Some(c) = db::get_conversation_by_remote_id(conn, workspace, remote_id)
+        .map_err(|e| e.to_string())?
+    {
+        return Ok(c);
+    }
+    let breadth = chat::validate_breadth(breadth).unwrap_or("note");
+    let handle = db::create_conversation(conn, workspace, CHAT_SCOPE_NOTE, note_id, breadth)
+        .map_err(|e| e.to_string())?;
+    db::set_conversation_remote_id(conn, &handle.id, remote_id).map_err(|e| e.to_string())?;
+    Ok(handle)
+}
+
+/// Parse a PocketBase timestamp to epoch-ms (0 on failure). Matches the
+/// `chat_messages` read-through's handling (`map_remote_message`) so all
+/// server-sourced dates use one parser.
+fn pb_timestamp_ms(v: Option<&serde_json::Value>) -> i64 {
+    v.and_then(|x| x.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.timestamp_millis())
+        .unwrap_or(0)
+}
+
+/// Map one server conversation JSON to a session-list entry, reconciling it to
+/// its local handle so the returned `id` is local. Handles both the GET list
+/// items and the FLAT POST-create response (same shape).
+fn cloud_conversation_meta(
+    state: &State<AppState>,
+    workspace: &str,
+    note_id: &str,
+    item: &serde_json::Value,
+) -> Result<ConversationMeta, String> {
+    let remote_id = item
+        .get("id")
+        .and_then(|v| v.as_str())
+        .ok_or("Team chat returned a conversation without an id")?;
+    let breadth = item.get("breadth").and_then(|v| v.as_str()).unwrap_or("note");
+    let handle = {
+        let conn = state.db.lock();
+        ensure_workspace_handle(&conn, workspace, note_id, remote_id, breadth)?
+    };
+    Ok(ConversationMeta {
+        id: handle.id,
+        title: item.get("title").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+        breadth: breadth.to_string(),
+        updated_at: pb_timestamp_ms(item.get("updated")),
+        message_count: item.get("message_count").and_then(|v| v.as_i64()).unwrap_or(0),
+    })
+}
+
+/// Local workspace handles the server GET omitted — the legacy-merge core (issue
+/// #61). A handle is "unlisted" when it has a `remote_id` (so it maps to a real
+/// server conversation) that is NOT among the server's returned ids. Pure so the
+/// union/dedup logic is unit-testable without HTTP.
+fn unlisted_legacy_handles<'a>(
+    server_remote_ids: &std::collections::HashSet<String>,
+    local_handles: &'a [db::Conversation],
+) -> Vec<&'a db::Conversation> {
+    local_handles
+        .iter()
+        .filter(|h| {
+            h.remote_id
+                .as_deref()
+                .is_some_and(|rid| !server_remote_ids.contains(rid))
+        })
+        .collect()
+}
+
+/// List a workspace Note's sessions from humla-cloud (issue #61). GETs the server
+/// list (one-shot 401 re-auth, 404 → legacy fallback), reconciles each to a local
+/// handle, then UNIONS in local handles the server omitted (pre-#19 threads not
+/// yet adopted — their message count is read through). Most-recently-updated
+/// first.
+async fn list_conversations_cloud(
+    state: &State<'_, AppState>,
+    workspace: &str,
+    note_id: &str,
+) -> Result<Vec<ConversationMeta>, String> {
+    let mut attempt = 0u8;
+    let val = loop {
+        let (base, token) = super::cloud::cloud_session(state).await?;
+        let resp = reqwest::Client::new()
+            .get(format!("{}/api/humla/chat/conversations", base.trim_end_matches('/')))
+            .bearer_auth(&token)
+            .query(&[("workspace_id", workspace), ("note_id", note_id)])
+            .send()
+            .await
+            .map_err(|e| format!("Couldn't reach Team chat: {e}"))?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return legacy_workspace_sessions(state, workspace, note_id).await;
+        }
+        if status == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
+            super::cloud::forget_session();
+            attempt += 1;
+            continue;
+        }
+        if !status.is_success() {
+            let body: serde_json::Value = resp.json().await.unwrap_or_default();
+            let reason = body.get("reason").and_then(|r| r.as_str()).unwrap_or_default();
+            let server_msg = body.get("error").and_then(|m| m.as_str()).unwrap_or_default();
+            return Err(chat::cloud::cloud_chat_error_message(reason, server_msg));
+        }
+        break resp.json::<serde_json::Value>().await.unwrap_or_default();
+    };
+
+    let items = val.get("conversations").and_then(|c| c.as_array()).cloned().unwrap_or_default();
+    let mut metas: Vec<ConversationMeta> = Vec::with_capacity(items.len());
+    let mut server_remote_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for item in &items {
+        if let Some(rid) = item.get("id").and_then(|v| v.as_str()) {
+            server_remote_ids.insert(rid.to_string());
+        }
+        metas.push(cloud_conversation_meta(state, workspace, note_id, item)?);
+    }
+
+    // Union: local handles the server GET omitted (pre-#19, not yet adopted).
+    // Snapshot the fields we need up front so no borrow / db lock crosses the
+    // read-through `.await`.
+    let legacy: Vec<(String, String, String, i64, String)> = {
+        let conn = state.db.lock();
+        let local_handles =
+            db::list_conversations(&conn, workspace, CHAT_SCOPE_NOTE, note_id).map_err(|e| e.to_string())?;
+        unlisted_legacy_handles(&server_remote_ids, &local_handles)
+            .into_iter()
+            .map(|h| {
+                (
+                    h.id.clone(),
+                    h.remote_id.clone().unwrap_or_default(),
+                    h.breadth.clone(),
+                    h.updated_at,
+                    resolved_title(h),
+                )
+            })
+            .collect()
+    };
+    for (id, remote_id, breadth, updated_at, title) in legacy {
+        // A legacy handle has a remote_id, so it has server messages; read the
+        // real count so the no-op guard never reuses a non-empty legacy thread.
+        let message_count = super::cloud::fetch_chat_messages(state, &remote_id)
+            .await
+            .map(|r| r.len() as i64)
+            .unwrap_or(0);
+        metas.push(ConversationMeta { id, title, breadth, updated_at, message_count });
+    }
+
+    // Server list is already -updated; re-sort so merged legacy entries land in
+    // the right place (id break-ties deterministically).
+    metas.sort_by(|a, b| b.updated_at.cmp(&a.updated_at).then_with(|| b.id.cmp(&a.id)));
+    Ok(metas)
+}
+
+/// The pre-#19 fallback: the note's single workspace handle (if it exists) as a
+/// one-element session list, its message count read through from the server.
+async fn legacy_workspace_sessions(
+    state: &State<'_, AppState>,
+    workspace: &str,
+    note_id: &str,
+) -> Result<Vec<ConversationMeta>, String> {
+    let handle = {
+        let conn = state.db.lock();
+        db::latest_conversation(&conn, workspace, CHAT_SCOPE_NOTE, note_id)
+            .map_err(|e| e.to_string())?
+    };
+    let Some(handle) = handle else { return Ok(Vec::new()) };
+    let message_count = match handle.remote_id.as_deref() {
+        Some(remote_id) => {
+            super::cloud::fetch_chat_messages(state, remote_id).await.map(|r| r.len() as i64).unwrap_or(0)
+        }
+        None => 0,
+    };
+    Ok(vec![ConversationMeta {
+        title: resolved_title(&handle),
+        id: handle.id,
+        breadth: handle.breadth,
+        updated_at: handle.updated_at,
+        message_count,
+    }])
+}
+
+/// Create a workspace session via humla-cloud (issue #61). The server is a dumb
+/// creator, so the no-op guard is CLIENT-side: list first (server ∪ legacy) and,
+/// if the most-recent session is empty, reuse it instead of POSTing. Otherwise
+/// POST — inheriting breadth from the Note's most-recent workspace session, which
+/// the server honors — and reconcile the FLAT response to a local handle. A 404
+/// (route absent on an older server) is a clean error: a server-authoritative
+/// conversation can't be created without the server.
+async fn new_conversation_cloud(
+    state: &State<'_, AppState>,
+    workspace: &str,
+    note_id: &str,
+) -> Result<ConversationMeta, String> {
+    // Client-side no-op guard: reuse the empty most-recent session if there is
+    // one (the list already unions server + legacy and is most-recent-first).
+    let existing = list_conversations_cloud(state, workspace, note_id).await?;
+    if let Some(most_recent) = existing.into_iter().next() {
+        if most_recent.message_count == 0 {
+            return Ok(most_recent);
+        }
+    }
+
+    // Inherit breadth from the Note's most-recent session in THIS workspace,
+    // just like the personal path ("note" only when there's no prior session).
+    let breadth = {
+        let conn = state.db.lock();
+        inherited_breadth(&conn, workspace, note_id)
+    };
+    let body = serde_json::json!({
+        "workspace_id": workspace,
+        "note_id": note_id,
+        "breadth": breadth,
+    });
+    let mut attempt = 0u8;
+    let val = loop {
+        let (base, token) = super::cloud::cloud_session(state).await?;
+        let resp = reqwest::Client::new()
+            .post(format!("{}/api/humla/chat/conversations", base.trim_end_matches('/')))
+            .bearer_auth(&token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("Couldn't reach Team chat: {e}"))?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err("Starting a new Team chat needs a newer server — this workspace's server \
+                        doesn't support multiple chat sessions yet."
+                .into());
+        }
+        if status == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
+            super::cloud::forget_session();
+            attempt += 1;
+            continue;
+        }
+        if !status.is_success() {
+            let b: serde_json::Value = resp.json().await.unwrap_or_default();
+            let reason = b.get("reason").and_then(|r| r.as_str()).unwrap_or_default();
+            let server_msg = b.get("error").and_then(|m| m.as_str()).unwrap_or_default();
+            return Err(chat::cloud::cloud_chat_error_message(reason, server_msg));
+        }
+        // The POST response is the conversation object itself — no wrapper.
+        break resp.json::<serde_json::Value>().await.unwrap_or_default();
+    };
+    cloud_conversation_meta(state, workspace, note_id, &val)
 }
 
 #[cfg(test)]
@@ -856,7 +1380,7 @@ mod tests {
         let conn = db::open(&dir.path().join("heal.sqlite")).unwrap();
         let note = note_in_folder(&conn, None); // no folder
         let conv =
-            db::get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note.id)
+            db::create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note.id, "note")
                 .unwrap();
         // Simulate a breadth stored while the note still had a folder, then lost it.
         db::set_conversation_breadth(&conn, &conv.id, "folder").unwrap();
@@ -865,7 +1389,7 @@ mod tests {
         assert_eq!(effective, "note", "stale folder breadth heals to note");
         // The heal is persisted, so the chip and the request never diverge.
         let reloaded =
-            db::get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note.id)
+            db::latest_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note.id)
                 .unwrap()
                 .unwrap();
         assert_eq!(reloaded.breadth, "note");
@@ -878,7 +1402,7 @@ mod tests {
         let folder = db::create_folder(&conn, "Team", "").unwrap();
         let note = note_in_folder(&conn, Some(&folder.id));
         let conv =
-            db::get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note.id)
+            db::create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note.id, "note")
                 .unwrap();
         assert_eq!(
             heal_and_read_breadth(&conn, &conv.id, "folder", &note).unwrap(),
@@ -913,6 +1437,126 @@ mod tests {
         assert!(res.is_err());
         let err = res.err().unwrap().to_string();
         assert!(err.contains("embedding model"), "clear guidance, not a raw 400: {err}");
+    }
+
+    /// A user turn (for tests that need a session to have messages).
+    fn add_user_message(conn: &rusqlite::Connection, conversation_id: &str, text: &str) {
+        db::insert_chat_message(conn, conversation_id, "user", &chat::text_parts_json("b", text))
+            .unwrap();
+    }
+
+    #[test]
+    fn first_session_defaults_breadth_to_note() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("first.sqlite")).unwrap();
+        // A Note with no sessions → the first new session defaults to "note".
+        let conv = new_personal_conversation(&conn, "n1").unwrap();
+        assert_eq!(conv.breadth, "note");
+        assert_eq!(db::conversation_message_count(&conn, &conv.id).unwrap(), 0);
+    }
+
+    #[test]
+    fn new_session_inherits_breadth_from_the_most_recent() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("inherit.sqlite")).unwrap();
+        let first =
+            db::create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "n1", "note")
+                .unwrap();
+        db::set_conversation_breadth(&conn, &first.id, "all").unwrap();
+        // The most-recent session has messages, so the guard doesn't reuse it.
+        add_user_message(&conn, &first.id, "hi");
+
+        let second = new_personal_conversation(&conn, "n1").unwrap();
+        assert_ne!(second.id, first.id, "a genuinely new session was created");
+        assert_eq!(second.breadth, "all", "breadth is inherited from the most recent session");
+    }
+
+    #[test]
+    fn new_chat_no_ops_when_the_most_recent_session_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("noop.sqlite")).unwrap();
+        let first =
+            db::create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "n1", "note")
+                .unwrap();
+        // No messages on the most-recent session → "new chat" returns it as-is.
+        let again = new_personal_conversation(&conn, "n1").unwrap();
+        assert_eq!(again.id, first.id, "an empty most-recent session is reused, not duplicated");
+        assert_eq!(
+            db::list_conversations(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "n1").unwrap().len(),
+            1,
+            "no empty duplicate session was created"
+        );
+    }
+
+    #[test]
+    fn inherited_breadth_resolves_per_tenant_for_a_workspace() {
+        // The workspace create path inherits breadth the same way as personal,
+        // scoped to the workspace tenant (issue #61 fix 2). "note" only when the
+        // Note has no prior session in that tenant.
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("wsbreadth.sqlite")).unwrap();
+        assert_eq!(inherited_breadth(&conn, "wsA", "n1"), "note", "first-ever session defaults to note");
+        let conv =
+            db::create_conversation(&conn, "wsA", CHAT_SCOPE_NOTE, "n1", "note").unwrap();
+        db::set_conversation_breadth(&conn, &conv.id, "all").unwrap();
+        assert_eq!(inherited_breadth(&conn, "wsA", "n1"), "all", "inherits the workspace session's breadth");
+        // A different tenant's breadth doesn't leak across.
+        assert_eq!(inherited_breadth(&conn, CHAT_TENANT_PERSONAL, "n1"), "note");
+    }
+
+    #[test]
+    fn resolve_existing_rejects_a_cross_scope_conversation_id() {
+        // An explicit id from another Note/tenant must be a clean error, never a
+        // silent cross-scope operation (issue #61 fix 3).
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("xscope.sqlite")).unwrap();
+        let n1 = db::create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "n1", "note").unwrap();
+
+        // Matching (tenant, note) resolves.
+        let ok = resolve_existing(&conn, CHAT_TENANT_PERSONAL, "n1", Some(&n1.id)).unwrap();
+        assert_eq!(ok.unwrap().id, n1.id);
+        // Wrong note → error.
+        assert!(resolve_existing(&conn, CHAT_TENANT_PERSONAL, "n2", Some(&n1.id)).is_err());
+        // Wrong tenant → error.
+        assert!(resolve_existing(&conn, "wsA", "n1", Some(&n1.id)).is_err());
+        // An unknown id is not an error — falls back to the active session (None).
+        assert!(resolve_existing(&conn, CHAT_TENANT_PERSONAL, "n1", Some("missing")).unwrap().is_none());
+    }
+
+    #[test]
+    fn unlisted_legacy_handles_unions_only_the_server_omitted_remote_ids() {
+        // Legacy-merge core (issue #61 fix 5): surface local handles whose
+        // remote_id the server GET omitted, deduped by remote_id; skip handles
+        // already in the server list and handles with no remote_id (never sent).
+        fn handle(id: &str, remote: Option<&str>) -> db::Conversation {
+            db::Conversation {
+                id: id.to_string(),
+                scope: CHAT_SCOPE_NOTE.to_string(),
+                scope_id: "n1".to_string(),
+                tenant: "wsA".to_string(),
+                remote_id: remote.map(String::from),
+                breadth: "note".to_string(),
+                title: None,
+                created_at: 0,
+                updated_at: 0,
+            }
+        }
+        let local = vec![
+            handle("h_srv", Some("srv1")),  // already in server list → skip
+            handle("h_legacy", Some("srv2")), // server omitted → surface
+            handle("h_unsent", None),        // never sent (no remote_id) → skip
+        ];
+        let server_ids: std::collections::HashSet<String> = ["srv1".to_string()].into_iter().collect();
+        let unlisted = unlisted_legacy_handles(&server_ids, &local);
+        assert_eq!(unlisted.len(), 1, "only the server-omitted, remote-id'd handle");
+        assert_eq!(unlisted[0].id, "h_legacy");
+
+        // Empty server list → every remote-id'd handle is legacy; the unsent one
+        // is still skipped.
+        let none: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let unlisted = unlisted_legacy_handles(&none, &local);
+        let ids: Vec<&str> = unlisted.iter().map(|h| h.id.as_str()).collect();
+        assert_eq!(ids, vec!["h_srv", "h_legacy"]);
     }
 
     /// Cross-repo round-trip of a real workspace `chat_send` against a live

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -160,10 +160,14 @@ pub fn open(path: &Path) -> Result<Connection> {
             created_at  INTEGER NOT NULL,
             updated_at  INTEGER NOT NULL
         );
-        -- One conversation per (tenant, scope, scope_id) — e.g. one Personal
-        -- chat per Note. The get-or-create path relies on this uniqueness.
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_conversations_scope
-            ON conversations(tenant, scope, scope_id);
+        -- Multiple conversations ("sessions") per (tenant, scope, scope_id) are
+        -- allowed since #61: the active one is the most-recently-updated row, and
+        -- an explicit command creates a fresh one. The old UNIQUE index
+        -- `idx_conversations_scope` that enforced one-per-scope is dropped below
+        -- (idempotent migration); this non-unique index (a DIFFERENT name, so the
+        -- DROP can't clobber it) keeps the most-recent lookup cheap.
+        CREATE INDEX IF NOT EXISTS idx_conversations_recent
+            ON conversations(tenant, scope, scope_id, updated_at DESC);
 
         CREATE TABLE IF NOT EXISTS messages (
             id              TEXT PRIMARY KEY,
@@ -293,6 +297,21 @@ pub fn open(path: &Path) -> Result<Connection> {
         "ALTER TABLE conversations ADD COLUMN breadth TEXT NOT NULL DEFAULT 'note'",
         [],
     );
+    // Chat sessions (issue #61). Two idempotent steps:
+    //   1. Drop the old UNIQUE index that pinned one conversation per
+    //      (tenant, scope, scope_id) — sessions need many per scope now. IF
+    //      EXISTS makes this a no-op on fresh DBs and on reruns.
+    //   2. Add a nullable `title` column. Nullable (no default) so a freshly
+    //      created conversation carries NULL until its first user message sets
+    //      it (`set_conversation_title`); the backfill below fills legacy rows.
+    let _ = conn.execute("DROP INDEX IF EXISTS idx_conversations_scope", []);
+    let _ = conn.execute("ALTER TABLE conversations ADD COLUMN title TEXT", []);
+    // Back-fill titles for pre-#61 conversations ONCE — guarded by a settings
+    // flag inside the fn so it can't re-run on later launches (that would
+    // date-title empty conversations created after the migration and block their
+    // first-message title). Existing threads keep their identity: title derived
+    // from the oldest user message, date fallback when empty.
+    backfill_conversation_titles(&conn)?;
     // Index is created AFTER the ALTERs so it's safe on both fresh DBs and
     // older DBs that needed the column added.
     conn.execute(
@@ -928,6 +947,10 @@ pub struct Conversation {
     /// single source of truth for the Scope chip; a live filter on retrieval
     /// within the conversation, not a conversation-identity dimension.
     pub breadth: String,
+    /// Session title (issue #61). NULL until the first user message sets it
+    /// (personal scope) or the migration back-fills it; the session list falls
+    /// back to a derived date label when it's still absent.
+    pub title: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -953,17 +976,21 @@ fn map_conversation(row: &rusqlite::Row) -> rusqlite::Result<Conversation> {
         tenant: row.get(3)?,
         remote_id: row.get(4)?,
         breadth: row.get(5)?,
-        created_at: row.get(6)?,
-        updated_at: row.get(7)?,
+        title: row.get(6)?,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
     })
 }
 
 const CONVERSATION_COLS: &str =
-    "id, scope, scope_id, tenant, remote_id, breadth, created_at, updated_at";
+    "id, scope, scope_id, tenant, remote_id, breadth, title, created_at, updated_at";
 
-/// The existing conversation for a scope, or None. Used to reload history
-/// without creating an empty conversation just for opening the Chat tab.
-pub fn get_conversation(
+/// The most-recently-updated conversation ("active session") for a scope, or
+/// None (issue #61). This replaces the old get-or-create: opening the Chat tab
+/// resolves the active session with this and never creates a row as a side
+/// effect. `updated_at` is bumped on every message append, so the newest thread
+/// wins; `created_at` then `id` break ties deterministically.
+pub fn latest_conversation(
     conn: &Connection,
     tenant: &str,
     scope: &str,
@@ -971,7 +998,8 @@ pub fn get_conversation(
 ) -> Result<Option<Conversation>> {
     let mut stmt = conn.prepare_cached(&format!(
         "SELECT {CONVERSATION_COLS} FROM conversations
-         WHERE tenant = ?1 AND scope = ?2 AND scope_id = ?3",
+         WHERE tenant = ?1 AND scope = ?2 AND scope_id = ?3
+         ORDER BY updated_at DESC, created_at DESC, id DESC LIMIT 1",
     ))?;
     match stmt.query_row(params![tenant, scope, scope_id], map_conversation) {
         Ok(c) => Ok(Some(c)),
@@ -980,27 +1008,139 @@ pub fn get_conversation(
     }
 }
 
-/// Get the conversation for a scope, creating it lazily if absent. The unique
-/// index on (tenant, scope, scope_id) makes this the single conversation for a
-/// Note — there is no conversation-list / "new chat" concept in this slice.
-pub fn get_or_create_conversation(
+/// All conversations for a scope, most-recently-updated first (issue #61) — the
+/// backing query for the session list.
+pub fn list_conversations(
     conn: &Connection,
     tenant: &str,
     scope: &str,
     scope_id: &str,
-) -> Result<Conversation> {
-    if let Some(c) = get_conversation(conn, tenant, scope, scope_id)? {
-        return Ok(c);
+) -> Result<Vec<Conversation>> {
+    let mut stmt = conn.prepare_cached(&format!(
+        "SELECT {CONVERSATION_COLS} FROM conversations
+         WHERE tenant = ?1 AND scope = ?2 AND scope_id = ?3
+         ORDER BY updated_at DESC, created_at DESC, id DESC",
+    ))?;
+    let rows = stmt
+        .query_map(params![tenant, scope, scope_id], map_conversation)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// One conversation by its primary key, or None (issue #61). Used to resolve an
+/// explicit `conversation_id` from the frontend.
+pub fn get_conversation_by_id(conn: &Connection, id: &str) -> Result<Option<Conversation>> {
+    let mut stmt = conn
+        .prepare_cached(&format!("SELECT {CONVERSATION_COLS} FROM conversations WHERE id = ?1"))?;
+    match stmt.query_row(params![id], map_conversation) {
+        Ok(c) => Ok(Some(c)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
     }
+}
+
+/// The workspace handle whose `remote_id` maps to a given server conversation
+/// (issue #61). Lets the session-list reconcile server-authoritative workspace
+/// conversations back to their local handle rows without duplicating them.
+pub fn get_conversation_by_remote_id(
+    conn: &Connection,
+    tenant: &str,
+    remote_id: &str,
+) -> Result<Option<Conversation>> {
+    let mut stmt = conn.prepare_cached(&format!(
+        "SELECT {CONVERSATION_COLS} FROM conversations WHERE tenant = ?1 AND remote_id = ?2",
+    ))?;
+    match stmt.query_row(params![tenant, remote_id], map_conversation) {
+        Ok(c) => Ok(Some(c)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Create a fresh conversation with an explicit initial breadth (issue #61),
+/// returning the inserted row. Title starts NULL (set from the first user
+/// message); remote_id starts NULL (set later for a workspace handle).
+pub fn create_conversation(
+    conn: &Connection,
+    tenant: &str,
+    scope: &str,
+    scope_id: &str,
+    breadth: &str,
+) -> Result<Conversation> {
     let id = uuid::Uuid::new_v4().to_string();
     let now = now_ms();
     conn.execute(
-        "INSERT INTO conversations (id, scope, scope_id, tenant, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
-        params![id, scope, scope_id, tenant, now],
+        "INSERT INTO conversations (id, scope, scope_id, tenant, breadth, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)",
+        params![id, scope, scope_id, tenant, breadth, now],
     )?;
-    get_conversation(conn, tenant, scope, scope_id)?
+    get_conversation_by_id(conn, &id)?
         .ok_or_else(|| anyhow::anyhow!("conversation vanished after insert"))
+}
+
+/// Number of persisted messages in a conversation (issue #61) — feeds the
+/// session-list `message_count` and the new-chat no-op guard.
+pub fn conversation_message_count(conn: &Connection, conversation_id: &str) -> Result<i64> {
+    let mut stmt = conn
+        .prepare_cached("SELECT COUNT(*) FROM messages WHERE conversation_id = ?1")?;
+    Ok(stmt.query_row(params![conversation_id], |r| r.get(0))?)
+}
+
+/// Set a conversation's title (issue #61). Personal scope sets this once from
+/// the first user message at send time; the migration back-fill also calls it.
+pub fn set_conversation_title(conn: &Connection, id: &str, title: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE conversations SET title = ?1 WHERE id = ?2",
+        params![title, id],
+    )?;
+    Ok(())
+}
+
+/// Back-fill titles for conversations that predate the `title` column (issue
+/// #61). For each NULL-title row, derive a title from its oldest user message
+/// (whitespace-collapsed, char-boundary-truncated) or a date fallback when the
+/// conversation has no user message.
+///
+/// Guarded by a one-time `chat_titles_backfilled_v1` flag (the repo's migration-
+/// flag pattern) so it runs EXACTLY ONCE, not on every launch. Running it every
+/// open would date-title empty conversations created after the migration, and
+/// that non-NULL date title would then block the send-time message-derived
+/// title. After the one run, conversations created later keep NULL title until
+/// their first user message sets it.
+fn backfill_conversation_titles(conn: &Connection) -> Result<()> {
+    const FLAG: &str = "chat_titles_backfilled_v1";
+    if get_setting(conn, FLAG)?.as_deref() == Some("true") {
+        return Ok(());
+    }
+    let pending: Vec<(String, i64)> = {
+        let mut stmt =
+            conn.prepare("SELECT id, created_at FROM conversations WHERE title IS NULL")?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows
+    };
+    for (conv_id, created_at) in pending {
+        let content: Option<String> = conn
+            .query_row(
+                "SELECT content FROM messages WHERE conversation_id = ?1 AND role = 'user'
+                 ORDER BY seq LIMIT 1",
+                params![conv_id],
+                |r| r.get(0),
+            )
+            .optional()?;
+        let text = content.map(|c| crate::chat::parts_plain_text(&c));
+        let title = crate::chat::derive_title(
+            text.as_deref().filter(|t| !t.trim().is_empty()),
+            created_at,
+        );
+        conn.execute(
+            "UPDATE conversations SET title = ?1 WHERE id = ?2",
+            params![title, conv_id],
+        )?;
+    }
+    set_setting(conn, FLAG, "true")?;
+    Ok(())
 }
 
 /// Record the humla-cloud conversation record id for a workspace conversation
@@ -1865,16 +2005,19 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let conn = open(&dir.path().join("conv.sqlite")).unwrap();
 
-        let personal = get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1").unwrap();
-        let workspace = get_or_create_conversation(&conn, "wsA", CHAT_SCOPE_NOTE, "note1").unwrap();
+        let personal = create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1", "note").unwrap();
+        let workspace = create_conversation(&conn, "wsA", CHAT_SCOPE_NOTE, "note1", "note").unwrap();
         assert_ne!(personal.id, workspace.id, "same Note, different tenant → distinct conversations");
         assert!(workspace.remote_id.is_none(), "no server id until the first turn");
 
         set_conversation_remote_id(&conn, &workspace.id, "srvConv123").unwrap();
-        let reloaded = get_conversation(&conn, "wsA", CHAT_SCOPE_NOTE, "note1").unwrap().unwrap();
+        let reloaded = latest_conversation(&conn, "wsA", CHAT_SCOPE_NOTE, "note1").unwrap().unwrap();
         assert_eq!(reloaded.remote_id.as_deref(), Some("srvConv123"));
+        // Round-trips by its server id too (the workspace session-list reconcile).
+        let by_remote = get_conversation_by_remote_id(&conn, "wsA", "srvConv123").unwrap().unwrap();
+        assert_eq!(by_remote.id, workspace.id);
         // The personal conversation is untouched by the workspace one's remote id.
-        let personal_reload = get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1").unwrap().unwrap();
+        let personal_reload = latest_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1").unwrap().unwrap();
         assert!(personal_reload.remote_id.is_none());
     }
 
@@ -1889,12 +2032,12 @@ mod tests {
         let conv_id = {
             let conn = open(&path).unwrap();
             let conv =
-                get_or_create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1")
+                create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1", "note")
                     .unwrap();
             assert_eq!(conv.breadth, "note", "new conversations default to note breadth");
             set_conversation_breadth(&conn, &conv.id, "all").unwrap();
             let reloaded =
-                get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1")
+                latest_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1")
                     .unwrap()
                     .unwrap();
             assert_eq!(reloaded.breadth, "all", "the stored breadth round-trips");
@@ -1903,11 +2046,105 @@ mod tests {
         // Re-open the same DB file: migrations must be idempotent and the stored
         // breadth must not be reset by the (repeated) ALTER TABLE.
         let conn = open(&path).unwrap();
-        let reloaded = get_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1")
+        let reloaded = latest_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note1")
             .unwrap()
             .unwrap();
         assert_eq!(reloaded.id, conv_id);
         assert_eq!(reloaded.breadth, "all", "breadth survives a re-open (idempotent migration)");
+    }
+
+    /// Migration idempotency + first-session preservation (issue #61). Seeds a
+    /// pre-#61 DB — the old UNIQUE `idx_conversations_scope`, no `title` column,
+    /// a conversation with a user message and an empty one — then runs `open()`
+    /// (the migrations) twice and asserts: the unique index is dropped, titles
+    /// back-fill (from the oldest user message, char-truncated; date fallback for
+    /// the empty one), and the existing thread is preserved as the note's single
+    /// (first) session. Reopening is a no-op on already-titled rows.
+    #[test]
+    fn migration_drops_unique_index_and_backfills_titles_idempotently() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mig.sqlite");
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE conversations (
+                    id TEXT PRIMARY KEY, scope TEXT NOT NULL, scope_id TEXT NOT NULL,
+                    tenant TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+                    remote_id TEXT, breadth TEXT NOT NULL DEFAULT 'note'
+                );
+                CREATE UNIQUE INDEX idx_conversations_scope
+                    ON conversations(tenant, scope, scope_id);
+                CREATE TABLE messages (
+                    id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, seq INTEGER NOT NULL,
+                    role TEXT NOT NULL, content TEXT NOT NULL, created_at INTEGER NOT NULL
+                );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO conversations (id, scope, scope_id, tenant, created_at, updated_at)
+                 VALUES ('conv1','note','n1','personal',1000,2000)",
+                [],
+            )
+            .unwrap();
+            let parts = crate::chat::text_parts_json("b0", "  Discuss the Q3 roadmap  and next steps ");
+            conn.execute(
+                "INSERT INTO messages (id, conversation_id, seq, role, content, created_at)
+                 VALUES ('m1','conv1',0,'user',?1,1500)",
+                params![parts],
+            )
+            .unwrap();
+            // An empty conversation (no messages) → date fallback from created_at.
+            conn.execute(
+                "INSERT INTO conversations (id, scope, scope_id, tenant, created_at, updated_at)
+                 VALUES ('conv2','note','n2','personal',0,0)",
+                [],
+            )
+            .unwrap();
+        }
+
+        // Run migrations twice — must be idempotent.
+        for _ in 0..2 {
+            let conn = open(&path).unwrap();
+            let has_unique: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master
+                     WHERE type = 'index' AND name = 'idx_conversations_scope'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(has_unique, 0, "the old unique index is dropped");
+        }
+
+        let conn = open(&path).unwrap();
+        // Title back-filled from the oldest user message: whitespace collapsed.
+        let conv1 = get_conversation_by_id(&conn, "conv1").unwrap().unwrap();
+        assert_eq!(conv1.title.as_deref(), Some("Discuss the Q3 roadmap and next steps"));
+        // The existing thread is preserved as the note's single (first) session.
+        let latest = latest_conversation(&conn, "personal", "note", "n1").unwrap().unwrap();
+        assert_eq!(latest.id, "conv1");
+        assert_eq!(list_conversations(&conn, "personal", "note", "n1").unwrap().len(), 1);
+        // The empty conversation gets the date fallback (created_at = epoch 0).
+        let conv2 = get_conversation_by_id(&conn, "conv2").unwrap().unwrap();
+        assert_eq!(conv2.title.as_deref(), Some("Chat 1970-01-01"));
+
+        // The backfill ran ONCE and set its flag.
+        assert_eq!(get_setting(&conn, "chat_titles_backfilled_v1").unwrap().as_deref(), Some("true"));
+
+        // A conversation created AFTER the backfill flag is set must NOT be
+        // date-titled by a later launch — it keeps NULL title until its first
+        // user message titles it (the hazard fix).
+        let fresh = create_conversation(&conn, "personal", "note", "n3", "note").unwrap();
+        assert!(fresh.title.is_none(), "a new empty conversation starts untitled");
+        drop(conn);
+        let conn = open(&path).unwrap(); // reopen: backfill is skipped by the flag
+        let fresh = get_conversation_by_id(&conn, &fresh.id).unwrap().unwrap();
+        assert!(fresh.title.is_none(), "reopen must not date-title a post-migration conversation");
+        // First user message titles it (mirrors chat_send's send-time titling).
+        let title = crate::chat::derive_title(Some("What is the plan?"), fresh.created_at);
+        set_conversation_title(&conn, &fresh.id, &title).unwrap();
+        let titled = get_conversation_by_id(&conn, &fresh.id).unwrap().unwrap();
+        assert_eq!(titled.title.as_deref(), Some("What is the plan?"), "message-derived title, not a date");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -353,6 +353,8 @@ where
             commands::summarize_note,
             commands::chat_send,
             commands::chat_history,
+            commands::chat_list_conversations,
+            commands::chat_new_conversation,
             commands::chat_set_breadth,
             commands::chat_get_breadth,
             commands::chat_reindex_note,

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -48,6 +48,12 @@ function assistantWithCitation(text: string): ChatMessageDto {
   };
 }
 
+// `chat_history` returns { conversationId, messages } since #61; a non-empty
+// history implies a resolved session id.
+function history(messages: ChatMessageDto[] = []) {
+  return { conversationId: messages.length ? "c1" : null, messages };
+}
+
 function renderPanel(noteId = "n1") {
   return render(
     <MemoryRouter>
@@ -70,7 +76,7 @@ describe("ChatPanel readiness", () => {
   });
 
   it("shows the input + empty state once a key is present", async () => {
-    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => [] });
+    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => history() });
     renderPanel();
     await waitFor(() =>
       expect(screen.getByPlaceholderText(/Ask about your notes/)).toBeInTheDocument(),
@@ -88,7 +94,8 @@ describe("ChatPanel send", () => {
         sent = true;
         return { conversationId: "c1", truncated: false };
       },
-      chat_history: () => (sent ? [userMsg("What happened?"), assistantMsg("A summary.")] : []),
+      chat_history: () =>
+        history(sent ? [userMsg("What happened?"), assistantMsg("A summary.")] : []),
     });
     renderPanel();
 
@@ -108,7 +115,7 @@ describe("ChatPanel send", () => {
         sent = true;
         return { conversationId: "c1", truncated: true };
       },
-      chat_history: () => (sent ? [userMsg("hi"), assistantMsg("hello")] : []),
+      chat_history: () => history(sent ? [userMsg("hi"), assistantMsg("hello")] : []),
     });
     renderPanel();
     const input = await screen.findByPlaceholderText(/Ask about your notes/);
@@ -124,7 +131,8 @@ describe("ChatPanel retrieval UI (#47)", () => {
   it("renders a citation chip for a cited note", async () => {
     mockTauri({
       provider_key_get: () => "sk-test",
-      chat_history: () => [userMsg("what happened?"), assistantWithCitation("Here's what I found.")],
+      chat_history: () =>
+        history([userMsg("what happened?"), assistantWithCitation("Here's what I found.")]),
     });
     renderPanel();
     await waitFor(() => expect(screen.getByText("Here's what I found.")).toBeInTheDocument());
@@ -133,7 +141,7 @@ describe("ChatPanel retrieval UI (#47)", () => {
   });
 
   it("offers the scope breadths in the Scope popover", async () => {
-    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => [] });
+    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => history() });
     renderPanel();
     const trigger = await screen.findByRole("button", { name: "Chat scope" });
     fireEvent.click(trigger);
@@ -145,7 +153,7 @@ describe("ChatPanel retrieval UI (#47)", () => {
 
 describe("ChatPanel context pinning (#58)", () => {
   it("renders no tenant picker — chat is pinned to the loaded context", async () => {
-    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => [] });
+    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => history() });
     signIntoWorkspace("Acme Team");
     renderPanel();
     await screen.findByPlaceholderText(/Ask about your notes/);
@@ -154,7 +162,7 @@ describe("ChatPanel context pinning (#58)", () => {
   });
 
   it("shows the workspace name as a non-interactive context indicator", async () => {
-    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => [] });
+    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => history() });
     signIntoWorkspace("Acme Team");
     renderPanel();
     // The indicator shows where chat goes; it is not a button (no popover).
@@ -164,7 +172,7 @@ describe("ChatPanel context pinning (#58)", () => {
   });
 
   it("shows Personal as the context indicator when signed out", async () => {
-    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => [] });
+    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => history() });
     renderPanel();
     const indicator = await screen.findByLabelText("Chat context");
     expect(indicator).toHaveTextContent("Personal");
@@ -175,7 +183,7 @@ describe("ChatPanel scope breadth (#58)", () => {
   it("initialises the scope chip from the persisted breadth", async () => {
     mockTauri({
       provider_key_get: () => "sk-test",
-      chat_history: () => [],
+      chat_history: () => history(),
       chat_get_breadth: () => "all",
     });
     renderPanel();
@@ -188,7 +196,7 @@ describe("ChatPanel scope breadth (#58)", () => {
     let setArgs: { noteId?: string; breadth?: string } | undefined;
     mockTauri({
       provider_key_get: () => "sk-test",
-      chat_history: () => [],
+      chat_history: () => history(),
       chat_get_breadth: () => "note",
       chat_set_breadth: (args) => {
         setArgs = args as { noteId?: string; breadth?: string };

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -72,6 +72,10 @@ function toolActivityLabel(name: string): string {
 export function ChatPanel({ noteId }: { noteId: string }) {
   const { loading: readinessLoading, ready, hint, provider, model } = useChatReadiness();
   const [messages, setMessages] = useState<ChatMessageDto[]>([]);
+  // The session the panel is on (issue #61). Single-threaded for now: it tracks
+  // the note's active/most-recent conversation, captured from the history load
+  // and the send result. null until resolved (or when the note has none yet).
+  const [conversationId, setConversationId] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [streaming, setStreaming] = useState("");
@@ -119,10 +123,16 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     setTruncated(false);
     setSending(false);
     sendingRef.current = false;
+    setConversationId(null);
+    // Load the active session's history and remember which session it resolved
+    // to (issue #61), so subsequent sends/breadth writes target the same one.
     ipc
       .chatHistory(noteId)
       .then((h) => {
-        if (!cancelled) setMessages(h);
+        if (!cancelled) {
+          setMessages(h.messages);
+          setConversationId(h.conversationId);
+        }
       })
       .catch(() => {
         if (!cancelled) setMessages([]);
@@ -147,7 +157,7 @@ export function ChatPanel({ noteId }: { noteId: string }) {
   // optimistically, then write it through so the next turn reads the new value.
   function selectBreadth(next: ChatScope) {
     setScope(next);
-    void ipc.chatSetBreadth(noteId, next).catch((e) => setError(String(e)));
+    void ipc.chatSetBreadth(noteId, conversationId, next).catch((e) => setError(String(e)));
   }
 
   // Stream subscription. Bound once; cancelled-flag + claim keeps it StrictMode-
@@ -210,13 +220,18 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     };
     setMessages((m) => [...m, optimistic]);
     try {
-      const result = await ipc.chatSend(noteId, text);
-      setMessages(await ipc.chatHistory(noteId));
+      // Send to the resolved session (null lazily creates the note's first one),
+      // capturing the id the backend landed on so the reload targets it (#61).
+      const result = await ipc.chatSend(noteId, conversationId, text);
+      setConversationId(result.conversationId);
+      const h = await ipc.chatHistory(noteId, result.conversationId);
+      setMessages(h.messages);
       setTruncated(result.truncated);
     } catch (e) {
       setError((prev) => prev ?? String(e));
       try {
-        setMessages(await ipc.chatHistory(noteId));
+        const h = await ipc.chatHistory(noteId, conversationId);
+        setMessages(h.messages);
       } catch {
         /* keep the optimistic view */
       }

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -387,22 +387,37 @@ export const ipc = {
   // AI chat over a single Note (issue #46). `chatSend` runs one grounded,
   // streamed completion — the answer arrives via chat_* events, so the
   // resolved promise only carries the conversation id + a truncation flag.
-  // `chatHistory` reloads a Note's persisted conversation after restart.
+  // `chatHistory` reloads a conversation and reports which one it resolved to.
+  //
+  // Chat sessions (issue #61): a Note can have multiple conversations. Each call
+  // takes an optional `conversationId` — omit it (or pass null) to target the
+  // active/most-recent session; opening the tab creates nothing. `chatHistory`
+  // returns the resolved `conversationId` so the panel learns which session it's
+  // on; `chatSend` returns it too (lazy-creating on the first turn).
   //
   // Chat is pinned to the loaded context (issue #58): the backend derives the
-  // tenant from the active workspace (Personal when none), so neither call
-  // takes a tenant. Retrieval breadth ("note" | "folder" | "all") is persisted
-  // on the conversation server-side — `chatSetBreadth` writes it, `chatGetBreadth`
-  // reads it back to initialise the Scope chip. `chatSend` no longer carries a
-  // scope: it reads the persisted breadth, so the UI can never diverge from it.
-  chatSend: (noteId: string, message: string) =>
-    invoke<ChatSendResult>("chat_send", { noteId, message }),
-  chatHistory: (noteId: string) => invoke<ChatMessageDto[]>("chat_history", { noteId }),
-  // Persist / read the Scope chip's breadth on the current context's
-  // conversation (issue #58). The single source of truth for retrieval breadth.
-  chatSetBreadth: (noteId: string, breadth: ChatScope) =>
-    invoke<void>("chat_set_breadth", { noteId, breadth }),
-  chatGetBreadth: (noteId: string) => invoke<ChatScope>("chat_get_breadth", { noteId }),
+  // tenant from the active workspace (Personal when none), so no call takes a
+  // tenant. Retrieval breadth ("note" | "folder" | "all") is persisted on the
+  // conversation server-side — `chatSetBreadth` writes it, `chatGetBreadth` reads
+  // it back to initialise the Scope chip. `chatSend` carries no scope: it reads
+  // the persisted breadth, so the UI can never diverge from it.
+  chatSend: (noteId: string, conversationId: string | null, message: string) =>
+    invoke<ChatSendResult>("chat_send", { noteId, conversationId, message }),
+  chatHistory: (noteId: string, conversationId: string | null = null) =>
+    invoke<ChatHistory>("chat_history", { noteId, conversationId }),
+  // List / create chat sessions for a Note (issue #61). Personal reads local
+  // SQLite; a workspace reads/creates server-authoritative sessions. There is no
+  // delete command — a deliberate v1 decision.
+  chatListConversations: (noteId: string) =>
+    invoke<ConversationMeta[]>("chat_list_conversations", { noteId }),
+  chatNewConversation: (noteId: string) =>
+    invoke<ConversationMeta>("chat_new_conversation", { noteId }),
+  // Persist / read the Scope chip's breadth on a conversation (issue #58/#61).
+  // The single source of truth for retrieval breadth.
+  chatSetBreadth: (noteId: string, conversationId: string | null, breadth: ChatScope) =>
+    invoke<void>("chat_set_breadth", { noteId, conversationId, breadth }),
+  chatGetBreadth: (noteId: string, conversationId: string | null = null) =>
+    invoke<ChatScope>("chat_get_breadth", { noteId, conversationId }),
   // Rebuild a Note's retrieval index — called on Note-view unmount so edits
   // that didn't trigger summarize/diarize still land in search.
   chatReindexNote: (noteId: string) => invoke<void>("chat_reindex_note", { noteId }),
@@ -447,6 +462,18 @@ export type ChatMessageDto = {
   createdAt: number;
 };
 export type ChatSendResult = { conversationId: string; truncated: boolean };
+// `chatHistory` result (issue #61): the messages plus the conversation they were
+// resolved to. `conversationId` is null when the Note has no session yet.
+export type ChatHistory = { conversationId: string | null; messages: ChatMessageDto[] };
+// One chat session in the list (issue #61). `title` is resolved server/back-end
+// side (stored title, else a date fallback), so it always renders.
+export type ConversationMeta = {
+  id: string;
+  title: string;
+  breadth: ChatScope;
+  updatedAt: number;
+  messageCount: number;
+};
 // Retrieval breadth chosen in the Scope popover (issue #47), persisted per
 // conversation on the backend (issue #58).
 export type ChatScope = "note" | "folder" | "all";


### PR DESCRIPTION
Closes #61 (child of #60).

Sessions at the data-model/IPC layer, no new UI — the existing single-thread ChatPanel keeps working against the new model, so this is releasable alone.

- **Migration** (idempotent): drop `idx_conversations_scope` unique index (replaced by non-unique `idx_conversations_recent`), add nullable `title`, one-time backfill (`chat_titles_backfilled_v1` flag) from each thread's oldest user message, date fallback for empty threads.
- **IPC**: new `chat_list_conversations` / `chat_new_conversation` (no-op guard on an empty most-recent session; breadth inherited from the note's previous conversation, first-ever defaults to `note`); `chat_send` / `chat_history` / breadth commands take an explicit `conversation_id` validated against note+tenant; opening the chat tab stays lazy (no rows created until first send / explicit new).
- **Titles**: personal set once at first send; workspace titles server-managed.
- **Workspace**: server-authoritative against the deployed humla-cloud#19 routes (`/api/humla/chat/conversations`, PB-native `created`/`updated`, flat POST response), client-side no-op guard, and legacy pre-#19 threads merged from local note↔remote_id handles until an adopting turn stamps them server-side (contract verified post-merge and documented on humla-cloud#19). 404s degrade gracefully for not-yet-updated servers.
- **Frontend**: ChatPanel threads the resolved conversation id; no visual changes.

Tests: backend 314 passed, frontend 188 passed, `tsc --noEmit` clean. Two-axis code review run pre-commit; findings fixed (title-backfill/restart interaction, workspace breadth inheritance, cross-scope id validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)