### PR TITLE
feat(chat): new chat button + history popover (#62)

### DIFF
--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { ChatPanel } from "./ChatPanel";
+import { ChatPanel, type ChatSessionControls } from "./ChatPanel";
 import { mockTauri } from "../test/tauri";
 import type { ChatMessageDto } from "../lib/ipc";
 import { useCloudStore, DISCONNECTED } from "../lib/cloud";
@@ -60,6 +60,24 @@ function renderPanel(noteId = "n1") {
       <ChatPanel noteId={noteId} />
     </MemoryRouter>,
   );
+}
+
+// Render capturing the header controls ChatPanel publishes (#62). The buttons
+// live in the Note header; testing through the controls contract keeps
+// ChatPanel's session behavior self-contained.
+function renderWithControls(noteId = "n1") {
+  const captured: { current: ChatSessionControls | null } = { current: null };
+  render(
+    <MemoryRouter>
+      <ChatPanel
+        noteId={noteId}
+        onControls={(c) => {
+          captured.current = c;
+        }}
+      />
+    </MemoryRouter>,
+  );
+  return captured;
 }
 
 beforeEach(() => {
@@ -176,6 +194,158 @@ describe("ChatPanel context pinning (#58)", () => {
     renderPanel();
     const indicator = await screen.findByLabelText("Chat context");
     expect(indicator).toHaveTextContent("Personal");
+  });
+});
+
+describe("ChatPanel sessions (#62)", () => {
+  it("hides the history affordance for a lone empty conversation", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: "c1", messages: [] }),
+      chat_list_conversations: () => [
+        { id: "c1", title: "", breadth: "note", updatedAt: 1, messageCount: 0 },
+      ],
+    });
+    const controls = renderWithControls();
+    await screen.findByPlaceholderText(/Ask about your notes/);
+    await waitFor(() => expect(controls.current).not.toBeNull());
+    expect(controls.current?.canBrowseHistory).toBe(false);
+  });
+
+  it("shows history once the note has another conversation", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: "c1", messages: [] }),
+      chat_list_conversations: () => [
+        { id: "c1", title: "", breadth: "note", updatedAt: 20, messageCount: 0 },
+        { id: "c2", title: "Earlier chat", breadth: "note", updatedAt: 10, messageCount: 4 },
+      ],
+    });
+    const controls = renderWithControls();
+    await screen.findByPlaceholderText(/Ask about your notes/);
+    await waitFor(() => expect(controls.current?.canBrowseHistory).toBe(true));
+    expect(controls.current?.conversations).toHaveLength(2);
+    expect(controls.current?.activeConversationId).toBe("c1");
+  });
+
+  it("'+' starts a fresh conversation and switches the pane to it", async () => {
+    let created = false;
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({
+        conversationId: "c1",
+        messages: [userMsg("Old question?"), assistantMsg("Old answer.")],
+      }),
+      chat_list_conversations: () => [
+        { id: "c1", title: "First", breadth: "note", updatedAt: 5, messageCount: 2 },
+      ],
+      chat_new_conversation: () => {
+        created = true;
+        // Inherits the prior breadth ("all") per #61.
+        return { id: "c2", title: "", breadth: "all", updatedAt: 9, messageCount: 0 };
+      },
+    });
+    const controls = renderWithControls();
+    await screen.findByText("Old answer.");
+    await waitFor(() => expect(controls.current).not.toBeNull());
+
+    await act(async () => {
+      await controls.current!.newChat();
+    });
+
+    expect(created).toBe(true);
+    // The pane is now the fresh, empty conversation.
+    expect(screen.queryByText("Old answer.")).toBeNull();
+    expect(screen.getByText(/Ask anything about your notes/)).toBeInTheDocument();
+    await waitFor(() => expect(controls.current?.activeConversationId).toBe("c2"));
+    // Inherited breadth is reflected in the Scope chip.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Chat scope" })).toHaveTextContent("All notes"),
+    );
+  });
+
+  it("a slow initial history load can't clobber a conversation started with '+'", async () => {
+    // Hold the mount history fetch open so it resolves AFTER newChat() lands.
+    let releaseInitialHistory: (() => void) | null = null;
+    let historyCalls = 0;
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: (args) => {
+        const cid = (args as { conversationId?: string | null }).conversationId ?? null;
+        historyCalls += 1;
+        if (cid === null && historyCalls === 1) {
+          return new Promise((resolve) => {
+            releaseInitialHistory = () =>
+              resolve({
+                conversationId: "c1",
+                messages: [userMsg("Old question?"), assistantMsg("Stale answer.")],
+              });
+          });
+        }
+        return { conversationId: cid ?? "c1", messages: [] };
+      },
+      chat_list_conversations: () => [
+        { id: "c1", title: "First", breadth: "note", updatedAt: 5, messageCount: 2 },
+      ],
+      chat_new_conversation: () => ({
+        id: "c2",
+        title: "",
+        breadth: "note",
+        updatedAt: 9,
+        messageCount: 0,
+      }),
+    });
+    const controls = renderWithControls();
+    await waitFor(() => expect(controls.current).not.toBeNull());
+
+    // Switch to a fresh conversation while the initial history is still pending.
+    await act(async () => {
+      await controls.current!.newChat();
+    });
+    expect(controls.current?.activeConversationId).toBe("c2");
+
+    // Now let the stale initial fetch resolve — it must be ignored.
+    await act(async () => {
+      releaseInitialHistory?.();
+      await Promise.resolve();
+    });
+    expect(screen.queryByText("Stale answer.")).toBeNull();
+    expect(controls.current?.activeConversationId).toBe("c2");
+  });
+
+  it("loads a chosen conversation's messages and its stored breadth", async () => {
+    const historyArgs: (string | null)[] = [];
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: (args) => {
+        const cid = (args as { conversationId?: string | null }).conversationId ?? null;
+        historyArgs.push(cid);
+        return cid === "c2"
+          ? { conversationId: "c2", messages: [userMsg("Q2"), assistantMsg("Answer two.")] }
+          : { conversationId: "c1", messages: [userMsg("Q1"), assistantMsg("Answer one.")] };
+      },
+      chat_get_breadth: (args) =>
+        (args as { conversationId?: string | null }).conversationId === "c2" ? "all" : "note",
+      chat_list_conversations: () => [
+        { id: "c1", title: "First", breadth: "note", updatedAt: 20, messageCount: 2 },
+        { id: "c2", title: "Second", breadth: "all", updatedAt: 10, messageCount: 2 },
+      ],
+    });
+    const controls = renderWithControls();
+    await screen.findByText("Answer one.");
+    await waitFor(() => expect(controls.current).not.toBeNull());
+
+    await act(async () => {
+      await controls.current!.openConversation("c2");
+    });
+
+    await waitFor(() => expect(screen.getByText("Answer two.")).toBeInTheDocument());
+    expect(screen.queryByText("Answer one.")).toBeNull();
+    expect(historyArgs).toContain("c2");
+    // The Scope chip tracks the loaded conversation's stored breadth.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Chat scope" })).toHaveTextContent("All notes"),
+    );
   });
 });
 

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useNavigate } from "react-router-dom";
@@ -13,6 +13,7 @@ import {
   type ChatCitation,
   type ChatMessageDto,
   type ChatScope,
+  type ConversationMeta,
 } from "../lib/ipc";
 import { useNotesStore } from "../lib/store";
 import { useCloudStore } from "../lib/cloud";
