### PR TITLE
feat(chat): workspace turn-allowance meter in the composer (#69)

### DIFF
--- a/src-tauri/src/chat/cloud.rs
+++ b/src-tauri/src/chat/cloud.rs
@@ -10,6 +10,7 @@
 //! user-message mapping — so they're unit-testable. The streaming orchestration
 //! (reqwest + emit + remote-id persistence) lives in `commands::chat`.
 
+use serde::Serialize;
 use serde_json::{json, Value};
 
 /// Build the JSON body for `POST /api/chat`. `remote_conversation_id` is the
@@ -172,9 +173,60 @@ pub fn cloud_chat_error_message(reason: &str, server_message: &str) -> String {
     }
 }
 
+/// The workspace turn allowance shown in the composer (issue #69). Serialized
+/// camelCase for the frontend (`{ used, cap, periodEnd }`).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UsageDto {
+    pub used: i64,
+    pub cap: i64,
+    pub period_end: i64,
+}
+
+/// Map a 200 usage body to a display DTO, or None when there's nothing to show.
+/// The meter is best-effort — it must never surface an error — so anything that
+/// isn't a clean metered reading maps to None:
+///   - `{ unmetered: true }`            → None (no allowance to display)
+///   - error shapes `{ reason, … }`     → None (no used/cap fields)
+///   - missing `used_turns`/`cap_turns` → None
+///   - `{ unmetered:false, used_turns, cap_turns[, period_end] }` → Some
+pub fn parse_usage(body: &Value) -> Option<UsageDto> {
+    if body.get("unmetered").and_then(|v| v.as_bool()) == Some(true) {
+        return None;
+    }
+    let used = body.get("used_turns").and_then(|v| v.as_i64())?;
+    let cap = body.get("cap_turns").and_then(|v| v.as_i64())?;
+    let period_end = body.get("period_end").and_then(|v| v.as_i64()).unwrap_or(0);
+    Some(UsageDto { used, cap, period_end })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_usage_maps_metered_some_and_everything_else_none() {
+        // Metered → Some with the counts.
+        assert_eq!(
+            parse_usage(&json!({
+                "unmetered": false, "used_turns": 2, "cap_turns": 3, "period_end": 1893456000
+            })),
+            Some(UsageDto { used: 2, cap: 3, period_end: 1893456000 })
+        );
+        // period_end optional → defaults to 0, still metered.
+        assert_eq!(
+            parse_usage(&json!({ "unmetered": false, "used_turns": 0, "cap_turns": 5 })),
+            Some(UsageDto { used: 0, cap: 5, period_end: 0 })
+        );
+        // Unmetered → nothing to show.
+        assert_eq!(parse_usage(&json!({ "unmetered": true })), None);
+        // Error shapes carry no used/cap → None.
+        assert_eq!(parse_usage(&json!({ "reason": "not_a_member", "error": "x" })), None);
+        assert_eq!(parse_usage(&json!({ "reason": "subscription_lapsed" })), None);
+        // Partial / malformed → None.
+        assert_eq!(parse_usage(&json!({ "used_turns": 2 })), None);
+        assert_eq!(parse_usage(&json!({})), None);
+    }
 
     #[test]
     fn request_defaults_to_note_breadth_with_grounding_anchor() {

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -612,6 +612,65 @@ pub fn chat_get_breadth(
     heal_and_read_breadth(&conn, &conversation.id, &conversation.breadth, &note)
 }
 
+/// Workspace turn-allowance for the composer meter (issue #69). Personal chat is
+/// unmetered by design → `None` with no HTTP. In a workspace, GET the chat
+/// service's usage endpoint (same base/token/one-shot-401-retry as the other
+/// cloud chat calls). A meter must NEVER error the pane, so EVERY outcome that
+/// isn't a clean metered reading maps to `None` (the client hides the display):
+///
+/// | Case                                   | Result         |
+/// |----------------------------------------|----------------|
+/// | Personal context                       | None (no HTTP) |
+/// | Not configured / not signed in         | None           |
+/// | Network error                          | None           |
+/// | 401 (after the one-shot re-auth retry) | None           |
+/// | 404 (route absent on an older server)  | None           |
+/// | 400 / 402 / 403 / 5xx                  | None           |
+/// | 200 `{ unmetered: true }`              | None           |
+/// | 200 malformed body                     | None           |
+/// | 200 `{ used_turns, cap_turns, … }`     | Some(UsageDto) |
+#[tauri::command]
+pub async fn chat_usage(app: AppHandle) -> Result<Option<chat::cloud::UsageDto>, String> {
+    let state: State<AppState> = app.state();
+    let workspace = {
+        let conn = state.db.lock();
+        match ChatContext::load(&conn) {
+            ChatContext::Personal => return Ok(None),
+            ChatContext::Workspace(id) => id,
+        }
+    };
+    Ok(usage_cloud(&state, &workspace).await)
+}
+
+/// GET the usage endpoint, collapsing every non-metered outcome to `None` so the
+/// meter can only ever report or silently hide (issue #69). See [`chat_usage`]
+/// for the full mapping. One-shot 401 re-auth mirrors the other cloud calls.
+async fn usage_cloud(state: &State<'_, AppState>, workspace: &str) -> Option<chat::cloud::UsageDto> {
+    let mut attempt = 0u8;
+    loop {
+        let (base, token) = super::cloud::cloud_session(state).await.ok()?;
+        let resp = reqwest::Client::new()
+            .get(format!("{}/api/chat/usage", base.trim_end_matches('/')))
+            .bearer_auth(&token)
+            .query(&[("workspace_id", workspace)])
+            .send()
+            .await
+            .ok()?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
+            super::cloud::forget_session();
+            attempt += 1;
+            continue;
+        }
+        if !status.is_success() {
+            // 404 / 402 / 403 / 400 / 5xx / repeated-401 → hide, never error.
+            return None;
+        }
+        let body: serde_json::Value = resp.json().await.ok()?;
+        return chat::cloud::parse_usage(&body);
+    }
+}
+
 #[tauri::command]
 pub async fn chat_send(
     app: AppHandle,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -357,6 +357,7 @@ where
             commands::chat_new_conversation,
             commands::chat_set_breadth,
             commands::chat_get_breadth,
+            commands::chat_usage,
             commands::chat_reindex_note,
             commands::permissions_status,
             commands::permissions_request,

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -764,4 +764,31 @@ describe("ChatPanel turn allowance (#69)", () => {
     // The failed send took the catch path — the meter is not refreshed.
     expect(usageCalls).toBe(callsAfterMount);
   });
+
+  it("colours the meter with the danger tone at the cap (#69)", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_usage: () => ({ used: 3, cap: 3, periodEnd: 0 }),
+    });
+    signIntoWorkspace("Acme Team");
+    renderPanel();
+    const meter = await screen.findByText("3/3 turns");
+    expect(meter.className).toContain("text-[var(--color-status-danger)]");
+  });
+});
+
+describe("ChatPanel breadth icons (#69)", () => {
+  it("shows the active scope's icon on the breadth trigger", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_get_breadth: () => "all",
+    });
+    renderPanel();
+    const trigger = await screen.findByRole("button", { name: "Chat scope" });
+    await waitFor(() => expect(trigger).toHaveTextContent("All notes"));
+    // "All notes" → the Files glyph (distinct from FileText / ChevronDown).
+    expect(trigger.querySelector(".lucide-files")).not.toBeNull();
+  });
 });

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -624,3 +624,144 @@ describe("ChatPanel composer breadth + chrome (#63)", () => {
     });
   });
 });
