### PR TITLE
feat(chat): composer breadth picker, workspace context line, redesign styling (#63)

### DIFF
--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -455,7 +455,13 @@ describe("ChatPanel composer breadth + chrome (#63)", () => {
     renderPanel();
     await screen.findByText("Here's the answer.");
     // Aggregated, past-tense, one line — search then a pluralised read count.
-    expect(screen.getByText("Searched your notes · Read 2 notes")).toBeInTheDocument();
+    const line = screen.getByText("Searched your notes · Read 2 notes");
+    expect(line).toBeInTheDocument();
+    // Reads like body text: same size as the answer (text-sm, not text-xs) and
+    // flush-left with the answer block (no px inset), with paragraph margins.
+    expect(line.className).toContain("text-sm");
+    expect(line.className).not.toContain("text-xs");
+    expect(line.className).not.toContain("px-1");
   });
 
   it("shows no tool-use line for an answer that used no tools", async () => {

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -57,6 +57,21 @@ function assistantWithCitation(text: string): ChatMessageDto {
   };
 }
 
+// An assistant turn that ran one or more tools (#63), for the persistent
+// tool-use receipt above the answer.
+function assistantWithTools(text: string, tools: string[]): ChatMessageDto {
+  return {
+    id: "a3",
+    role: "assistant",
+    seq: 1,
+    parts: [
+      ...tools.map((name, i) => ({ type: "tool" as const, id: `t${i}`, name, result: "ok" })),
+      { type: "text" as const, id: "b1", text },
+    ],
+    createdAt: 3,
+  };
+}
+
 // `chat_history` returns { conversationId, messages } since #61; a non-empty
 // history implies a resolved session id.
 function history(messages: ChatMessageDto[] = []) {
@@ -195,9 +210,11 @@ describe("ChatPanel context pinning (#58)", () => {
     signIntoWorkspace("Acme Team");
     renderPanel();
     // A muted line above the thread, exact copy per the ticket.
-    expect(
-      await screen.findByText("Chatting in Acme Team · visible to members"),
-    ).toBeInTheDocument();
+    const line = await screen.findByText("Chatting in Acme Team · visible to members");
+    expect(line).toBeInTheDocument();
+    // It owns its vertical space with a bottom hairline so scrolled message
+    // content passes beneath a proper boundary rather than colliding with it.
+    expect(line.className).toContain("border-b");
   });
 
   it("renders no context line in personal (signed out) (#63)", async () => {
@@ -424,6 +441,50 @@ describe("ChatPanel composer breadth + chrome (#63)", () => {
     renderPanel();
     const chip = await screen.findByRole("button", { name: /Kickoff notes/ });
     expect(chip.className).not.toContain("nd-chip");
+  });
+
+  it("shows a persistent, aggregated tool-use line above a tool-using answer", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () =>
+        history([
+          userMsg("what happened?"),
+          assistantWithTools("Here's the answer.", ["search_notes", "get_note", "get_note"]),
+        ]),
+    });
+    renderPanel();
+    await screen.findByText("Here's the answer.");
+    // Aggregated, past-tense, one line — search then a pluralised read count.
+    expect(screen.getByText("Searched your notes · Read 2 notes")).toBeInTheDocument();
+  });
+
+  it("shows no tool-use line for an answer that used no tools", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history([userMsg("hi"), assistantMsg("Plain answer.")]),
+    });
+    renderPanel();
+    await screen.findByText("Plain answer.");
+    expect(
+      screen.queryByText(/Searched your notes|Read a note|Read \d+ notes|Browsed your notes|Used a tool/),
+    ).toBeNull();
+  });
+
+  it("drops the assistant bubble and puts user messages in the gray bubble", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history([userMsg("my question"), assistantMsg("the answer")]),
+    });
+    renderPanel();
+    // User turn: right-aligned gray bubble (not the old amber accent pair).
+    const userBubble = (await screen.findByText("my question")).parentElement!;
+    expect(userBubble.className).toContain("bg-[var(--color-pill-hover)]");
+    expect(userBubble.className).not.toContain("accent-soft");
+    // Assistant turn: plain block, no bubble background / rounding.
+    const answerBlock = screen.getByText("the answer").parentElement!;
+    expect(answerBlock.className).toContain("prose-summary");
+    expect(answerBlock.className).not.toContain("rounded-[var(--radius-card)]");
+    expect(answerBlock.className).not.toContain("bg-[var(--color-pill-hover)]");
   });
 
   it("animates the thinking indicator with a reduced-motion guard", async () => {

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -3,8 +3,17 @@ import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom";
 import { ChatPanel, type ChatSessionControls } from "./ChatPanel";
 import { mockTauri } from "../test/tauri";
-import type { ChatMessageDto } from "../lib/ipc";
+import type { ChatMessageDto, Folder, Note } from "../lib/ipc";
 import { useCloudStore, DISCONNECTED } from "../lib/cloud";
+import { useNotesStore } from "../lib/store";
+
+// A minimal note carrying a folder, so the composer breadth picker's
+// "Folder: {name}" option appears (#63). Only the fields ChatPanel reads matter.
+function seedNoteWithFolder(noteId = "n1", folderName = "Roadmap") {
+  const note = { id: noteId, folder_id: "f1" } as unknown as Note;
+  const folder = { id: "f1", name: folderName } as unknown as Folder;
+  useNotesStore.setState({ notes: [note], folders: [folder] });
+}
 
 // Populate the cloud store as if signed into a workspace, so the Teams tenant
 // row appears (issue #50).
@@ -84,6 +93,8 @@ beforeEach(() => {
   mockTauri();
   // Default: signed out, so Personal is the only tenant unless a test opts in.
   useCloudStore.setState({ status: DISCONNECTED });
+  // No note/folder seeded by default (breadth picker shows no folder option).
+  useNotesStore.setState({ notes: [], folders: [] });
 });
 
 describe("ChatPanel readiness", () => {
@@ -179,21 +190,23 @@ describe("ChatPanel context pinning (#58)", () => {
     expect(screen.queryByRole("button", { name: "Chat tenant" })).toBeNull();
   });
 
-  it("shows the workspace name as a non-interactive context indicator", async () => {
+  it("shows the workspace context line in a workspace (#63)", async () => {
     mockTauri({ provider_key_get: () => "sk-test", chat_history: () => history() });
     signIntoWorkspace("Acme Team");
     renderPanel();
-    // The indicator shows where chat goes; it is not a button (no popover).
-    const indicator = await screen.findByLabelText("Chat context");
-    expect(indicator).toHaveTextContent("Acme Team");
-    expect(indicator.tagName).not.toBe("BUTTON");
+    // A muted line above the thread, exact copy per the ticket.
+    expect(
+      await screen.findByText("Chatting in Acme Team · visible to members"),
+    ).toBeInTheDocument();
   });
 
-  it("shows Personal as the context indicator when signed out", async () => {
+  it("renders no context line in personal (signed out) (#63)", async () => {
     mockTauri({ provider_key_get: () => "sk-test", chat_history: () => history() });
     renderPanel();
-    const indicator = await screen.findByLabelText("Chat context");
-    expect(indicator).toHaveTextContent("Personal");
+    await screen.findByPlaceholderText(/Ask about your notes/);
+    // Personal context shows nothing — no indicator at all.
+    expect(screen.queryByText(/visible to members/)).toBeNull();
+    expect(screen.queryByText(/Chatting in/)).toBeNull();
   });
 });
 
@@ -378,5 +391,63 @@ describe("ChatPanel scope breadth (#58)", () => {
     fireEvent.click(await screen.findByText("All notes"));
     await waitFor(() => expect(setArgs?.breadth).toBe("all"));
     expect(setArgs?.noteId).toBe("n1");
+  });
+});
+
+describe("ChatPanel composer breadth + chrome (#63)", () => {
+  it("shows the current breadth on the composer trigger (not just inside the popover)", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_get_breadth: () => "all",
+    });
+    renderPanel();
+    const trigger = await screen.findByRole("button", { name: "Chat scope" });
+    // The active breadth is always visible on the trigger itself.
+    await waitFor(() => expect(trigger).toHaveTextContent("All notes"));
+  });
+
+  it("offers 'Folder: {name}' only when the note has a folder", async () => {
+    seedNoteWithFolder("n1", "Roadmap");
+    mockTauri({ provider_key_get: () => "sk-test", chat_history: () => history() });
+    renderPanel();
+    fireEvent.click(await screen.findByRole("button", { name: "Chat scope" }));
+    expect(await screen.findByText("Folder: Roadmap")).toBeInTheDocument();
+  });
+
+  it("renders the citation chip without the uppercase-mono nd-chip class", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () =>
+        history([userMsg("what happened?"), assistantWithCitation("Here's what I found.")]),
+    });
+    renderPanel();
+    const chip = await screen.findByRole("button", { name: /Kickoff notes/ });
+    expect(chip.className).not.toContain("nd-chip");
+  });
+
+  it("animates the thinking indicator with a reduced-motion guard", async () => {
+    let releaseSend: (() => void) | null = null;
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_send: () =>
+        new Promise((resolve) => {
+          releaseSend = () => resolve({ conversationId: "c1", truncated: false });
+        }),
+    });
+    renderPanel();
+    const input = await screen.findByPlaceholderText(/Ask about your notes/);
+    fireEvent.change(input, { target: { value: "hi" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    // While the send is in flight the thinking line shows, animated but gated
+    // behind prefers-reduced-motion. The activity line shares these classes.
+    const thinking = await screen.findByText("Thinking…");
+    expect(thinking.className).toContain("animate-pulse");
+    expect(thinking.className).toContain("motion-reduce:animate-none");
+    await act(async () => {
+      releaseSend?.();
+      await Promise.resolve();
+    });
   });
 });

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -6,10 +6,10 @@ import { open as openExternal } from "@tauri-apps/plugin-shell";
 import {
   AlertTriangle,
   ChevronDown,
+  CornerDownLeft,
   FileText,
   Loader2,
   MessageCircle,
-  Send,
   Settings2,
 } from "lucide-react";
 import {
@@ -75,6 +75,43 @@ function toolActivityLabel(name: string): string {
       return "Browsing your notes…";
     default:
       return "Working…";
+  }
+}
+
+// Past-tense, aggregated summary of the tools an assistant turn used (#63), for
+// a persistent one-line receipt above the answer (like Claude Desktop's tool
+// rows), e.g. "Searched your notes · Read 2 notes". Returns null when the turn
+// used no tools. History, not progress — the caller renders it un-animated,
+// unlike the live activity line.
+function summarizeToolUse(m: ChatMessageDto): string | null {
+  const counts = new Map<string, number>();
+  for (const p of m.parts) {
+    if (p.type === "tool") counts.set(p.name, (counts.get(p.name) ?? 0) + 1);
+  }
+  if (counts.size === 0) return null;
+  const seen = new Set<string>();
+  const segments: string[] = [];
+  for (const [name, n] of counts) {
+    const label = toolPastLabel(name, n);
+    // Collapse duplicate labels (e.g. two distinct unknown tools → one "Used a tool").
+    if (!seen.has(label)) {
+      seen.add(label);
+      segments.push(label);
+    }
+  }
+  return segments.join(" · ");
+}
+
+function toolPastLabel(name: string, count: number): string {
+  switch (name) {
+    case "search_notes":
+      return "Searched your notes";
+    case "get_note":
+      return count === 1 ? "Read a note" : `Read ${count} notes`;
+    case "list_notes":
+      return "Browsed your notes";
+    default:
+      return "Used a tool";
   }
 }
 