@@ -69,9 +70,38 @@ function toolActivityLabel(name: string): string {
   }
 }
 
-export function ChatPanel({ noteId }: { noteId: string }) {
+// What the panel publishes upward so the Note header (owner of the +/history
+// buttons per #62) can render session chrome without duplicating any chat
+// state: the conversation list + which one is active, a visibility flag for the
+// history affordance, and the two actions the header triggers. ChatPanel stays
+// the sole owner of conversationId/messages; this is a read-only projection plus
+// action callbacks.
+export type ChatSessionControls = {
+  /** The note these controls belong to — lets the header ignore a stale
+   *  projection for one frame after a note switch. */
+  noteId: string;
+  conversations: ConversationMeta[];
+  activeConversationId: string | null;
+  /** Lone-empty-conversation rule (#62): nothing worth browsing → header hides history. */
+  canBrowseHistory: boolean;
+  newChat: () => Promise<void>;
+  openConversation: (id: string) => Promise<void>;
+};
+
+export function ChatPanel({
+  noteId,
+  onControls,
+}: {
+  noteId: string;
+  onControls?: (controls: ChatSessionControls | null) => void;
+}) {
   const { loading: readinessLoading, ready, hint, provider, model } = useChatReadiness();
   const [messages, setMessages] = useState<ChatMessageDto[]>([]);
+  // This Note's conversations (issue #61/#62), most-recent first from the
+  // backend (local rows in Personal; server list merged in a workspace). Feeds
+  // the history popover and the history-visibility rule. Reset to [] on note /
+  // workspace switch so the header hides until the fresh list is known.
+  const [conversations, setConversations] = useState<ConversationMeta[]>([]);
   // The session the panel is on (issue #61). Single-threaded for now: it tracks
   // the note's active/most-recent conversation, captured from the history load
   // and the send result. null until resolved (or when the note has none yet).
@@ -88,6 +118,11 @@ export function ChatPanel({ noteId }: { noteId: string }) {
   const [scope, setScope] = useState<ChatScope>("note");
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const sendingRef = useRef(false);
+  // Bumped on every context switch (note/workspace load, "+", history select).
+  // In-flight async work (a streaming send, a history fetch) captures the gen
+  // at start and drops its writes if the gen moved — so a stale response can't
+  // leak into the conversation the user switched to (#62).
+  const switchGenRef = useRef(0);
 
   // The anchor note's folder drives the "this folder" scope option.
   const folder = useNotesStore((s) => {
@@ -95,6 +130,84 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     const fid = note?.folder_id;
     return fid ? s.folders.find((f) => f.id === fid) ?? null : null;
   });
+
+  // Re-fetch the note's conversation list. Guarded by the switch gen so a slow
+  // list load can't clobber the list after a note/workspace switch. Stable per
+  // note so the callbacks and publish effect below keep stable identities.
+  const reloadConversationList = useCallback(
+    async (gen: number) => {
+      try {
+        const list = await ipc.chatListConversations(noteId);
+        if (gen === switchGenRef.current && Array.isArray(list)) setConversations(list);
+      } catch {
+        /* keep the prior list */
+      }
+    },
+    [noteId],
+  );
+
+  // Clear the transient per-turn UI (streaming/activity/errors) and stop
+  // accepting stream deltas. Shared by the note-switch load effect and every
+  // in-pane switch so the reset stays in one place.
+  const resetTransient = useCallback(() => {
+    sendingRef.current = false;
+    setSending(false);
+    setStreaming("");
+    setActivity(null);
+    setLiveCitations([]);
+    setError(null);
+    setTruncated(false);
+  }, []);
+
+  // Advance the switch gen (dropping any in-flight send/history writes) and
+  // reset transient UI. Shared by "+" and history select so a switch mid-stream
+  // can't bleed into the loaded conversation.
+  const beginSwitch = useCallback((): number => {
+    const gen = ++switchGenRef.current;
+    resetTransient();
+    return gen;
+  }, [resetTransient]);
+
+  // "+" — start (or reuse) a fresh conversation and switch the pane to it. The
+  // backend no-ops when the most-recent conversation is already empty, returning
+  // it instead of creating a duplicate; either way we land on `meta` with an
+  // empty message list and its inherited breadth reflected in the Scope chip.
+  const newChat = useCallback(async () => {
+    const gen = beginSwitch();
+    try {
+      const meta = await ipc.chatNewConversation(noteId);
+      if (gen !== switchGenRef.current || !meta) return;
+      setConversationId(meta.id);
+      setMessages([]);
+      setScope(meta.breadth ?? "note");
+      setConversations((prev) => [meta, ...prev.filter((c) => c.id !== meta.id)]);
+      void reloadConversationList(gen);
+    } catch (e) {
+      if (gen === switchGenRef.current) setError(String(e));
+    }
+  }, [noteId, beginSwitch, reloadConversationList]);
+
+  // Load a conversation chosen from the history popover: its messages and its
+  // own stored breadth (so the Scope chip tracks the loaded conversation, #62).
+  const openConversation = useCallback(
+    async (id: string) => {
+      const gen = beginSwitch();
+      setConversationId(id);
+      try {
+        const [h, b] = await Promise.all([
+          ipc.chatHistory(noteId, id),
+          ipc.chatGetBreadth(noteId, id),
+        ]);
+        if (gen !== switchGenRef.current) return;
+        setMessages(h?.messages ?? []);
+        if (h?.conversationId) setConversationId(h.conversationId);
+        if (b) setScope(b);
+      } catch {
+        if (gen === switchGenRef.current) setMessages([]);
+      }
+    },
+    [noteId, beginSwitch],
+  );
 
   // Chat is pinned to the loaded context (issue #58). The chat follows the
   // active workspace (Personal when none) — there's no tenant picker; the
@@ -114,44 +227,46 @@ export function ChatPanel({ noteId }: { noteId: string }) {
   // reset that lived in `changeTenant`. On unmount / change, rebuild the note's
   // retrieval index so edits made this session are searchable next time.
   useEffect(() => {
+    const gen = ++switchGenRef.current;
     let cancelled = false;
     setInput("");
-    setStreaming("");
-    setActivity(null);
-    setLiveCitations([]);
-    setError(null);
-    setTruncated(false);
-    setSending(false);
-    sendingRef.current = false;
+    resetTransient();
     setConversationId(null);
-    // Load the active session's history and remember which session it resolved
-    // to (issue #61), so subsequent sends/breadth writes target the same one.
+    // Hide the history affordance until the fresh list is known (no flicker of
+    // the previous note's conversations on switch, #62).
+    setConversations([]);
+    // Both async loads gate on the gen as well as `cancelled`: an in-flight
+    // initial fetch could otherwise resolve after the user hits "+" / opens a
+    // history entry and clobber the just-switched-to conversation (#62). The gen
+    // moves on every switch; `cancelled` alone doesn't (beginSwitch never flips
+    // it), so we need both.
     ipc
       .chatHistory(noteId)
       .then((h) => {
-        if (!cancelled) {
+        if (!cancelled && gen === switchGenRef.current) {
           setMessages(h.messages);
           setConversationId(h.conversationId);
         }
       })
       .catch(() => {
-        if (!cancelled) setMessages([]);
+        if (!cancelled && gen === switchGenRef.current) setMessages([]);
       });
     // Initialise the chip from the backend's persisted breadth in one round
     // trip; fall back to "note" if it can't be read.
     ipc
       .chatGetBreadth(noteId)
       .then((b) => {
-        if (!cancelled && b) setScope(b);
+        if (!cancelled && gen === switchGenRef.current && b) setScope(b);
       })
       .catch(() => {
-        if (!cancelled) setScope("note");
+        if (!cancelled && gen === switchGenRef.current) setScope("note");
       });
+    void reloadConversationList(gen);
     return () => {
       cancelled = true;
       void ipc.chatReindexNote(noteId).catch(() => {});
     };
-  }, [noteId, workspaceId]);
+  }, [noteId, workspaceId, reloadConversationList, resetTransient]);
 
   // Persist a breadth change to the conversation (issue #58): update the chip
   // optimistically, then write it through so the next turn reads the new value.
@@ -200,6 +315,43 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     if (el) el.scrollTop = el.scrollHeight;
   }, [messages, streaming, sending, activity]);
 
+  // Publish the session controls to the owner (Note header) whenever the list,
+  // the active conversation, or its emptiness changes. Only while ready — no
+  // chat chrome before a provider is configured. `null` tells the header to
+  // render nothing. Actions are stable, so this fires only on real data changes.
+  useEffect(() => {
+    if (!onControls) return;
+    if (!ready) {
+      onControls(null);
+      return;
+    }
+    // Hide only for a lone empty conversation: nothing to browse. Show once
+    // there's a second conversation (incl. a teammate's), any stored non-empty
+    // conversation, or a live just-sent turn. Keyed off list content rather than
+    // the resolved active id so it doesn't flicker while history resolves (#62).
+    const canBrowseHistory =
+      conversations.length > 1 ||
+      conversations.some((c) => c.messageCount > 0) ||
+      messages.length > 0;
+    onControls({
+      noteId,
+      conversations,
+      activeConversationId: conversationId,
+      canBrowseHistory,
+      newChat,
+      openConversation,
+    });
+  }, [
+    onControls,
+    ready,
+    noteId,
+    conversations,
+    conversationId,
+    messages.length,
+    newChat,
+    openConversation,
+  ]);
+
   async function send() {
     const text = input.trim();
     if (!text || sending || !ready) return;
@@ -211,6 +363,9 @@ export function ChatPanel({ noteId }: { noteId: string }) {
     setTruncated(false);
     setSending(true);
     sendingRef.current = true;
+    // Snapshot the switch gen: if the user opens another conversation or hits
+    // "+" mid-send, the gen moves and we drop this turn's writes (#62).
+    const gen = switchGenRef.current;
     const optimistic: ChatMessageDto = {
       id: `optimistic-${Date.now()}`,
       role: "user",
@@ -223,23 +378,31 @@ export function ChatPanel({ noteId }: { noteId: string }) {
       // Send to the resolved session (null lazily creates the note's first one),
       // capturing the id the backend landed on so the reload targets it (#61).
       const result = await ipc.chatSend(noteId, conversationId, text);
+      if (gen !== switchGenRef.current) return;
       setConversationId(result.conversationId);
       const h = await ipc.chatHistory(noteId, result.conversationId);
+      if (gen !== switchGenRef.current) return;
       setMessages(h.messages);
       setTruncated(result.truncated);
+      // A first turn creates the conversation and bumps message counts — refresh
+      // the list so the history popover + its visibility rule stay current (#62).
+      void reloadConversationList(gen);
     } catch (e) {
+      if (gen !== switchGenRef.current) return;
       setError((prev) => prev ?? String(e));
       try {
         const h = await ipc.chatHistory(noteId, conversationId);
-        setMessages(h.messages);
+        if (gen === switchGenRef.current) setMessages(h.messages);
       } catch {
         /* keep the optimistic view */
       }
     } finally {
-      setStreaming("");
-      setActivity(null);
-      setSending(false);
-      sendingRef.current = false;
+      if (gen === switchGenRef.current) {
+        setStreaming("");
+        setActivity(null);
+        setSending(false);
+        sendingRef.current = false;
+      }
     }
   }
 

--- a/src/components/SelectablePopover.test.tsx
+++ b/src/components/SelectablePopover.test.tsx
@@ -122,6 +122,35 @@ describe("SelectablePopover", () => {
     expect(screen.getByText("yesterday")).toBeInTheDocument();
   });
 
+  it("anchors the menu's left edge to the trigger by default", () => {
+    render(
+      <SelectablePopover ariaLabel="Menu" trigger={<span>Open</span>} items={items} activeId="c1" onSelect={vi.fn()} />,
+    );
+    open("Menu");
+    const menu = screen.getByRole("menu");
+    // left is pinned (0px in jsdom's zero-rect), right is left unset.
+    expect(menu.style.left).toBe("0px");
+    expect(menu.style.right).toBe("");
+  });
+
+  it("anchors the menu's right edge to the trigger with align='end' (#62)", () => {
+    render(
+      <SelectablePopover
+        ariaLabel="Menu"
+        align="end"
+        trigger={<span>Open</span>}
+        items={items}
+        activeId="c1"
+        onSelect={vi.fn()}
+      />,
+    );
+    open("Menu");
+    const menu = screen.getByRole("menu");
+    // right is pinned, left is left unset — so it opens leftward, not past the edge.
+    expect(menu.style.right).not.toBe("");
+    expect(menu.style.left).toBe("");
+  });
+
   it("is a plain checkmark menu when no edit callbacks are given (Scope-popover mode)", () => {
     render(
       <SelectablePopover ariaLabel="Scope" trigger={<span>All notes</span>} items={items} activeId="c1" onSelect={vi.fn()} />,

--- a/src/components/SelectablePopover.test.tsx
+++ b/src/components/SelectablePopover.test.tsx
@@ -101,6 +101,27 @@ describe("SelectablePopover", () => {
     expect(onDelete).toHaveBeenCalledWith("c2");
   });
 
+  it("renders an optional secondary description line under a row (#62)", () => {
+    const withDesc = [
+      { id: "c1", label: "Kickoff questions", description: "5m ago" },
+      { id: "c2", label: "New chat", description: "yesterday" },
+    ];
+    render(
+      <SelectablePopover
+        ariaLabel="Chat history"
+        trigger={<span>History</span>}
+        items={withDesc}
+        activeId="c1"
+        onSelect={vi.fn()}
+      />,
+    );
+    open("Chat history");
+    // Both the primary label and its relative-date secondary line render.
+    expect(screen.getByRole("menuitemradio", { name: /Kickoff questions/ })).toBeInTheDocument();
+    expect(screen.getByText("5m ago")).toBeInTheDocument();
+    expect(screen.getByText("yesterday")).toBeInTheDocument();
+  });
+
   it("is a plain checkmark menu when no edit callbacks are given (Scope-popover mode)", () => {
     render(
       <SelectablePopover ariaLabel="Scope" trigger={<span>All notes</span>} items={items} activeId="c1" onSelect={vi.fn()} />,

--- a/src/components/SelectablePopover.tsx
+++ b/src/components/SelectablePopover.tsx
@@ -13,7 +13,12 @@ import { Check, Pencil, Trash2, Plus } from "lucide-react";
 // when there's no room below, and closes on outside-click / Escape / scroll.
 // No new UI dependency.
 
-export type PopoverItem = { id: string; label: string };
+export type PopoverItem = {
+  id: string;
+  label: string;
+  /** Optional muted second line under the label (e.g. a relative date, #62). */
+  description?: string;
+};
 
 type Props = {
   trigger: ReactNode;
@@ -248,7 +253,14 @@ export function SelectablePopover({
                       aria-hidden
                       className={"shrink-0 " + (selected ? "text-[var(--color-accent-text)]" : "opacity-0")}
                     />
-                    <span className="truncate">{item.label}</span>
+                    <span className="flex min-w-0 flex-col">
+                      <span className="truncate">{item.label}</span>
+                      {item.description && (
+                        <span className="truncate text-xs text-[var(--color-text-muted)]">
+                          {item.description}
+                        </span>
+                      )}
+                    </span>
                   </button>
                   {editable && (
                     <span className="flex items-center opacity-0 group-hover:opacity-100 transition-opacity pr-1">

--- a/src/components/SelectablePopover.tsx
+++ b/src/components/SelectablePopover.tsx
@@ -36,6 +36,13 @@ type Props = {
   createPlaceholder?: string;
   /** Accessible name for the trigger. */
   ariaLabel?: string;
+  /**
+   * Horizontal anchor. "start" (default) pins the menu's left edge to the
+   * trigger's left edge (existing behavior). "end" pins its right edge to the
+   * trigger's right edge, so a right-aligned trigger opens leftward instead of
+   * overflowing the viewport (#62).
+   */
+  align?: "start" | "end";
 };
 
 export function SelectablePopover({
@@ -50,6 +57,7 @@ export function SelectablePopover({
   createLabel = "New",
   createPlaceholder = "Name",
   ariaLabel,
+  align = "start",
 }: Props) {
   const [open, setOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -60,7 +68,9 @@ export function SelectablePopover({
   const [pos, setPos] = useState<{
     top?: number;
     bottom?: number;
-    left: number;
+    // Exactly one of left/right is set, per `align`.
+    left?: number;
+    right?: number;
     minWidth: number;
     maxHeight: number;
   } | null>(null);
@@ -87,14 +97,17 @@ export function SelectablePopover({
     const preferredMax = 280;
     const spaceBelow = window.innerHeight - rect.bottom - gap - edgeMargin;
     const spaceAbove = rect.top - gap - edgeMargin;
-    const left = rect.left;
+    // Anchor the left edge to the trigger's left ("start") or the right edge to
+    // the trigger's right ("end") so a right-aligned trigger opens leftward.
+    const anchor =
+      align === "end" ? { right: window.innerWidth - rect.right } : { left: rect.left };
     const minWidth = Math.max(rect.width, 200);
     if (spaceBelow >= Math.min(preferredMax, 150) || spaceBelow >= spaceAbove) {
-      setPos({ top: rect.bottom + gap, left, minWidth, maxHeight: Math.max(120, Math.min(preferredMax, spaceBelow)) });
+      setPos({ ...anchor, top: rect.bottom + gap, minWidth, maxHeight: Math.max(120, Math.min(preferredMax, spaceBelow)) });
     } else {
-      setPos({ bottom: window.innerHeight - rect.top + gap, left, minWidth, maxHeight: Math.max(120, Math.min(preferredMax, spaceAbove)) });
+      setPos({ ...anchor, bottom: window.innerHeight - rect.top + gap, minWidth, maxHeight: Math.max(120, Math.min(preferredMax, spaceAbove)) });
     }
-  }, [open]);
+  }, [open, align]);
 
   useEffect(() => {
     if (!open) return;
@@ -180,6 +193,7 @@ export function SelectablePopover({
               top: pos.top,
               bottom: pos.bottom,
               left: pos.left,
+              right: pos.right,
               minWidth: pos.minWidth,
               maxHeight: pos.maxHeight,
             }}

--- a/src/lib/chatSessions.test.ts
+++ b/src/lib/chatSessions.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { relativeTime, conversationTitle } from "./chatSessions";
+
+const NOW = new Date("2026-07-24T12:00:00").getTime();
+const secs = (n: number) => NOW - n * 1000;
+const mins = (n: number) => NOW - n * 60_000;
+const hrs = (n: number) => NOW - n * 3_600_000;
+const days = (n: number) => NOW - n * 86_400_000;
+
+describe("relativeTime", () => {
+  it("reads as 'just now' for the whole first minute (no 0m dead zone)", () => {
+    expect(relativeTime(NOW, NOW)).toBe("just now");
+    expect(relativeTime(secs(10), NOW)).toBe("just now");
+    expect(relativeTime(secs(44), NOW)).toBe("just now");
+    expect(relativeTime(secs(59), NOW)).toBe("just now");
+  });
+
+  it("counts minutes under an hour, starting at 60s", () => {
+    expect(relativeTime(secs(60), NOW)).toBe("1m ago");
+    expect(relativeTime(mins(5), NOW)).toBe("5m ago");
+    expect(relativeTime(mins(59), NOW)).toBe("59m ago");
+  });
+
+  it("counts hours under a day", () => {
+    expect(relativeTime(hrs(1), NOW)).toBe("1h ago");
+    expect(relativeTime(hrs(23), NOW)).toBe("23h ago");
+  });
+
+  it("says 'yesterday' one calendar day back", () => {
+    expect(relativeTime(days(1), NOW)).toBe("yesterday");
+  });
+
+  it("counts days within the past week", () => {
+    expect(relativeTime(days(3), NOW)).toBe("3d ago");
+    expect(relativeTime(days(6), NOW)).toBe("6d ago");
+  });
+
+  it("falls back to a locale date beyond a week", () => {
+    const older = days(30);
+    expect(relativeTime(older, NOW)).toBe(
+      new Date(older).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+    );
+  });
+
+  it("includes the year for a date in a different year", () => {
+    const lastYear = new Date("2025-01-02T12:00:00").getTime();
+    expect(relativeTime(lastYear, NOW)).toBe(
+      new Date(lastYear).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      }),
+    );
+  });
+
+  it("never renders a future timestamp as negative", () => {
+    expect(relativeTime(NOW + 5_000, NOW)).toBe("just now");
+  });
+});
+
+describe("conversationTitle", () => {
+  it("uses the stored title when present", () => {
+    expect(conversationTitle({ title: "Kickoff questions" })).toBe("Kickoff questions");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(conversationTitle({ title: "  Trimmed  " })).toBe("Trimmed");
+  });
+
+  it("falls back to 'New chat' for an empty or whitespace title", () => {
+    expect(conversationTitle({ title: "" })).toBe("New chat");
+    expect(conversationTitle({ title: "   " })).toBe("New chat");
+  });
+});

--- a/src/lib/chatSessions.ts
+++ b/src/lib/chatSessions.ts
@@ -1,0 +1,41 @@
+// Display helpers for the chat history popover (issue #62). Kept pure and
+// framework-free so they unit-test without rendering. `relativeTime` is generic
+// enough to hoist to a shared module if a second caller ever appears; for now
+// the chat history list is its only consumer.
+
+// A short, human relative timestamp: "just now" / "5m ago" / "3h ago" /
+// "yesterday" / "4d ago", then a locale date past a week (with the year only
+// when it differs). `now` is injectable for deterministic tests.
+export function relativeTime(ts: number, now: number = Date.now()): string {
+  const diffMs = Math.max(0, now - ts);
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+
+  // Beyond a day, count whole calendar days so "yesterday" tracks the date
+  // boundary rather than a rolling 24h window.
+  const then = new Date(ts);
+  then.setHours(0, 0, 0, 0);
+  const midnight = new Date(now);
+  midnight.setHours(0, 0, 0, 0);
+  const dayDiff = Math.round((midnight.getTime() - then.getTime()) / 86_400_000);
+  if (dayDiff <= 1) return "yesterday";
+  if (dayDiff < 7) return `${dayDiff}d ago`;
+
+  const sameYear = new Date(ts).getFullYear() === new Date(now).getFullYear();
+  return new Date(ts).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
+}
+
+// The title shown for a conversation row. Titles can be NULL/empty (legacy
+// workspace threads, unsent conversations); fall back to a quiet, consistent
+// label — the relative date rides alongside as the row's secondary line.
+export function conversationTitle(meta: { title: string }): string {
+  return meta.title.trim() || "New chat";
+}

--- a/src/pages/Note.tsx
+++ b/src/pages/Note.tsx
@@ -22,6 +22,7 @@ import {
   MessageSquare,
   MoreHorizontal,
   PanelRight,
+  Plus,
   RefreshCw,
   Sparkles,
   Users,
@@ -37,8 +38,9 @@ import { SpeakerLabels, speakerColorMap } from "../components/SpeakerLabels";
 import { RecordingSessions } from "../components/RecordingSessions";
 import { groupTimeline, resolveActivePill, formatSessionCaption } from "../lib/sessions";
 import { RecordingBar } from "../components/RecordingBar";
-import { ChatPanel } from "../components/ChatPanel";
+import { ChatPanel, type ChatSessionControls } from "../components/ChatPanel";
 import { SelectablePopover } from "../components/SelectablePopover";
+import { conversationTitle, relativeTime } from "../lib/chatSessions";
 import type { LayoutOutletContext } from "../components/Layout";
 import { SkeletonLines } from "../components/Skeleton";
 import { NoteEditor } from "../components/Editor";
@@ -127,6 +129,11 @@ export function Note() {
   const [thinkingExpanded, setThinkingExpanded] = useState<boolean>(true);
   const [panelOpen, setPanelOpen] = useState<boolean>(true);
   const [activeTab, setActiveTab] = useState<"summary" | "transcript" | "chat">("summary");
+  // Chat session chrome for the panel header (issue #62). ChatPanel owns all
+  // chat state and publishes this projection up; the header's +/history buttons
+  // render purely from it. null = no chat chrome (provider not ready / no tab).
+  const [chatControls, setChatControls] = useState<ChatSessionControls | null>(null);
+  const handleChatControls = useCallback((c: ChatSessionControls | null) => setChatControls(c), []);
   const [panelWidth, setPanelWidth] = useState<number>(() => {
     const saved = typeof localStorage !== "undefined" ? Number(localStorage.getItem("humla.panelWidth")) : NaN;
     return saved >= 320 && saved <= 720 ? saved : 440;
@@ -831,6 +838,9 @@ export function Note() {
                 Chat
               </button>
             </div>
+            {activeTab === "chat" && chatControls?.noteId === draft.id && (
+              <ChatHistoryControls controls={chatControls} />
+            )}
             <button
               type="button"
               onClick={() => setPanelOpen(false)}
@@ -919,7 +929,7 @@ export function Note() {
                 )}
               </div>
             ) : activeTab === "chat" ? (
-              <ChatPanel noteId={draft.id} />
+              <ChatPanel noteId={draft.id} onControls={handleChatControls} />
             ) : (
               <div className="flex-1 min-h-0 flex flex-col px-4 py-4">
                 <div className="flex flex-wrap items-center gap-2 mb-4 shrink-0">
@@ -1341,6 +1351,52 @@ function FolderPicker({
 }
 
 // Per-Note Client picker (issue #43). Built on the reusable
+// Chat session chrome for the panel header (issue #62): a "+" that starts a
+// fresh conversation and a history button opening a popover of this Note's
+// conversations (title + relative date, most recent first, current one marked).
+// Selecting one loads it. The history button is hidden for a lone empty
+// conversation — the panel decides that via `canBrowseHistory`. All state lives
+// in ChatPanel; this only renders the projection it publishes.
+function ChatHistoryControls({ controls }: { controls: ChatSessionControls }) {
+  const { conversations, activeConversationId, canBrowseHistory, newChat, openConversation } =
+    controls;
+  const items = [...conversations]
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .map((c) => ({
+      id: c.id,
+      label: conversationTitle(c),
+      description: relativeTime(c.updatedAt),
+    }));
+  return (
+    <div className="flex items-center gap-0.5">
+      <button
+        type="button"
+        onClick={() => void newChat()}
+        title="New chat"
+        aria-label="New chat"
+        className="nd-btn-icon"
+      >
+        <Plus size={16} strokeWidth={1.7} aria-hidden="true" />
+      </button>
+      {canBrowseHistory && (
+        <SelectablePopover
+          ariaLabel="Chat history"
+          items={items}
+          activeId={activeConversationId}
+          onSelect={(id) => {
+            if (id) void openConversation(id);
+          }}
+          trigger={
+            <span className="nd-btn-icon" title="Chat history">
+              <History size={16} strokeWidth={1.7} aria-hidden="true" />
+            </span>
+          }
+        />
+      )}
+    </div>
+  );
+}
+
 // SelectablePopover primitive: assign / reassign / unassign plus full inline
 // create / rename / delete — all Client management lives here (there's no
 // browse-by-Client surface). Mirrors FolderPicker's placement but is richer,

--- a/src/pages/Note.tsx
+++ b/src/pages/Note.tsx
@@ -1381,6 +1381,7 @@ function ChatHistoryControls({ controls }: { controls: ChatSessionControls }) {
       {canBrowseHistory && (
         <SelectablePopover
           ariaLabel="Chat history"
+          align="end"
           items={items}
           activeId={activeConversationId}
           onSelect={(id) => {


### PR DESCRIPTION
Closes #62 (child of #60).

First user-facing slice of chat sessions, on top of the #61 data model:

- **"+" and history buttons** in the note panel header (chat tab only, `nd-btn-icon` vocabulary, right of the tabs beside close). "+" starts a fresh conversation (backend no-op guard + breadth inheritance); the history popover lists this note's conversations — title with "New chat" fallback, relative date, most recent first, current marked. Selecting loads that conversation's messages and stored breadth.
- **Empty state**: history button hides when there's nothing to browse (lone empty conversation), no flicker while the list loads; teammates' workspace conversations count as browsable.
- **State design**: ChatPanel stays the sole owner of chat state, publishing a controls projection to Note.tsx; a switch-generation guard keeps late-resolving fetches and in-flight streams from leaking across conversation switches (incl. the initial per-note load — race found in review, fixed with a regression test).
- **SelectablePopover**: backward-compatible `description` line + `align="end"` right-anchoring (fixes the off-screen clipping found in manual testing; other call sites unchanged).
- New `chatSessions` helpers (relativeTime, conversationTitle) with unit tests.

Deferred to #64: popover focus-restore-to-trigger (pre-existing primitive behavior, noted there).

Tests: frontend 207 passed, `tsc --noEmit` clean, backend untouched (314 passed). Two-axis code review run pre-commit; manually verified in the running app (popover placement re-tested after the alignment fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)