+
+describe("ChatPanel turn allowance (#69)", () => {
+  it("shows the workspace turn allowance bottom-right of the composer", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_usage: () => ({ used: 2, cap: 3, periodEnd: 0 }),
+    });
+    signIntoWorkspace("Acme Team");
+    renderPanel();
+    expect(await screen.findByText("2/3 turns")).toBeInTheDocument();
+  });
+
+  it("renders no allowance in personal context", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      // Even if the backend returned a reading, personal must never show it.
+      chat_usage: () => ({ used: 2, cap: 3, periodEnd: 0 }),
+    });
+    renderPanel();
+    await screen.findByPlaceholderText(/ask about your notes/i);
+    expect(screen.queryByText(/turns/)).toBeNull();
+  });
+
+  it("hides the allowance when the backend returns null (unmetered / unavailable)", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_usage: () => null,
+    });
+    signIntoWorkspace("Acme Team");
+    renderPanel();
+    await screen.findByPlaceholderText(/ask about your notes/i);
+    expect(screen.queryByText(/turns/)).toBeNull();
+  });
+
+  it("refreshes the allowance after a completed send", async () => {
+    let sent = false;
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_send: () => {
+        sent = true;
+        return { conversationId: "c1", truncated: false };
+      },
+      chat_history: () => history(sent ? [userMsg("q"), assistantMsg("a")] : []),
+      // Allowance consumed by the completed turn: 2/3 before, 3/3 after.
+      chat_usage: () => ({ used: sent ? 3 : 2, cap: 3, periodEnd: 0 }),
+    });
+    signIntoWorkspace("Acme Team");
+    renderPanel();
+    expect(await screen.findByText("2/3 turns")).toBeInTheDocument();
+    const input = await screen.findByRole("textbox", { name: /ask about your notes/i });
+    fireEvent.change(input, { target: { value: "q" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => expect(screen.getByText("3/3 turns")).toBeInTheDocument());
+  });
+
+  it("clears the old workspace's meter on a workspace switch until the new fetch resolves", async () => {
+    let releaseB: (() => void) | null = null;
+    let phase: "A" | "B" = "A";
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_usage: () =>
+        phase === "A"
+          ? { used: 2, cap: 3, periodEnd: 0 }
+          : new Promise((resolve) => {
+              releaseB = () => resolve({ used: 1, cap: 9, periodEnd: 0 });
+            }),
+    });
+    signIntoWorkspace("Acme Team");
+    renderPanel();
+    expect(await screen.findByText("2/3 turns")).toBeInTheDocument();
+
+    // Switch to a different workspace whose usage fetch is still pending.
+    phase = "B";
+    act(() => {
+      const ws = { id: "ws2", name: "Beta Team", role: "owner" as const, plan_status: "active" as const };
+      useCloudStore.setState({
+        status: {
+          ...DISCONNECTED,
+          configured: true,
+          logged_in: true,
+          base_url: "https://sync.humla.team",
+          current_workspace: ws,
+          workspaces: [ws],
+        },
+      });
+    });
+    // The old workspace's numbers must not linger while B's fetch is pending.
+    await waitFor(() => expect(screen.queryByText("2/3 turns")).toBeNull());
+    expect(screen.queryByText(/turns/)).toBeNull();
+
+    // Once B resolves, its own numbers appear.
+    await act(async () => {
+      releaseB?.();
+      await Promise.resolve();
+    });
+    expect(await screen.findByText("1/9 turns")).toBeInTheDocument();
+  });
+
+  it("hides the meter when the usage fetch throws", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_usage: () => {
+        throw new Error("usage boom");
+      },
+    });
+    signIntoWorkspace("Acme Team");
+    renderPanel();
+    await screen.findByPlaceholderText(/ask about your notes/i);
+    expect(screen.queryByText(/turns/)).toBeNull();
+  });
+
+  it("does not refetch the meter when a send fails", async () => {
+    let usageCalls = 0;
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_send: () => {
+        throw new Error("send failed");
+      },
+      chat_usage: () => {
+        usageCalls += 1;
+        return { used: 2, cap: 3, periodEnd: 0 };
+      },
+    });
+    signIntoWorkspace("Acme Team");
+    renderPanel();
+    expect(await screen.findByText("2/3 turns")).toBeInTheDocument();
+    const callsAfterMount = usageCalls;
+    const input = await screen.findByRole("textbox", { name: /ask about your notes/i });
+    fireEvent.change(input, { target: { value: "q" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await screen.findByText(/send failed/);
+    // The failed send took the catch path — the meter is not refreshed.
+    expect(usageCalls).toBe(callsAfterMount);
+  });
+});

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -8,6 +8,8 @@ import {
   ChevronDown,
   CornerDownLeft,
   FileText,
+  Files,
+  Folder,
   Loader2,
   MessageCircle,
   Settings2,
@@ -28,6 +30,7 @@ import { useNotesStore } from "../lib/store";
 import { useCloudStore } from "../lib/cloud";
 import { useChatReadiness } from "./provider/useChatReadiness";
 import { SelectablePopover, type PopoverItem } from "./SelectablePopover";
+import { usageTone } from "../lib/chatSessions";
 import { RECOMMENDED_OLLAMA_MODEL } from "../lib/localModels";
 import { CommandSnippet } from "./CommandSnippet";
 import { cn } from "../lib/cn";
@@ -691,7 +694,18 @@ export function ChatPanel({
             folderName={folder?.name ?? null}
           />
           {usage && (
-            <span className="text-xs text-[var(--color-text-muted)] tabular-nums">
+            <span
+              className={cn(
+                "text-xs tabular-nums",
+                // Colour-only status by fraction consumed (#69) — AAA on the
+                // panel surface in both themes. Size/weight unchanged.
+                {
+                  default: "text-[var(--color-text-muted)]",
+                  warning: "text-[var(--color-status-warning)]",
+                  danger: "text-[var(--color-status-danger)]",
+                }[usageTone(usage.used, usage.cap)],
+              )}
+            >
               {usage.used}/{usage.cap} turns
             </span>
           )}
@@ -716,14 +730,24 @@ function BreadthPicker({
   onScope: (s: ChatScope) => void;
   folderName: string | null;
 }) {
+  // Per-scope icons so the options read at a glance (#69). Colour inherited.
   const items: PopoverItem[] = [
-    { id: "note", label: "This note" },
-    ...(folderName ? [{ id: "folder", label: `Folder: ${folderName}` }] : []),
-    { id: "all", label: "All notes" },
+    { id: "note", label: "This note", icon: <FileText size={14} strokeWidth={1.7} aria-hidden="true" /> },
+    ...(folderName
+      ? [
+          {
+            id: "folder",
+            label: `Folder: ${folderName}`,
+            icon: <Folder size={14} strokeWidth={1.7} aria-hidden="true" />,
+          },
+        ]
+      : []),
+    { id: "all", label: "All notes", icon: <Files size={14} strokeWidth={1.7} aria-hidden="true" /> },
   ];
   // If the folder disappears while "folder" is selected, fall back to "note".
   const activeId = scope === "folder" && !folderName ? "note" : scope;
-  const label = items.find((i) => i.id === activeId)?.label ?? "This note";
+  const active = items.find((i) => i.id === activeId);
+  const label = active?.label ?? "This note";
 
   return (
     <SelectablePopover
@@ -733,6 +757,7 @@ function BreadthPicker({
       onSelect={(id) => onScope((id as ChatScope) ?? "note")}
       trigger={
         <span className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] cursor-pointer hover:text-[var(--color-text)] transition-colors">
+          {active?.icon}
           {label}
           <ChevronDown size={12} strokeWidth={2} aria-hidden="true" className="shrink-0" />
         </span>

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -21,6 +21,7 @@ import {
   type ChatCitation,
   type ChatMessageDto,
   type ChatScope,
+  type ChatUsage,
   type ConversationMeta,
 } from "../lib/ipc";
 import { useNotesStore } from "../lib/store";
@@ -166,6 +167,9 @@ export function ChatPanel({
   // list replacement; normal sends (appended turns, streamed deltas) leave it
   // false so those stay announced (#64).
   const [bulkLoading, setBulkLoading] = useState(false);
+  // Workspace turn allowance for the composer meter (issue #69). null in personal
+  // context and on any unavailable/error/unmetered outcome → the display hides.
+  const [usage, setUsage] = useState<ChatUsage | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   // The composer is auto-focused exactly once per mount, on the first transition
@@ -287,6 +291,27 @@ export function ChatPanel({
     s.status.logged_in ? s.status.current_workspace?.id ?? null : null,
   );
 
+  // Fetch the workspace turn allowance for the composer meter (issue #69). Only
+  // in a workspace — personal chat is unmetered, so we skip the round-trip and
+  // clear the display. Gen-guarded so a slow response can't land after a switch.
+  // The backend already collapses every unavailable/error/unmetered case to
+  // null, so we just mirror whatever it returns (null hides the display).
+  const refreshUsage = useCallback(
+    async (gen: number) => {
+      if (!workspaceId) {
+        setUsage(null);
+        return;
+      }
+      try {
+        const u = await ipc.chatUsage();
+        if (gen === switchGenRef.current) setUsage(u);
+      } catch {
+        if (gen === switchGenRef.current) setUsage(null);
+      }
+    },
+    [workspaceId],
+  );
+
   // Load persisted history + breadth on mount, note change, and workspace
   // switch, clearing transient state. Keying on the workspace id makes a context
   // switch reload the right conversation — this replaces the old per-tenant
@@ -301,6 +326,10 @@ export function ChatPanel({
     // Hide the history affordance until the fresh list is known (no flicker of
     // the previous note's conversations on switch, #62).
     setConversations([]);
+    // Clear the turn meter until the new context's fetch resolves (#69). Scoped
+    // to this effect, not resetTransient: usage is per-WORKSPACE, so clearing on
+    // every per-conversation "+"/history switch would flicker it needlessly.
+    setUsage(null);
     // Defer SR announcements until the initial message list has loaded (#64).
     setBulkLoading(true);
     // Both async loads gate on the gen as well as `cancelled`: an in-flight
@@ -334,11 +363,12 @@ export function ChatPanel({
         if (!cancelled && gen === switchGenRef.current) setScope("note");
       });
     void reloadConversationList(gen);
+    void refreshUsage(gen);
     return () => {
       cancelled = true;
       void ipc.chatReindexNote(noteId).catch(() => {});
     };
-  }, [noteId, workspaceId, reloadConversationList, resetTransient]);
+  }, [noteId, workspaceId, reloadConversationList, refreshUsage, resetTransient]);
 
   // Persist a breadth change to the conversation (issue #58): update the chip
   // optimistically, then write it through so the next turn reads the new value.
@@ -470,6 +500,8 @@ export function ChatPanel({
       // A first turn creates the conversation and bumps message counts — refresh
       // the list so the history popover + its visibility rule stay current (#62).
       void reloadConversationList(gen);
+      // A completed turn consumes allowance — refresh the composer meter (#69).
+      void refreshUsage(gen);
     } catch (e) {
       if (gen !== switchGenRef.current) return;
       setError((prev) => prev ?? String(e));
@@ -648,16 +680,21 @@ export function ChatPanel({
             <CornerDownLeft size={16} strokeWidth={1.7} />
           </button>
         </div>
-        {/* Composer control row (#63): breadth picker at bottom-left. Right side
-            is intentionally empty for now — justify-between reserves it for the
-            monthly turn-allowance display coming in a later issue, so adding it
-            won't need a layout restructure. */}
+        {/* Composer control row: breadth picker bottom-left, workspace turn
+            allowance bottom-right (#69). The meter shows only in a metered
+            workspace — `usage` is null in personal context and on any
+            unavailable/error/unmetered outcome, so nothing renders then. */}
         <div className="flex items-center justify-between px-1">
           <BreadthPicker
             scope={scope}
             onScope={selectBreadth}
             folderName={folder?.name ?? null}
           />
+          {usage && (
+            <span className="text-xs text-[var(--color-text-muted)] tabular-nums">
+              {usage.used}/{usage.cap} turns
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/SelectablePopover.test.tsx
+++ b/src/components/SelectablePopover.test.tsx
@@ -186,6 +186,24 @@ describe("SelectablePopover", () => {
     expect(document.activeElement).toBe(outside);
   });
 
+  it("renders an optional leading icon in menu rows (#69)", () => {
+    const withIcons = [
+      { id: "c1", label: "This note", icon: <span data-testid="row-icon" /> },
+      { id: "c2", label: "All notes", icon: <span data-testid="row-icon" /> },
+    ];
+    render(
+      <SelectablePopover
+        ariaLabel="Chat scope"
+        trigger={<span>This note</span>}
+        items={withIcons}
+        activeId="c1"
+        onSelect={vi.fn()}
+      />,
+    );
+    open("Chat scope");
+    expect(screen.getAllByTestId("row-icon")).toHaveLength(2);
+  });
+
   it("is a plain checkmark menu when no edit callbacks are given (Scope-popover mode)", () => {
     render(
       <SelectablePopover ariaLabel="Scope" trigger={<span>All notes</span>} items={items} activeId="c1" onSelect={vi.fn()} />,

--- a/src/components/SelectablePopover.tsx
+++ b/src/components/SelectablePopover.tsx
@@ -18,6 +18,8 @@ export type PopoverItem = {
   label: string;
   /** Optional muted second line under the label (e.g. a relative date, #62). */
   description?: string;
+  /** Optional leading icon rendered before the label (e.g. a scope glyph, #69). */
+  icon?: ReactNode;
 };
 
 type Props = {
@@ -279,6 +281,11 @@ export function SelectablePopover({
                       aria-hidden
                       className={"shrink-0 " + (selected ? "text-[var(--color-accent-text)]" : "opacity-0")}
                     />
+                    {item.icon && (
+                      <span className="shrink-0 inline-flex" aria-hidden="true">
+                        {item.icon}
+                      </span>
+                    )}
                     <span className="flex min-w-0 flex-col">
                       <span className="truncate">{item.label}</span>
                       {item.description && (

--- a/src/lib/chatSessions.test.ts
+++ b/src/lib/chatSessions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { relativeTime, conversationTitle } from "./chatSessions";
+import { relativeTime, conversationTitle, usageTone } from "./chatSessions";
 
 const NOW = new Date("2026-07-24T12:00:00").getTime();
 const secs = (n: number) => NOW - n * 1000;
@@ -70,5 +70,28 @@ describe("conversationTitle", () => {
   it("falls back to 'New chat' for an empty or whitespace title", () => {
     expect(conversationTitle({ title: "" })).toBe("New chat");
     expect(conversationTitle({ title: "   " })).toBe("New chat");
+  });
+});
+
+describe("usageTone", () => {
+  it("stays default below 70%", () => {
+    expect(usageTone(0, 100)).toBe("default");
+    expect(usageTone(69, 100)).toBe("default");
+  });
+
+  it("warns from 70% to 89%", () => {
+    expect(usageTone(70, 100)).toBe("warning");
+    expect(usageTone(89, 100)).toBe("warning");
+  });
+
+  it("goes danger at 90% and once used reaches or passes the cap", () => {
+    expect(usageTone(90, 100)).toBe("danger");
+    expect(usageTone(100, 100)).toBe("danger");
+    expect(usageTone(5, 3)).toBe("danger");
+  });
+
+  it("is default for a non-positive cap (total edge)", () => {
+    expect(usageTone(0, 0)).toBe("default");
+    expect(usageTone(2, 0)).toBe("default");
   });
 });

--- a/src/lib/chatSessions.ts
+++ b/src/lib/chatSessions.ts
@@ -39,3 +39,16 @@ export function relativeTime(ts: number, now: number = Date.now()): string {
 export function conversationTitle(meta: { title: string }): string {
   return meta.title.trim() || "New chat";
 }
+
+// The colour tone for the usage meter by fraction of allowance consumed (#69):
+// default below 70%, warning at 70–89%, danger at >=90% (and once used >= cap).
+// A non-positive cap has no meaningful fraction → default (shouldn't happen for
+// a metered workspace, but keeps the function total).
+export type UsageTone = "default" | "warning" | "danger";
+export function usageTone(used: number, cap: number): UsageTone {
+  if (cap <= 0) return "default";
+  const ratio = used / cap;
+  if (used >= cap || ratio >= 0.9) return "danger";
+  if (ratio >= 0.7) return "warning";
+  return "default";
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -418,6 +418,10 @@ export const ipc = {
     invoke<void>("chat_set_breadth", { noteId, conversationId, breadth }),
   chatGetBreadth: (noteId: string, conversationId: string | null = null) =>
     invoke<ChatScope>("chat_get_breadth", { noteId, conversationId }),
+  // Workspace turn allowance for the composer meter (issue #69). null in personal
+  // context, and on any unavailable/error/unmetered outcome — a meter never
+  // errors the pane, so the caller just hides the display when this is null.
+  chatUsage: () => invoke<ChatUsage | null>("chat_usage"),
   // Rebuild a Note's retrieval index — called on Note-view unmount so edits
   // that didn't trigger summarize/diarize still land in search.
   chatReindexNote: (noteId: string) => invoke<void>("chat_reindex_note", { noteId }),
@@ -477,6 +481,9 @@ export type ConversationMeta = {
 // Retrieval breadth chosen in the Scope popover (issue #47), persisted per
 // conversation on the backend (issue #58).
 export type ChatScope = "note" | "folder" | "all";
+// Workspace turn allowance for the composer meter (issue #69). Only ever present
+// for a metered workspace; personal/unmetered/unavailable resolve to null.
+export type ChatUsage = { used: number; cap: number; periodEnd: number };
 
 // Streaming events (the #46 wire contract + #47 tool/citation events).
 export type ChatTextDeltaEvent = {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -70,6 +70,12 @@
   --color-warning-text: #8a6a1a;      /* readable gold for warning-as-text (light) */
   --color-speaker-4: #c0463f;         /* speaker red (4th, cycling) */
 
+  /* Usage-meter status colours (#69) — AAA (>=7:1) on --color-surface, the
+     panel/composer background. Warm gold + red hues darkened for the light
+     canvas; distinct from --color-warning/-danger, which don't clear AAA. */
+  --color-status-warning: #69531a;    /* 7.29:1 on #fffef9 */
+  --color-status-danger: #9f2c25;     /* 7.27:1 on #fffef9 */
+
   --color-ink: var(--color-text);
   --color-ink-muted: var(--color-text-muted);
 
@@ -114,6 +120,11 @@
     --color-warning-text: #ddb255;
     --color-speaker-4: #e07a72;
 
+    /* Usage-meter status colours (#69) — AAA (>=7:1) on --color-surface #2a2418,
+       the panel/composer background. Warm hues lightened for the dark canvas. */
+    --color-status-warning: #d3ae4c;  /* 7.28:1 on #2a2418 */
+    --color-status-danger: #e8a09c;   /* 7.29:1 on #2a2418 */
+
     --color-ink: var(--color-text);
     --color-ink-muted: var(--color-text-muted);
 
@@ -125,6 +136,10 @@
 
 /* === DARK explicit === */
 :root[data-theme="dark"] {
+  /* Usage-meter status colours (#69) — AAA (>=7:1) on --color-surface #2a2418,
+     the panel/composer background. Warm hues lightened for the dark canvas. */
+  --color-status-warning: #d3ae4c;  /* 7.28:1 on #2a2418 */
+  --color-status-danger: #e8a09c;   /* 7.29:1 on #2a2418 */
   --color-canvas: #0e0c08;
   --color-sidebar-bg: #1d1912;
   --color-surface: #2a2418;


### PR DESCRIPTION
Closes #69. Server side: michaelwilhelmsen/humla-cloud#21 (merged + deployed to sync.humla.team, endpoint verified live).

Balances the composer control row: breadth picker bottom-left, `{used}/{cap} turns` bottom-right — workspace context only (personal chat stays unmetered by design).

- **Rust**: new `chat_usage` command — personal resolves to `None` with no HTTP; workspace GETs the chat service's `/api/chat/usage` with the same base/token/one-shot-401-retry as the other cloud calls. Every non-metered outcome (404 on an old server, 402/403, network errors, `unmetered:true` deployments, malformed bodies) maps to `None`: the meter can only hide, never error the pane. JSON→DTO seam unit-tested.
- **Frontend**: fetch on mount/workspace switch + after *completed* sends only; workspace switches clear the stale meter before the new fetch resolves (per-workspace state, deliberately not cleared on per-conversation switches).
- **AAA status tones**: new `--color-status-warning`/`--color-status-danger` tokens, numerically validated ≥7:1 on `--color-surface` in both themes (7.27–7.29:1) and defined in all three theme blocks (incl. the explicit `data-theme="dark"` override — a gap caught in review of the review). Muted <70%, warning 70–89%, danger ≥90%/at-cap, threshold-tested.
- **Breadth scope icons**: FileText/Folder/Files in the popover rows and on the trigger; `SelectablePopover` gains a backward-compatible `icon` slot.

Cloud-request skeleton duplication (3rd copy) tracked in #72.

Tests: frontend 240, backend 316, `tsc --noEmit` clean. Two-axis review run (URL/auth/field-name chain traced clean against the deployed contract); user-verified in the running app incl. the live prod meter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)