@@ -457,10 +494,14 @@ export function ChatPanel({
   return (
     <div className="flex-1 min-h-0 flex flex-col">
       {/* Workspace context signal (#63): nothing in Personal; one muted line in
-          a workspace. No breadth/tenant chrome here — breadth moved to the
-          composer, and the tenant is pinned to the loaded workspace (#58). */}
+          a workspace. It sits OUTSIDE the scroll container as a fixed flex item,
+          so it stays visible as a privacy signal while messages scroll beneath
+          it. It must own its vertical space with a bottom hairline, or scrolled
+          bubbles butt straight up against the text with no separation. No
+          breadth/tenant chrome here — breadth moved to the composer, and the
+          tenant is pinned to the loaded workspace (#58). */}
       {workspaceName && (
-        <div className="shrink-0 px-4 pt-3 text-xs text-[var(--color-text-muted)]">
+        <div className="shrink-0 px-4 py-2 border-b border-[var(--color-line)] text-xs text-[var(--color-text-muted)]">
           Chatting in {workspaceName} · visible to members
         </div>
       )}
@@ -475,7 +516,13 @@ export function ChatPanel({
           </div>
         ) : (
           messages.map((m) => (
-            <Bubble key={m.id} role={m.role} text={partsText(m)} citations={messageCitations(m)} />
+            <Bubble
+              key={m.id}
+              role={m.role}
+              text={partsText(m)}
+              citations={messageCitations(m)}
+              toolSummary={summarizeToolUse(m)}
+            />
           ))
         )}
         {sending && streaming.length > 0 && (
@@ -514,7 +561,12 @@ export function ChatPanel({
       )}
 
       <div className="shrink-0 border-t border-[var(--color-line)] p-2.5 flex flex-col gap-1.5">
-        <div className="flex items-end gap-2">
+        {/* Send button lives INSIDE the input (Claude-Desktop style): the input
+            spans the full composer width, and the button is absolutely pinned to
+            its right edge. The textarea is single-line (rows=1, no auto-grow — it
+            scrolls internally), so the button is vertically centred; pr clears
+            the button so text never runs under it. */}
+        <div className="relative">
           <textarea
             value={input}
             onChange={(e) => setInput(e.target.value)}
@@ -522,7 +574,7 @@ export function ChatPanel({
             rows={1}
             placeholder="Ask about your notes…"
             disabled={sending}
-            className="flex-1 resize-none max-h-40 bg-transparent text-sm leading-relaxed px-2 py-1.5 outline-none placeholder:text-[var(--color-text-disabled)] disabled:opacity-60"
+            className="w-full resize-none max-h-40 bg-transparent text-sm leading-relaxed pl-2 pr-12 py-2 outline-none placeholder:text-[var(--color-text-disabled)] disabled:opacity-60"
           />
           <button
             type="button"
@@ -531,17 +583,18 @@ export function ChatPanel({
             title="Send"
             aria-label="Send"
             className={cn(
-              "nd-btn-icon shrink-0",
+              "nd-btn-icon absolute right-1.5 top-1/2 -translate-y-1/2",
               (sending || input.trim().length === 0) && "opacity-40 pointer-events-none",
             )}
           >
-            <Send size={16} strokeWidth={1.7} />
+            <CornerDownLeft size={16} strokeWidth={1.7} />
           </button>
         </div>
-        {/* Breadth picker, bottom-left (#63): the retrieval breadth was a chip in
-            the deleted ScopeBar row; it now lives in the composer as a quiet
-            labelled dropdown that always shows the current value. */}
-        <div className="flex items-center px-1">
+        {/* Composer control row (#63): breadth picker at bottom-left. Right side
+            is intentionally empty for now — justify-between reserves it for the
+            monthly turn-allowance display coming in a later issue, so adding it
+            won't need a layout restructure. */}
+        <div className="flex items-center justify-between px-1">
           <BreadthPicker
             scope={scope}
             onScope={selectBreadth}
@@ -597,32 +650,37 @@ function Bubble({
   role,
   text,
   citations,
+  toolSummary,
 }: {
   role: "user" | "assistant";
   text: string;
   citations: ChatCitation[];
+  // Persistent tool-use receipt for an assistant turn (#63), null when none.
+  toolSummary?: string | null;
 }) {
-  const isUser = role === "user";
-  return (
-    <div className={cn("flex flex-col", isUser ? "items-end" : "items-start")}>
-      <div
-        className={cn(
-          "max-w-[85%] rounded-[var(--radius-card)] px-3 py-2 text-sm leading-relaxed",
-          isUser
-            ? "bg-[var(--color-accent-soft)] text-[var(--color-accent-text)]"
-            : "bg-[var(--color-pill-hover)] text-[var(--color-text)]",
-        )}
-      >
-        {isUser ? (
+  // User turns keep a right-aligned bubble (now the quiet gray pair — authorship
+  // reads from alignment, #64). Assistant turns are plain full-width blocks on
+  // the canvas, Claude-Desktop style: no bubble, no background — just the answer,
+  // its tool-use receipt above, and citation chips below.
+  if (role === "user") {
+    return (
+      <div className="flex flex-col items-end">
+        <div className="max-w-[85%] rounded-[var(--radius-card)] px-3 py-2 text-sm leading-relaxed bg-[var(--color-pill-hover)] text-[var(--color-text)]">
           <span className="whitespace-pre-wrap">{text}</span>
-        ) : (
-          <div className="prose-summary">
-            <Markdown source={text} />
-          </div>
-        )}
+        </div>
       </div>
-      {!isUser && citations.length > 0 && (
-        <div className="mt-1.5 flex flex-wrap gap-1.5 max-w-[85%]">
+    );
+  }
+  return (
+    <div className="flex flex-col">
+      {toolSummary && (
+        <div className="mb-1 px-1 text-xs text-[var(--color-text-muted)]">{toolSummary}</div>
+      )}
+      <div className="prose-summary text-sm leading-relaxed text-[var(--color-text)]">
+        <Markdown source={text} />
+      </div>
+      {citations.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1.5">
           {citations.map((c) => (
             <CitationChip key={c.noteId} citation={c} />
           ))}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -3,7 +3,15 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useNavigate } from "react-router-dom";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
-import { AlertTriangle, FileText, Loader2, MessageCircle, Send, Settings2 } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  FileText,
+  Loader2,
+  MessageCircle,
+  Send,
+  Settings2,
+} from "lucide-react";
 import {
   ipc,
   onChatCitations,
@@ -448,12 +456,14 @@ export function ChatPanel({
 
   return (
     <div className="flex-1 min-h-0 flex flex-col">
-      <ScopeBar
-        scope={scope}
-        onScope={selectBreadth}
-        folderName={folder?.name ?? null}
-        workspaceName={workspaceName}
-      />
+      {/* Workspace context signal (#63): nothing in Personal; one muted line in
+          a workspace. No breadth/tenant chrome here — breadth moved to the
+          composer, and the tenant is pinned to the loaded workspace (#58). */}
+      {workspaceName && (
+        <div className="shrink-0 px-4 pt-3 text-xs text-[var(--color-text-muted)]">
+          Chatting in {workspaceName} · visible to members
+        </div>
+      )}
 
       <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-4 py-4 flex flex-col gap-3">
         {messages.length === 0 && !sending ? (
@@ -473,12 +483,20 @@ export function ChatPanel({
         )}
         {activity && (
           <div className="self-start flex items-center gap-1.5 text-xs text-[var(--color-text-muted)] px-1">
-            <Loader2 size={12} strokeWidth={2} className="animate-spin" />
-            {activity}
+            <Loader2
+              size={12}
+              strokeWidth={2}
+              aria-hidden="true"
+              className="animate-spin motion-reduce:animate-none"
+            />
+            {/* Same soft pulse as "Thinking…"; static under prefers-reduced-motion. */}
+            <span className="animate-pulse motion-reduce:animate-none">{activity}</span>
           </div>
         )}
         {showTyping && (
-          <div className="self-start text-xs text-[var(--color-text-muted)] px-1">Thinking…</div>
+          <div className="self-start text-xs text-[var(--color-text-muted)] px-1">
+            <span className="animate-pulse motion-reduce:animate-none">Thinking…</span>
+          </div>
         )}
       </div>
 
@@ -495,50 +513,60 @@ export function ChatPanel({
         </div>
       )}
 
-      <div className="shrink-0 border-t border-[var(--color-line)] p-2.5 flex items-end gap-2">
-        <textarea
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={onKeyDown}
-          rows={1}
-          placeholder="Ask about your notes…"
-          disabled={sending}
-          className="flex-1 resize-none max-h-40 bg-transparent text-sm leading-relaxed px-2 py-1.5 outline-none placeholder:text-[var(--color-text-disabled)] disabled:opacity-60"
-        />
-        <button
-          type="button"
-          onClick={() => void send()}
-          disabled={sending || input.trim().length === 0}
-          title="Send"
-          aria-label="Send"
-          className={cn(
-            "nd-btn-icon shrink-0",
-            (sending || input.trim().length === 0) && "opacity-40 pointer-events-none",
-          )}
-        >
-          <Send size={16} strokeWidth={1.7} />
-        </button>
+      <div className="shrink-0 border-t border-[var(--color-line)] p-2.5 flex flex-col gap-1.5">
+        <div className="flex items-end gap-2">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={onKeyDown}
+            rows={1}
+            placeholder="Ask about your notes…"
+            disabled={sending}
+            className="flex-1 resize-none max-h-40 bg-transparent text-sm leading-relaxed px-2 py-1.5 outline-none placeholder:text-[var(--color-text-disabled)] disabled:opacity-60"
+          />
+          <button
+            type="button"
+            onClick={() => void send()}
+            disabled={sending || input.trim().length === 0}
+            title="Send"
+            aria-label="Send"
+            className={cn(
+              "nd-btn-icon shrink-0",
+              (sending || input.trim().length === 0) && "opacity-40 pointer-events-none",
+            )}
+          >
+            <Send size={16} strokeWidth={1.7} />
+          </button>
+        </div>
+        {/* Breadth picker, bottom-left (#63): the retrieval breadth was a chip in
+            the deleted ScopeBar row; it now lives in the composer as a quiet
+            labelled dropdown that always shows the current value. */}
+        <div className="flex items-center px-1">
+          <BreadthPicker
+            scope={scope}
+            onScope={selectBreadth}
+            folderName={folder?.name ?? null}
+          />
+        </div>
       </div>
     </div>
   );
 }
 
-// Context indicator + breadth selector at the top of the chat. The chat is
-// pinned to the loaded context (issue #58): a non-interactive indicator shows
-// where chat goes (the active workspace name, or "Personal") — there is no
-// tenant picker, since the sidebar WorkspaceSwitcher is the source of truth.
-// "This folder" only appears when the note has a folder (nothing to widen to
-// otherwise).
-function ScopeBar({
+// Retrieval-breadth picker for the composer (#63). A quiet, sentence-case
+// labelled dropdown — not a chip, not bordered — that always shows the current
+// breadth on the trigger (fixing the old bug where the active value only
+// appeared inside the popover). Semantics unchanged (issue #58): per-
+// conversation, persisted via chat_set_breadth. "Folder: {name}" only appears
+// when the note has a folder (nothing to widen to otherwise).
+function BreadthPicker({
   scope,
   onScope,
   folderName,
-  workspaceName,
 }: {
   scope: ChatScope;
   onScope: (s: ChatScope) => void;
   folderName: string | null;
-  workspaceName: string | null;
 }) {
   const items: PopoverItem[] = [
     { id: "note", label: "This note" },
@@ -550,32 +578,18 @@ function ScopeBar({
   const label = items.find((i) => i.id === activeId)?.label ?? "This note";
 
   return (
-    <div className="shrink-0 flex items-center gap-2 px-4 py-2 border-b border-[var(--color-line)]">
-      <span
-        aria-label="Chat context"
-        title={
-          workspaceName
-            ? `Chatting in ${workspaceName} — follows the workspace loaded in the sidebar`
-            : "Chatting in Personal (on-device)"
-        }
-        className="nd-chip inline-flex items-center gap-1 text-xs"
-      >
-        {workspaceName ?? "Personal"}
-      </span>
-      <span className="text-xs text-[var(--color-text-disabled)]">·</span>
-      <span className="text-xs text-[var(--color-text-disabled)]">Search</span>
-      <SelectablePopover
-        ariaLabel="Chat scope"
-        items={items}
-        activeId={activeId}
-        onSelect={(id) => onScope((id as ChatScope) ?? "note")}
-        trigger={
-          <span className="nd-chip inline-flex items-center gap-1 text-xs cursor-pointer">
-            {label}
-          </span>
-        }
-      />
-    </div>
+    <SelectablePopover
+      ariaLabel="Chat scope"
+      items={items}
+      activeId={activeId}
+      onSelect={(id) => onScope((id as ChatScope) ?? "note")}
+      trigger={
+        <span className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] cursor-pointer hover:text-[var(--color-text)] transition-colors">
+          {label}
+          <ChevronDown size={12} strokeWidth={2} aria-hidden="true" className="shrink-0" />
+        </span>
+      }
+    />
   );
 }
 
@@ -627,9 +641,11 @@ function CitationChip({ citation }: { citation: ChatCitation }) {
       type="button"
       onClick={() => navigate(`/note/${citation.noteId}`)}
       title={`Open “${title}” (${date})`}
-      className="nd-chip inline-flex items-center gap-1 text-xs cursor-pointer hover:text-[var(--color-text)]"
+      // Sentence-case, quiet chip built from existing tokens (no nd-chip, so no
+      // uppercase mono per design/REFACTOR.md typography rules, #63).
+      className="inline-flex items-center gap-1 rounded-[var(--radius)] border border-[var(--color-line-visible)] bg-[var(--color-surface)] px-2 py-1 text-xs text-[var(--color-text-muted)] cursor-pointer transition-colors hover:text-[var(--color-text)] hover:border-[var(--color-text-muted)]"
     >
-      <FileText size={11} strokeWidth={1.7} className="shrink-0" />
+      <FileText size={11} strokeWidth={1.7} aria-hidden="true" className="shrink-0" />
       <span className="truncate max-w-[16rem]">{title}</span>
     </button>
   );

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -563,9 +563,11 @@ export function ChatPanel({
       <div className="shrink-0 border-t border-[var(--color-line)] p-2.5 flex flex-col gap-1.5">
         {/* Send button lives INSIDE the input (Claude-Desktop style): the input
             spans the full composer width, and the button is absolutely pinned to
-            its right edge. The textarea is single-line (rows=1, no auto-grow — it
-            scrolls internally), so the button is vertically centred; pr clears
-            the button so text never runs under it. */}
+            its right edge. The textarea is `block` so it has no inline-block
+            baseline gap — the relative wrapper's height then equals the visible
+            input's height, and `top-1/2 -translate-y-1/2` centres the button
+            against the true input height (no pixel nudging). The small icon-button
+            variant (28px) fits comfortably inside without touching the edges. */}
         <div className="relative">
           <textarea
             value={input}
@@ -574,7 +576,7 @@ export function ChatPanel({
             rows={1}
             placeholder="Ask about your notes…"
             disabled={sending}
-            className="w-full resize-none max-h-40 bg-transparent text-sm leading-relaxed pl-2 pr-12 py-2 outline-none placeholder:text-[var(--color-text-disabled)] disabled:opacity-60"
+            className="block w-full resize-none max-h-40 bg-transparent text-sm leading-relaxed pl-2 pr-11 py-2 outline-none placeholder:text-[var(--color-text-disabled)] disabled:opacity-60"
           />
           <button
             type="button"
@@ -583,7 +585,7 @@ export function ChatPanel({
             title="Send"
             aria-label="Send"
             className={cn(
-              "nd-btn-icon absolute right-1.5 top-1/2 -translate-y-1/2",
+              "nd-btn-icon nd-btn-icon-sm absolute right-1.5 top-1/2 -translate-y-1/2",
               (sending || input.trim().length === 0) && "opacity-40 pointer-events-none",
             )}
           >
@@ -674,7 +676,11 @@ function Bubble({
   return (
     <div className="flex flex-col">
       {toolSummary && (
-        <div className="mb-1 px-1 text-xs text-[var(--color-text-muted)]">{toolSummary}</div>
+        // Reads like a paragraph of the answer: same body size (text-sm) and
+        // left edge as the answer block (no inset), with margin above and below
+        // so it isn't flush against neighbouring turns. Muted, since it's a
+        // secondary receipt of what the assistant did (#63).
+        <div className="my-1.5 text-sm text-[var(--color-text-muted)]">{toolSummary}</div>
       )}
       <div className="prose-summary text-sm leading-relaxed text-[var(--color-text)]">
         <Markdown source={text} />


### PR DESCRIPTION
Closes #63 (child of #60).

The chat pane's chrome catches up with the redesign, plus transcript/composer polish from three rounds of in-app review:

- **ScopeBar deleted** — no workspace chip, no "Search" label, no separator, no header breadth pill.
- **Breadth picker in the composer** (bottom-left): quiet sentence-case dropdown ("This note" / "Folder: {name}" / "All notes"), current value always visible on the trigger; semantics unchanged (per-conversation, `chat_set_breadth`, folder option only when the note has one).
- **Workspace context line**: nothing in personal; in a workspace one muted, properly bounded line above the thread — "Chatting in {workspace} · visible to members".
- **Claude-Desktop-style transcript**: assistant answers as plain full-width blocks (no bubble), user messages in the gray right-aligned bubble, and a persistent past-tense tool-use line above each answer ("Searched your notes · Read 2 notes") derived from persisted message parts.
- **Composer**: full-width input, ↵ return-glyph send button inside it (centered structurally — the textarea's inline-block baseline gap was the misalignment root cause), row ready for the #69 turn-allowance display.
- **Animations**: "Thinking…" and the live activity line share a soft pulse, static under `prefers-reduced-motion`.
- **No uppercase mono remains in the pane**; CitationChip restyled sentence-case; `.nd-chip` utility untouched elsewhere; message-bubble AA contrast preserved.

Follow-ups tracked: turn-allowance display (#69, blocked by michaelwilhelmsen/humla-cloud#21), focus polish (#64).

Tests: frontend 214 passed, `tsc --noEmit` clean, backend untouched. Two-axis code review clean on both axes; user-verified in the running app across three feedback rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)