### PR TITLE
feat(chat): role-aware activation pane + BYOK error taxonomy (#76)

### DIFF
--- a/src-tauri/src/chat/cloud.rs
+++ b/src-tauri/src/chat/cloud.rs
@@ -159,6 +159,27 @@ pub fn cloud_chat_error_message(reason: &str, server_message: &str) -> String {
                 .to_string()
         }
         "not_a_member" => "You're not a member of this workspace.".to_string(),
+        // BYOK-first reasons (issue #76). Distinct from the managed add-on's
+        // `quota_exhausted` upsell above. The client renders role-aware copy for
+        // these when it has the reason code; these strings are the fallback and
+        // the send-rejection text.
+        "chat_not_activated" => {
+            "Workspace chat isn't activated yet — the owner can turn it on in workspace settings."
+                .to_string()
+        }
+        "byok_key_invalid" => {
+            "This workspace's OpenAI key was rejected — the owner can re-enter it in workspace \
+             settings."
+                .to_string()
+        }
+        "byok_provider_quota" => {
+            "This workspace's OpenAI account is out of quota — the owner can check it in workspace \
+             settings."
+                .to_string()
+        }
+        "byok_key_unavailable" => {
+            "Workspace chat is temporarily unavailable — try again shortly.".to_string()
+        }
         "chat_disabled" | "chat_unavailable" | "index_unavailable" => {
             "Team chat isn't available on this server.".to_string()
         }
@@ -418,6 +439,23 @@ mod tests {
     }
 
     #[test]
+    fn error_frame_relays_the_top_level_reason_to_the_client() {
+        // The server's mid-turn SSE error frame carries a top-level `reason`
+        // (byok_key_invalid / byok_provider_quota). Framing → "error" → chat_error,
+        // and JSON parse keeps `reason` so the client's chat_error payload (which
+        // the stream pump re-emits verbatim, only re-stamping conversationId) can
+        // drive the role-aware BYOK error copy (#76).
+        let (event, data) = parse_sse_frame(
+            "event: error\ndata: {\"reason\":\"byok_key_invalid\",\"message\":\"nope\"}",
+        )
+        .unwrap();
+        assert_eq!(event, "error");
+        assert_eq!(tauri_event_for(&event), Some("chat_error"));
+        let v: Value = serde_json::from_str(&data).unwrap();
+        assert_eq!(v.get("reason").and_then(|r| r.as_str()), Some("byok_key_invalid"));
+    }
+
+    #[test]
     fn finds_the_first_event_terminator() {
         assert_eq!(find_event_end(b"event: a\ndata: 1\n\nrest"), Some((16, 2)));
         // CRLF framing.
@@ -469,5 +507,25 @@ mod tests {
         assert!(q.contains("add-on"), "quota block names the chat add-on: {q}");
         assert_eq!(cloud_chat_error_message("weird_reason", "raw server text"), "raw server text");
         assert!(!cloud_chat_error_message("weird_reason", "  ").is_empty());
+    }
+
+    #[test]
+    fn byok_reasons_map_to_distinct_messages_not_the_addon_upsell() {
+        let na = cloud_chat_error_message("chat_not_activated", "");
+        let invalid = cloud_chat_error_message("byok_key_invalid", "");
+        let quota = cloud_chat_error_message("byok_provider_quota", "");
+        let unavail = cloud_chat_error_message("byok_key_unavailable", "");
+        // Each is distinct and non-generic.
+        for m in [&na, &invalid, &quota, &unavail] {
+            assert_ne!(*m, "Team chat failed — please try again.");
+        }
+        assert!(na.to_lowercase().contains("activated"));
+        assert!(invalid.to_lowercase().contains("rejected"));
+        assert!(quota.to_lowercase().contains("quota"));
+        assert!(unavail.to_lowercase().contains("try again"));
+        // None of them reuse the managed add-on's upsell copy.
+        for m in [&na, &invalid, &quota, &unavail] {
+            assert!(!m.contains("add-on"), "BYOK reason must not name the managed add-on: {m}");
+        }
     }
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -305,6 +305,11 @@ struct ChatDonePayload {
 struct ChatErrorPayload {
     conversation_id: String,
     message: String,
+    /// Machine reason code (issue #76) so the client can render role-aware copy
+    /// for the BYOK error taxonomy (byok_key_invalid / byok_provider_quota /
+    /// byok_key_unavailable / chat_not_activated). Empty when unknown.
+    #[serde(default)]
+    reason: String,
 }
 
 /// Tool activity between steps — drives the "searching your notes…" progress
@@ -946,7 +951,11 @@ pub async fn chat_send(
             let message = e.to_string();
             let _ = app.emit(
                 "chat_error",
-                ChatErrorPayload { conversation_id: conversation_id.clone(), message: message.clone() },
+                ChatErrorPayload {
+                    conversation_id: conversation_id.clone(),
+                    message: message.clone(),
+                    reason: String::new(),
+                },
             );
             Err(message)
         }
@@ -1023,7 +1032,11 @@ async fn chat_send_cloud(
             Err(e) => {
                 let _ = app.emit(
                     "chat_error",
-                    ChatErrorPayload { conversation_id: conversation.id.clone(), message: e.clone() },
+                    ChatErrorPayload {
+                        conversation_id: conversation.id.clone(),
+                        message: e.clone(),
+                        reason: String::new(),
+                    },
                 );
                 return Err(e);
             }
@@ -1034,7 +1047,11 @@ async fn chat_send_cloud(
         let text = chat::cloud::cloud_chat_error_message(&reason, &server_msg);
         let _ = app.emit(
             "chat_error",
-            ChatErrorPayload { conversation_id: conversation.id.clone(), message: text.clone() },
+            ChatErrorPayload {
+                conversation_id: conversation.id.clone(),
+                message: text.clone(),
+                reason: reason.clone(),
+            },
         );
         return Err(text);
     }

--- a/src/components/ChatKeyEntry.tsx
+++ b/src/components/ChatKeyEntry.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from "react";
+import { cloudApi, type ChatKeyMeta } from "../lib/cloud";
+import { ipc } from "../lib/ipc";
+import { Btn } from "../pages/settings/components/Btn";
+
+// Shared masked key-entry for workspace BYOK activation (issues #75/#76). Used
+// by both the workspace-settings panel (ChatKeyPanel) and the chat activation
+// pane, so the test-on-save flow + security posture live in one place: the key
+// is `type="password"`, sent straight to the server hook, cleared the instant
+// it's saved, and never persisted client-side. The "use the key from Settings"
+// shortcut reads the personal Keychain key entirely in Rust — it never enters
+// the webview. On success the parent gets the fresh metadata via `onActivated`.
+
+const inputCls =
+  "flex-1 min-w-0 text-sm px-3 py-2 rounded-md border border-[var(--color-line-visible)] bg-[var(--color-surface)] focus:border-[var(--color-text-muted)] transition-colors";
+
+export function ChatKeyEntry({
+  workspaceId,
+  onActivated,
+  onCancel,
+}: {
+  workspaceId: string;
+  onActivated: (meta: ChatKeyMeta) => void;
+  /** When provided, shows a Cancel button (the rotate flow in settings). */
+  onCancel?: () => void;
+}) {
+  const [keyDraft, setKeyDraft] = useState("");
+  // Whether a personal OpenAI key is stored (Settings → Providers) — gates the
+  // shortcut. The key itself is read Rust-side; only this boolean is here.
+  const [hasPersonalKey, setHasPersonalKey] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    ipc
+      .getProviderKey("openai")
+      .then((k) => {
+        if (!cancelled) setHasPersonalKey(k != null);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function save() {
+    const key = keyDraft.trim();
+    if (!key) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const m = await cloudApi.chatKeySet(workspaceId, key);
+      // Clear the key from memory the moment it's saved — never retained.
+      setKeyDraft("");
+      onActivated(m);
+    } catch (e) {
+      // The Rust layer maps reason codes to a short message (never the key).
+      // Keep the draft so the owner can correct it.
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function useKeychain() {
+    setBusy(true);
+    setError(null);
+    try {
+      const m = await cloudApi.chatKeySetFromKeychain(workspaceId);
+      setKeyDraft("");
+      onActivated(m);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-2">
+        <input
+          type="password"
+          className={inputCls}
+          value={keyDraft}
+          onChange={(e) => setKeyDraft(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && save()}
+          placeholder="sk-…"
+          aria-label="OpenAI API key"
+          autoComplete="off"
+        />
+        <Btn onClick={save} disabled={busy || !keyDraft.trim()}>
+          {busy ? "Saving…" : "Save"}
+        </Btn>
+        {onCancel && (
+          <Btn
+            onClick={() => {
+              setKeyDraft("");
+              setError(null);
+              onCancel();
+            }}
+            disabled={busy}
+          >
+            Cancel
+          </Btn>
+        )}
+      </div>
+      <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
+        Your key is sent straight to the server, tested against OpenAI, and stored encrypted — it's
+        never kept on this device. Chat then runs on your OpenAI account, free and unmetered.
+      </p>
+      {hasPersonalKey && (
+        <div className="flex flex-col gap-1 pt-1">
+          <Btn onClick={useKeychain} disabled={busy}>
+            {busy ? "Saving…" : "Use the OpenAI key from Settings"}
+          </Btn>
+          <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
+            Shares the key from Settings → Providers with this workspace. Everyone's chat then runs
+            on your OpenAI account.
+          </p>
+        </div>
+      )}
+      {error && <p className="text-xs text-[var(--color-danger)] break-words">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -4,8 +4,36 @@ import { MemoryRouter } from "react-router-dom";
 import { ChatPanel, type ChatSessionControls } from "./ChatPanel";
 import { mockTauri } from "../test/tauri";
 import type { ChatMessageDto, Folder, Note } from "../lib/ipc";
-import { useCloudStore, DISCONNECTED } from "../lib/cloud";
+import { useCloudStore, DISCONNECTED, type CloudRole } from "../lib/cloud";
 import { useNotesStore } from "../lib/store";
+
+// Signed into a MANAGED (billing-enabled) workspace with the given role, so the
+// BYOK activation pane (#76) applies. The roster's owner is "Ada" for
+// member-facing "ask {owner}" copy.
+function signInBillingWorkspace(role: CloudRole = "owner") {
+  const ws = { id: "ws1", name: "Acme Team", role, plan_status: "active" as const };
+  useCloudStore.setState({
+    status: {
+      ...DISCONNECTED,
+      configured: true,
+      logged_in: true,
+      base_url: "https://sync.humla.team",
+      current_workspace: ws,
+      workspaces: [ws],
+      billing_enabled: true,
+    },
+    members: { u1: { id: "u1", name: "Ada", email: "ada@acme.com", role: "owner" } },
+  });
+}
+
+const UNCONFIGURED_KEY = { configured: false, last4: null, setBy: null, setAt: null, keyHealth: null };
+const CONFIGURED_KEY = {
+  configured: true,
+  last4: "n3Kq",
+  setBy: "u1",
+  setAt: null,
+  keyHealth: "ok",
+};
 
 // A minimal note carrying a folder, so the composer breadth picker's
 // "Folder: {name}" option appears (#63). Only the fields ChatPanel reads matter.
@@ -740,29 +768,25 @@ describe("ChatPanel turn allowance (#69)", () => {
     expect(screen.queryByText(/turns/)).toBeNull();
   });
 
-  it("does not refetch the meter when a send fails", async () => {
-    let usageCalls = 0;
+  it("keeps the meter value after a failed send (a failed turn consumes nothing)", async () => {
     mockTauri({
       provider_key_get: () => "sk-test",
       chat_history: () => history(),
       chat_send: () => {
         throw new Error("send failed");
       },
-      chat_usage: () => {
-        usageCalls += 1;
-        return { used: 2, cap: 3, periodEnd: 0 };
-      },
+      // The server value is unchanged by a failed turn; #76 re-detects activation
+      // in the catch (which reads usage), but the displayed number stays 2/3.
+      chat_usage: () => ({ used: 2, cap: 3, periodEnd: 0 }),
     });
     signIntoWorkspace("Acme Team");
     renderPanel();
     expect(await screen.findByText("2/3 turns")).toBeInTheDocument();
-    const callsAfterMount = usageCalls;
     const input = await screen.findByRole("textbox", { name: /ask about your notes/i });
     fireEvent.change(input, { target: { value: "q" } });
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
     await screen.findByText(/send failed/);
-    // The failed send took the catch path — the meter is not refreshed.
-    expect(usageCalls).toBe(callsAfterMount);
+    expect(screen.getByText("2/3 turns")).toBeInTheDocument();
   });
 
   it("colours the meter with the danger tone at the cap (#69)", async () => {
@@ -790,5 +814,128 @@ describe("ChatPanel breadth icons (#69)", () => {
     await waitFor(() => expect(trigger).toHaveTextContent("All notes"));
     // "All notes" → the Files glyph (distinct from FileText / ChevronDown).
     expect(trigger.querySelector(".lucide-files")).not.toBeNull();
+  });
+});
+
+describe("ChatPanel workspace activation (#76)", () => {
+  it("owner sees the activation pane with key entry when not activated", async () => {
+    mockTauri({
+      chat_history: () => history(),
+      chat_key_meta: () => UNCONFIGURED_KEY,
+      chat_usage: () => null,
+    });
+    signInBillingWorkspace("owner");
+    renderPanel();
+    // Values-first line respecting the claim boundary ("your OpenAI relationship").
+    expect(await screen.findByText(/your OpenAI relationship/)).toBeInTheDocument();
+    expect(screen.getByLabelText("OpenAI API key")).toBeInTheDocument();
+    // The composer is replaced by the activation state.
+    expect(screen.queryByPlaceholderText(/Ask about your notes/)).toBeNull();
+  });
+
+  it("member sees an ask-owner message with nothing actionable", async () => {
+    mockTauri({
+      chat_history: () => history(),
+      chat_key_meta: () => UNCONFIGURED_KEY,
+      chat_usage: () => null,
+    });
+    signInBillingWorkspace("member");
+    renderPanel();
+    expect(await screen.findByText(/ask Ada/)).toBeInTheDocument();
+    expect(screen.queryByLabelText("OpenAI API key")).toBeNull();
+    expect(screen.queryByPlaceholderText(/Ask about your notes/)).toBeNull();
+  });
+
+  it("flips to the composer after the owner activates, without a reload", async () => {
+    mockTauri({
+      chat_history: () => history(),
+      chat_key_meta: () => UNCONFIGURED_KEY,
+      chat_usage: () => null,
+      chat_key_set: () => CONFIGURED_KEY,
+    });
+    signInBillingWorkspace("owner");
+    renderPanel();
+    const input = await screen.findByLabelText("OpenAI API key");
+    fireEvent.change(input, { target: { value: "sk-abc" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    // Composer appears in place (same instance — no reload); entry gone.
+    expect(await screen.findByPlaceholderText(/Ask about your notes/)).toBeInTheDocument();
+    expect(screen.queryByLabelText("OpenAI API key")).toBeNull();
+  });
+
+  it("keeps history readable while unactivated", async () => {
+    mockTauri({
+      chat_history: () => history([userMsg("earlier q"), assistantMsg("earlier a")]),
+      chat_key_meta: () => UNCONFIGURED_KEY,
+      chat_usage: () => null,
+    });
+    signInBillingWorkspace("member");
+    renderPanel();
+    // Past conversation renders even though chat isn't activated…
+    expect(await screen.findByText("earlier a")).toBeInTheDocument();
+    expect(screen.getByText("earlier q")).toBeInTheDocument();
+    // …and the activation state shows instead of the composer.
+    expect(screen.getByText(/ask Ada/)).toBeInTheDocument();
+  });
+
+  it("shows the composer (not the pane) when the workspace key is configured", async () => {
+    mockTauri({
+      chat_history: () => history(),
+      chat_key_meta: () => CONFIGURED_KEY,
+      chat_usage: () => null,
+    });
+    signInBillingWorkspace("owner");
+    renderPanel();
+    expect(await screen.findByPlaceholderText(/Ask about your notes/)).toBeInTheDocument();
+    expect(screen.queryByLabelText("OpenAI API key")).toBeNull();
+  });
+
+  it("never shows the activation pane on a self-host server (billing disabled)", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_key_meta: () => UNCONFIGURED_KEY,
+      chat_usage: () => null,
+    });
+    signIntoWorkspace("Acme Team"); // billing_enabled false → self-host posture
+    renderPanel();
+    expect(await screen.findByPlaceholderText(/Ask about your notes/)).toBeInTheDocument();
+    expect(screen.queryByText(/your OpenAI relationship/)).toBeNull();
+  });
+
+  it("lets a member without a personal key send in an activated workspace", async () => {
+    let sent = false;
+    mockTauri({
+      provider_key_get: () => null, // no personal key → personal readiness is false
+      chat_history: () => history(sent ? [userMsg("q"), assistantMsg("a")] : []),
+      chat_key_meta: () => CONFIGURED_KEY, // workspace is activated
+      chat_usage: () => null,
+      chat_send: () => {
+        sent = true;
+        return { conversationId: "c1", truncated: false };
+      },
+    });
+    signInBillingWorkspace("member");
+    renderPanel();
+    const input = await screen.findByPlaceholderText(/Ask about your notes/);
+    fireEvent.change(input, { target: { value: "q" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    // The send must reach the backend — the workspace runs on the workspace key,
+    // not the member's (absent) personal key.
+    await waitFor(() => expect(sent).toBe(true));
+  });
+
+  it("lets a workspace member without a personal key reach the pane (no personal setup prompt)", async () => {
+    mockTauri({
+      provider_key_get: () => null,
+      chat_history: () => history(),
+      chat_key_meta: () => UNCONFIGURED_KEY,
+      chat_usage: () => null,
+    });
+    signInBillingWorkspace("member");
+    renderPanel();
+    expect(await screen.findByText(/ask Ada/)).toBeInTheDocument();
+    // NOT the personal "Add your OpenAI key" setup prompt.
+    expect(screen.queryByText(/Add your OpenAI key/)).toBeNull();
   });
 });

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -27,10 +27,11 @@ import {
   type ConversationMeta,
 } from "../lib/ipc";
 import { useNotesStore } from "../lib/store";
-import { useCloudStore } from "../lib/cloud";
+import { cloudApi, formatSeatPrice, useCloudStore, type ChatAddon, type ChatKeyMeta } from "../lib/cloud";
 import { useChatReadiness } from "./provider/useChatReadiness";
 import { SelectablePopover, type PopoverItem } from "./SelectablePopover";
-import { usageTone } from "../lib/chatSessions";
+import { ChatKeyEntry } from "./ChatKeyEntry";
+import { usageTone, liveChatErrorCopy } from "../lib/chatSessions";
 import { RECOMMENDED_OLLAMA_MODEL } from "../lib/localModels";
 import { CommandSnippet } from "./CommandSnippet";
 import { cn } from "../lib/cn";
@@ -161,6 +162,11 @@ export function ChatPanel({
   const [activity, setActivity] = useState<string | null>(null);
   const [liveCitations, setLiveCitations] = useState<ChatCitation[]>([]);
   const [error, setError] = useState<string | null>(null);
+  // Machine reason for the last error (issue #76) → drives role-aware BYOK copy
+  // in the live pane. null when cleared; the personal loop and unknown errors
+  // report an empty reason, which liveChatErrorCopy treats the same (falls back
+  // to the server message).
+  const [errorReason, setErrorReason] = useState<string | null>(null);
   const [truncated, setTruncated] = useState(false);
   // Scope chip breadth. Display state only — the backend conversation row is the
   // source of truth (issue #58); this mirrors it and is (re)initialised from it.
@@ -173,6 +179,10 @@ export function ChatPanel({
   // Workspace turn allowance for the composer meter (issue #69). null in personal
   // context and on any unavailable/error/unmetered outcome → the display hides.
   const [usage, setUsage] = useState<ChatUsage | null>(null);
+  // Workspace BYOK key metadata (issue #76). `undefined` = still checking (only
+  // in a managed workspace, to avoid flashing the composer before we know), then
+  // a `ChatKeyMeta` or `null`. Feeds the activation-pane decision.
+  const [keyMeta, setKeyMeta] = useState<ChatKeyMeta | null | undefined>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   // The composer is auto-focused exactly once per mount, on the first transition
@@ -218,6 +228,7 @@ export function ChatPanel({
     setActivity(null);
     setLiveCitations([]);
     setError(null);
+    setErrorReason(null);
     setTruncated(false);
   }, []);
 
@@ -293,26 +304,60 @@ export function ChatPanel({
   const workspaceId = useCloudStore((s) =>
     s.status.logged_in ? s.status.current_workspace?.id ?? null : null,
   );
+  // BYOK activation surface (issue #76). `billingEnabled` marks the managed
+  // (humla-cloud) server — the only place the activation pane applies; on self-
+  // host it never shows (chat_disabled keeps its existing behaviour). Role +
+  // members drive owner-vs-member copy; the add-on config drives the pitch.
+  const billingEnabled = useCloudStore((s) => s.status.billing_enabled);
+  const wsRole = useCloudStore((s) => s.status.current_workspace?.role ?? null);
+  const members = useCloudStore((s) => s.members);
+  const addon = useCloudStore((s) => s.status.chat_addon ?? null);
+  const inWorkspace = !!workspaceId;
+  const isOwner = wsRole === "owner";
+  const ownerMember = Object.values(members).find((m) => m.role === "owner");
+  const ownerName = ownerMember ? ownerMember.name || ownerMember.email : "the workspace owner";
+  // Personal chat gates on personal readiness (a configured provider/key);
+  // workspace chat does NOT — it runs on the workspace key, so a member without
+  // a personal key still reaches the pane (composer or activation state, #76).
+  const paneUsable = inWorkspace || ready;
 
-  // Fetch the workspace turn allowance for the composer meter (issue #69). Only
-  // in a workspace — personal chat is unmetered, so we skip the round-trip and
-  // clear the display. Gen-guarded so a slow response can't land after a switch.
-  // The backend already collapses every unavailable/error/unmetered case to
-  // null, so we just mirror whatever it returns (null hides the display).
-  const refreshUsage = useCallback(
+  // Activation gating (#76). Only on the managed server + a workspace. While the
+  // key metadata is still loading (undefined) show neither composer nor pane, so
+  // the composer doesn't flash before we know. `notActivated` = no key + no
+  // add-on (usage null). Self-host / personal never reach here. Computed here
+  // (above the effects) so the auto-focus effect can depend on it.
+  const billingWorkspace = inWorkspace && billingEnabled;
+  const activationLoading = billingWorkspace && keyMeta === undefined;
+  const notActivated = billingWorkspace && keyMeta != null && !keyMeta.configured && !usage;
+
+  // Fetch, gen-guarded, the workspace turn allowance for the composer meter
+  // (#69) and — on the managed server — the BYOK key metadata for the activation
+  // decision (#76). Personal → clear both, no round-trip. The backend collapses
+  // every unavailable/error/unmetered usage case to null (the meter hides).
+  const refreshActivation = useCallback(
     async (gen: number) => {
       if (!workspaceId) {
         setUsage(null);
+        setKeyMeta(null);
         return;
       }
       try {
-        const u = await ipc.chatUsage();
-        if (gen === switchGenRef.current) setUsage(u);
+        const [u, m] = await Promise.all([
+          ipc.chatUsage(),
+          billingEnabled ? cloudApi.chatKeyMeta(workspaceId) : Promise.resolve(null),
+        ]);
+        if (gen === switchGenRef.current) {
+          setUsage(u);
+          setKeyMeta(m);
+        }
       } catch {
-        if (gen === switchGenRef.current) setUsage(null);
+        if (gen === switchGenRef.current) {
+          setUsage(null);
+          setKeyMeta(null);
+        }
       }
     },
-    [workspaceId],
+    [workspaceId, billingEnabled],
   );
 
   // Load persisted history + breadth on mount, note change, and workspace
@@ -333,6 +378,9 @@ export function ChatPanel({
     // to this effect, not resetTransient: usage is per-WORKSPACE, so clearing on
     // every per-conversation "+"/history switch would flicker it needlessly.
     setUsage(null);
+    // Mark activation "checking" on a managed workspace so the footer shows
+    // neither composer nor pane until we know (#76); clear it otherwise.
+    setKeyMeta(billingEnabled && !!workspaceId ? undefined : null);
     // Defer SR announcements until the initial message list has loaded (#64).
     setBulkLoading(true);
     // Both async loads gate on the gen as well as `cancelled`: an in-flight
@@ -366,18 +414,28 @@ export function ChatPanel({
         if (!cancelled && gen === switchGenRef.current) setScope("note");
       });
     void reloadConversationList(gen);
-    void refreshUsage(gen);
+    void refreshActivation(gen);
     return () => {
       cancelled = true;
       void ipc.chatReindexNote(noteId).catch(() => {});
     };
-  }, [noteId, workspaceId, reloadConversationList, refreshUsage, resetTransient]);
+  }, [noteId, workspaceId, billingEnabled, reloadConversationList, refreshActivation, resetTransient]);
 
   // Persist a breadth change to the conversation (issue #58): update the chip
   // optimistically, then write it through so the next turn reads the new value.
   function selectBreadth(next: ChatScope) {
     setScope(next);
     void ipc.chatSetBreadth(noteId, conversationId, next).catch((e) => setError(String(e)));
+  }
+
+  // Owner activated chat from the pane (#76): the entry reports fresh metadata →
+  // flip to the composer WITHOUT a reload (BYOK is unmetered). Clear any prior
+  // activation error so the live pane starts clean.
+  function handleActivated(m: ChatKeyMeta) {
+    setKeyMeta(m);
+    setUsage(null);
+    setError(null);
+    setErrorReason(null);
   }
 
   // Stream subscription. Bound once; cancelled-flag + claim keeps it StrictMode-
@@ -407,7 +465,10 @@ export function ChatPanel({
       }
     }).then(claim);
     onChatError((e) => {
-      if (sendingRef.current) setError(e.message);
+      if (sendingRef.current) {
+        setError(e.message);
+        setErrorReason(e.reason ?? null);
+      }
     }).then(claim);
     return () => {
       cancelled = true;
@@ -425,11 +486,14 @@ export function ChatPanel({
   // mount so the Ollama readiness probe re-flipping ready false→true doesn't
   // steal focus from the note body while the user is typing there.
   useEffect(() => {
-    if (ready && !hasAutoFocusedRef.current) {
+    // Only "consume" the one-per-mount focus once the composer actually mounted
+    // (inputRef present) — otherwise the activation pane / loading state would
+    // eat it and the composer would never get focused when it appears (#76).
+    if (!hasAutoFocusedRef.current && inputRef.current) {
       hasAutoFocusedRef.current = true;
-      inputRef.current?.focus();
+      inputRef.current.focus();
     }
-  }, [ready]);
+  }, [paneUsable, notActivated, activationLoading]);
 
   // Publish the session controls to the owner (Note header) whenever the list,
   // the active conversation, or its emptiness changes. Only while ready — no
@@ -437,7 +501,9 @@ export function ChatPanel({
   // render nothing. Actions are stable, so this fires only on real data changes.
   useEffect(() => {
     if (!onControls) return;
-    if (!ready) {
+    // Publish whenever the chat UI is usable — including an unactivated workspace,
+    // so history (popover) stays reachable during the cutover (#76).
+    if (!paneUsable) {
       onControls(null);
       return;
     }
@@ -459,7 +525,7 @@ export function ChatPanel({
     });
   }, [
     onControls,
-    ready,
+    paneUsable,
     noteId,
     conversations,
     conversationId,
@@ -470,7 +536,10 @@ export function ChatPanel({
 
   async function send() {
     const text = input.trim();
-    if (!text || sending || !ready) return;
+    // Mirror the render gate, NOT personal readiness (#76): a workspace send runs
+    // on the workspace key, so it must not require a personal provider key — an
+    // owner who typed the key or any member can send in an activated workspace.
+    if (!text || sending || !paneUsable) return;
     setInput("");
     setError(null);
     setStreaming("");
@@ -503,11 +572,16 @@ export function ChatPanel({
       // A first turn creates the conversation and bumps message counts — refresh
       // the list so the history popover + its visibility rule stay current (#62).
       void reloadConversationList(gen);
-      // A completed turn consumes allowance — refresh the composer meter (#69).
-      void refreshUsage(gen);
+      // A completed turn consumes allowance — refresh the meter (#69).
+      void refreshActivation(gen);
     } catch (e) {
       if (gen !== switchGenRef.current) return;
       setError((prev) => prev ?? String(e));
+      // Authoritative activation fallback (#76): a send can fail with
+      // chat_not_activated if the proactive check was stale — re-detect so the
+      // pane flips in. (byok_* failures leave the key configured, so this stays
+      // on the live pane and the error copy shows instead.)
+      void refreshActivation(gen);
       try {
         const h = await ipc.chatHistory(noteId, conversationId);
         if (gen === switchGenRef.current) setMessages(h.messages);
@@ -531,7 +605,9 @@ export function ChatPanel({
     }
   }
 
-  if (!readinessLoading && !ready) {
+  // Personal chat gates on personal readiness; workspace chat never shows this
+  // setup prompt (it runs on the workspace key, activated via the pane below).
+  if (!inWorkspace && !readinessLoading && !ready) {
     const isOllama = provider === "ollama";
     return (
       <div className="flex-1 min-h-0 flex flex-col items-center justify-center gap-3 px-8 text-center">
@@ -563,6 +639,9 @@ export function ChatPanel({
   }
 
   const showTyping = sending && streaming.length === 0 && !activity;
+
+  // Role-aware BYOK error copy when we have the reason; else the server message.
+  const errorView = liveChatErrorCopy(errorReason, { isOwner, ownerName }) ?? error;
 
   return (
     <div className="flex-1 min-h-0 flex flex-col">
@@ -634,10 +713,10 @@ export function ChatPanel({
         )}
       </div>
 
-      {error && (
+      {!notActivated && errorView && (
         <div className="mx-4 mb-2 flex items-start gap-2 rounded-[var(--radius)] bg-[var(--color-accent-soft)] px-3 py-2 text-xs text-[var(--color-accent-text)]">
           <AlertTriangle size={13} strokeWidth={1.7} className="mt-px shrink-0" />
-          <span>{error}</span>
+          <span>{errorView}</span>
         </div>
       )}
       {truncated && !error && (
@@ -647,6 +726,22 @@ export function ChatPanel({
         </div>
       )}
 
+      {activationLoading ? (
+        <div className="shrink-0 border-t border-[var(--color-line)] p-4 text-sm text-[var(--color-text-muted)]">
+          Checking chat activation…
+        </div>
+      ) : notActivated ? (
+        <ActivationPane
+          // Remount on workspace switch so the entry draft is destroyed
+          // synchronously — belt-and-suspenders draft isolation (#76).
+          key={workspaceId as string}
+          workspaceId={workspaceId as string}
+          isOwner={isOwner}
+          ownerName={ownerName}
+          addon={addon}
+          onActivated={handleActivated}
+        />
+      ) : (
       <div className="shrink-0 border-t border-[var(--color-line)] p-2.5 flex flex-col gap-1.5">
         {/* Send button lives INSIDE the input (Claude-Desktop style): the input
             spans the full composer width, and the button is absolutely pinned to
@@ -711,6 +806,53 @@ export function ChatPanel({
           )}
         </div>
       </div>
+      )}
+    </div>
+  );
+}
+
+// Role-aware activation pane for an unactivated workspace (#76). Replaces the
+// composer while history stays readable above. Owner: a values-first line + the
+// shared key entry (+ the managed add-on as the alternative when the server
+// offers it). Member: nothing actionable, just who to ask. The privacy line
+// respects the PRD claim boundary — "your OpenAI relationship", not "we can't
+// see your data".
+function ActivationPane({
+  workspaceId,
+  isOwner,
+  ownerName,
+  addon,
+  onActivated,
+}: {
+  workspaceId: string;
+  isOwner: boolean;
+  ownerName: string;
+  addon: ChatAddon | null;
+  onActivated: (meta: ChatKeyMeta) => void;
+}) {
+  return (
+    <div className="shrink-0 border-t border-[var(--color-line)] p-4 flex flex-col gap-3">
+      {isOwner ? (
+        <>
+          <p className="text-sm leading-relaxed">
+            Turn on chat for this workspace with your own OpenAI key — your team's chat runs on your
+            OpenAI relationship, free and unmetered.
+          </p>
+          <ChatKeyEntry workspaceId={workspaceId} onActivated={onActivated} />
+          {addon?.available && (
+            <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
+              Prefer not to manage a key? The managed add-on
+              {addon.price_cents != null &&
+                ` (${formatSeatPrice(addon.price_cents, addon.currency)}/mo)`}{" "}
+              runs chat on Humla's key — set it up in Organization → Workspace chat.
+            </p>
+          )}
+        </>
+      ) : (
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Chat isn't activated for this workspace yet — ask {ownerName}.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/lib/chatSessions.test.ts
+++ b/src/lib/chatSessions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { relativeTime, conversationTitle, usageTone } from "./chatSessions";
+import { relativeTime, conversationTitle, usageTone, liveChatErrorCopy } from "./chatSessions";
 
 const NOW = new Date("2026-07-24T12:00:00").getTime();
 const secs = (n: number) => NOW - n * 1000;
@@ -93,5 +93,37 @@ describe("usageTone", () => {
   it("is default for a non-positive cap (total edge)", () => {
     expect(usageTone(0, 0)).toBe("default");
     expect(usageTone(2, 0)).toBe("default");
+  });
+});
+
+describe("liveChatErrorCopy", () => {
+  const owner = { isOwner: true, ownerName: "Ada" };
+  const member = { isOwner: false, ownerName: "Ada" };
+
+  it("gives the owner a fix path and the member an ask-owner line for a rejected key", () => {
+    expect(liveChatErrorCopy("byok_key_invalid", owner)).toMatch(/Organization → Workspace chat/);
+    expect(liveChatErrorCopy("byok_key_invalid", member)).toMatch(/ask Ada/);
+  });
+
+  it("distinguishes provider quota from the managed add-on upsell", () => {
+    const o = liveChatErrorCopy("byok_provider_quota", owner)!;
+    const m = liveChatErrorCopy("byok_provider_quota", member)!;
+    expect(o).toMatch(/out of quota/);
+    expect(m).toMatch(/ask Ada/);
+    // Never the managed add-on's upsell wording.
+    expect(o).not.toMatch(/add-on/);
+    expect(m).not.toMatch(/add-on/);
+  });
+
+  it("treats an unavailable key as transient for everyone", () => {
+    expect(liveChatErrorCopy("byok_key_unavailable", owner)).toMatch(/try again shortly/);
+    expect(liveChatErrorCopy("byok_key_unavailable", member)).toMatch(/try again shortly/);
+  });
+
+  it("returns null for reasons outside the taxonomy (caller falls back)", () => {
+    expect(liveChatErrorCopy("quota_exhausted", owner)).toBeNull();
+    expect(liveChatErrorCopy("chat_not_activated", owner)).toBeNull();
+    expect(liveChatErrorCopy(undefined, owner)).toBeNull();
+    expect(liveChatErrorCopy("", owner)).toBeNull();
   });
 });

--- a/src/lib/chatSessions.ts
+++ b/src/lib/chatSessions.ts
@@ -52,3 +52,30 @@ export function usageTone(used: number, cap: number): UsageTone {
   if (ratio >= 0.7) return "warning";
   return "default";
 }
+
+// Role-aware copy for the BYOK error taxonomy in the LIVE chat pane (#76): the
+// workspace key was rejected / its OpenAI account is out of quota / the key is
+// transiently unavailable. Owner gets a fix path (workspace settings); a member
+// gets "ask {owner}". Returns null for any other reason (incl. the managed
+// add-on's `quota_exhausted`, which keeps its own upsell copy) so the caller
+// falls back to the server-mapped message string.
+export function liveChatErrorCopy(
+  reason: string | null | undefined,
+  opts: { isOwner: boolean; ownerName: string },
+): string | null {
+  const { isOwner, ownerName } = opts;
+  switch (reason) {
+    case "byok_key_invalid":
+      return isOwner
+        ? "This workspace's OpenAI key was rejected. Re-enter it in Organization → Workspace chat."
+        : `This workspace's OpenAI key was rejected — ask ${ownerName} to fix it.`;
+    case "byok_provider_quota":
+      return isOwner
+        ? "This workspace's OpenAI account is out of quota. Check it in Organization → Workspace chat."
+        : `This workspace's OpenAI account is out of quota — ask ${ownerName} to check it.`;
+    case "byok_key_unavailable":
+      return "Workspace chat is temporarily unavailable — try again shortly.";
+    default:
+      return null;
+  }
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -493,7 +493,13 @@ export type ChatTextDeltaEvent = {
   delta: string;
 };
 export type ChatDoneEvent = { conversationId: string; messageId: string };
-export type ChatErrorEvent = { conversationId: string; message: string };
+export type ChatErrorEvent = {
+  conversationId: string;
+  message: string;
+  // Machine reason code (issue #76) so the pane can render role-aware BYOK
+  // error copy. Empty/absent for the personal loop and unknown errors.
+  reason?: string;
+};
 export type ChatToolActivityEvent = {
   conversationId: string;
   messageId: string;

--- a/src/pages/settings/tabs/ChatKeyPanel.tsx
+++ b/src/pages/settings/tabs/ChatKeyPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../../lib/cloud";
 import { ipc, type ChatUsage } from "../../../lib/ipc";
 import { Btn } from "../components/Btn";
+import { ChatKeyEntry } from "../../../components/ChatKeyEntry";
 
 // Workspace chat activation (BYOK, issue #75). The body of the settings "Chat"
 // section. Owner: masked key entry → server test-on-save → configured state
@@ -16,9 +17,6 @@ import { Btn } from "../components/Btn";
 // blocks window.confirm). Member: read-only state, no entry, no actions. The key
 // value is never persisted client-side — it lives only in the input until save,
 // then is cleared; only metadata comes back.
-
-const inputCls =
-  "flex-1 min-w-0 text-sm px-3 py-2 rounded-md border border-[var(--color-line-visible)] bg-[var(--color-surface)] focus:border-[var(--color-text-muted)] transition-colors";
 
 // Best-effort "when set" — the server may send an RFC3339 string or an epoch
 // number. Returns "" when it can't be parsed (the caller then omits the date).
@@ -37,12 +35,7 @@ export function ChatKeyPanel({ ws }: { ws: CloudWorkspace }) {
 
   const [meta, setMeta] = useState<ChatKeyMeta | null>(null);
   const [usage, setUsage] = useState<ChatUsage | null>(null);
-  // Whether a personal OpenAI key is stored (Settings → Providers). Gates the
-  // "use it for this workspace" shortcut — the key itself never enters the
-  // webview (a Rust command reads the Keychain and does the test-on-save, #75).
-  const [hasPersonalKey, setHasPersonalKey] = useState(false);
   const [loading, setLoading] = useState(true);
-  const [keyDraft, setKeyDraft] = useState("");
   const [rotating, setRotating] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -58,17 +51,14 @@ export function ChatKeyPanel({ ws }: { ws: CloudWorkspace }) {
       setError(null);
       try {
         // Usage tells BYOK (unmetered → null) apart from the managed add-on
-        // (metered → numbers); the meta drives the BYOK state itself. The key
-        // status ("stored" | null) gates the from-Keychain shortcut.
-        const [m, u, personalKey] = await Promise.all([
+        // (metered → numbers); the meta drives the BYOK state itself.
+        const [m, u] = await Promise.all([
           cloudApi.chatKeyMeta(ws.id),
           ipc.chatUsage().catch(() => null),
-          ipc.getProviderKey("openai").catch(() => null),
         ]);
         if (cancelled()) return;
         setMeta(m);
         setUsage(u);
-        setHasPersonalKey(personalKey != null);
       } catch (e) {
         if (cancelled()) return;
         setError(String(e));
@@ -82,7 +72,6 @@ export function ChatKeyPanel({ ws }: { ws: CloudWorkspace }) {
 
   useEffect(() => {
     let cancelled = false;
-    setKeyDraft("");
     setRotating(false);
     setConfirmRemove(false);
     setNotice(null);
@@ -97,48 +86,13 @@ export function ChatKeyPanel({ ws }: { ws: CloudWorkspace }) {
   const setter = meta?.setBy ? members[meta.setBy] : undefined;
   const setByName = setter ? setter.name || setter.email : ownerName;
 
-  async function save() {
-    const key = keyDraft.trim();
-    if (!key) return;
-    setBusy(true);
-    setError(null);
-    setNotice(null);
-    try {
-      const m = await cloudApi.chatKeySet(ws.id, key);
-      // Clear the key from memory the moment it's saved — never retained.
-      setKeyDraft("");
-      setRotating(false);
-      setMeta(m);
-      setUsage(null); // BYOK is unmetered
-      setNotice("Key saved and verified.");
-    } catch (e) {
-      // The Rust layer maps reason codes to a short message; show it verbatim.
-      // (Never contains the key.) Keep the draft so the owner can correct it.
-      setError(String(e));
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  // Set the workspace key from the personal Keychain key — the key is read and
-  // POSTed entirely in Rust (never touches the webview). Same result handling
-  // as a manual save.
-  async function useKeychain() {
-    setBusy(true);
-    setError(null);
-    setNotice(null);
-    try {
-      const m = await cloudApi.chatKeySetFromKeychain(ws.id);
-      setKeyDraft("");
-      setRotating(false);
-      setMeta(m);
-      setUsage(null);
-      setNotice("Key saved and verified.");
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setBusy(false);
-    }
+  // Shared ChatKeyEntry reports the fresh metadata after a successful save /
+  // rotate / keychain shortcut — flip to the configured state (BYOK is unmetered).
+  function handleActivated(m: ChatKeyMeta) {
+    setRotating(false);
+    setMeta(m);
+    setUsage(null);
+    setNotice("Key saved and verified.");
   }
 
   async function remove() {
@@ -165,45 +119,16 @@ export function ChatKeyPanel({ ws }: { ws: CloudWorkspace }) {
 
   const degraded = meta.configured && meta.keyHealth != null && meta.keyHealth !== "ok";
 
-  // Masked entry form (owner only), shared by first-time activation and rotate.
+  // Masked entry (owner only), shared with the chat activation pane (#76). The
+  // Cancel button appears only in the rotate flow.
   const entry = (
-    <div className="flex flex-col gap-2">
-      <div className="flex gap-2">
-        <input
-          type="password"
-          className={inputCls}
-          value={keyDraft}
-          onChange={(e) => setKeyDraft(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && save()}
-          placeholder="sk-…"
-          aria-label="OpenAI API key"
-          autoComplete="off"
-        />
-        <Btn onClick={save} disabled={busy || !keyDraft.trim()}>
-          {busy ? "Saving…" : "Save"}
-        </Btn>
-        {rotating && (
-          <Btn onClick={() => { setRotating(false); setKeyDraft(""); setError(null); }} disabled={busy}>
-            Cancel
-          </Btn>
-        )}
-      </div>
-      <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
-        Your key is sent straight to the server, tested against OpenAI, and stored encrypted — it's
-        never kept on this device. Chat then runs on your OpenAI account, free and unmetered.
-      </p>
-      {hasPersonalKey && (
-        <div className="flex flex-col gap-1 pt-1">
-          <Btn onClick={useKeychain} disabled={busy}>
-            {busy ? "Saving…" : "Use the OpenAI key from Settings"}
-          </Btn>
-          <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
-            Shares the key from Settings → Providers with this workspace. Everyone's chat then runs
-            on your OpenAI account.
-          </p>
-        </div>
-      )}
-    </div>
+    <ChatKeyEntry
+      // Remount on workspace switch → destroy any typed draft synchronously (#76).
+      key={ws.id}
+      workspaceId={ws.id}
+      onActivated={handleActivated}
+      onCancel={rotating ? () => setRotating(false) : undefined}
+    />
   );
 
   return (


### PR DESCRIPTION
Closes #76 (child of #74 — final slice). Server: michaelwilhelmsen/humla-cloud#23 (deployed).

- **Activation pane** for unactivated workspace chat: owners get a values-first pitch (respecting the PRD claim boundary), inline key entry via the shared `ChatKeyEntry` (extracted from #75's settings panel — same security posture, keychain shortcut included), and the add-on alternative only where offered; members get "ask {owner}". Activation flips to the live composer without reload and focuses it.
- **Cutover promise**: history + popover fully readable while unactivated; only the composer is swapped.
- **Detection**: proactive (key meta + usage, gen-guarded) with the server's `402 chat_not_activated` as authoritative fallback; self-host `chat_disabled` never triggers the pane (deliberate surface change documented in the commit).
- **Error taxonomy**: role-aware `byok_key_invalid` / `byok_provider_quota` copy, transient `byok_key_unavailable`; `quota_exhausted` upsell untouched; SSE reason relay pinned by a frame-parsing test.
- **Review hard-fix**: workspace sends no longer gate on personal chat readiness — a member without a personal OpenAI key can send in an activated workspace (regression-tested).

Tests: frontend 268, backend 321, tsc clean. Two-axis review run (security posture verified on the shared entry); user-verified in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)