### PR TITLE
feat(chat): CHAT_SCOPE_GLOBAL + scope threading through the chat commands (#93)

### DIFF
--- a/src-tauri/src/chat/cloud.rs
+++ b/src-tauri/src/chat/cloud.rs
@@ -32,19 +32,38 @@ pub fn build_cloud_request(
     message: &str,
     title: Option<&str>,
     breadth: &str,
-    note_id: &str,
+    note_id: Option<&str>,
     folder_id: Option<&str>,
 ) -> Result<Value, String> {
     // Reject an unknown breadth through the shared validator — one owner of the
     // vocabulary and its error, no duplicated match/message here.
     super::validate_breadth(breadth)?;
-    // `note_id` stays in every scope so the server can ground on the anchor
-    // Note regardless of breadth (under "all" the server ignores it by design).
+    // A library-wide turn (#93) sends NO `note_id` at all: the server 400s a
+    // malformed `note_id` under *every* breadth including "all", so a sentinel or
+    // an empty string would be rejected rather than ignored (humla-cloud#26).
+    // An EMPTY anchor is a caller bug, not "absent" — `ChatTarget::from_note_id`
+    // rejects it at the IPC boundary and this is the matching strictness, so the
+    // same value can't mean two things at two layers.
+    if note_id.is_some_and(|s| s.trim().is_empty()) {
+        return Err("An empty note id is not a valid chat anchor.".into());
+    }
+    let anchor = note_id;
+    // The anchor-less rule lives in `chat::check_anchor` — one owner, one message.
+    super::check_anchor(breadth, anchor.is_some())?;
+    // When present, `note_id` stays in every scope so the server can ground on the
+    // anchor Note regardless of breadth (under "all" the server ignores it by
+    // design).
+    let with_anchor = |mut v: Value| -> Value {
+        if let Some(id) = anchor {
+            v["note_id"] = json!(id);
+        }
+        v
+    };
     let scope = match breadth {
-        "note" => json!({ "breadth": "note", "note_id": note_id }),
-        "all" => json!({ "breadth": "all", "note_id": note_id }),
+        "note" => with_anchor(json!({ "breadth": "note" })),
+        "all" => with_anchor(json!({ "breadth": "all" })),
         "folder" => match folder_id.filter(|f| !f.is_empty()) {
-            Some(f) => json!({ "breadth": "folder", "note_id": note_id, "folder_id": f }),
+            Some(f) => with_anchor(json!({ "breadth": "folder", "folder_id": f })),
             None => {
                 return Err(
                     "\"Folder\" scope needs a folder, but this note isn't in one.".into()
@@ -375,7 +394,7 @@ mod tests {
 
     #[test]
     fn request_defaults_to_note_breadth_with_grounding_anchor() {
-        let b = build_cloud_request(None, "ws1", "hi", None, "note", "n1", None).unwrap();
+        let b = build_cloud_request(None, "ws1", "hi", None, "note", Some("n1"), None).unwrap();
         assert_eq!(b["workspace_id"], "ws1");
         assert_eq!(b["message"], "hi");
         assert_eq!(b["scope"], json!({ "breadth": "note", "note_id": "n1" }));
@@ -383,15 +402,50 @@ mod tests {
         assert!(b.get("title").is_none());
     }
 
+    /// #93: a library-wide turn OMITS `note_id` entirely. The server 400s a
+    /// malformed `note_id` under *every* breadth including "all" (humla-cloud#26),
+    /// so a sentinel or an empty string would be rejected rather than ignored —
+    /// the key has to be absent.
+    #[test]
+    fn a_library_wide_request_sends_no_anchor_at_all() {
+        let b = build_cloud_request(None, "ws1", "hi", None, "all", None, None).unwrap();
+        assert_eq!(b["scope"], json!({ "breadth": "all" }));
+        assert!(
+            b["scope"].get("note_id").is_none(),
+            "an absent anchor must not become a key at all"
+        );
+        // An EMPTY anchor is a caller bug, not "absent" — the same strictness
+        // `ChatTarget::from_note_id` applies at the IPC boundary, so `""` can't
+        // mean "a note" at one layer and "the library" at another.
+        let err = build_cloud_request(None, "ws1", "hi", None, "all", Some(""), None).unwrap_err();
+        assert!(err.contains("empty note id"), "got: {err}");
+    }
+
+    /// A note-less create must be breadth "all" — a note-less "folder" is a 400
+    /// server-side, so catch it here as our bug rather than as a failed turn.
+    #[test]
+    fn a_request_without_an_anchor_must_be_all_breadth() {
+        for breadth in ["note", "folder"] {
+            let err = build_cloud_request(None, "ws1", "hi", None, breadth, None, Some("f1"))
+                .unwrap_err();
+            assert!(err.contains("needs an anchor note"), "{breadth}: {err}");
+        }
+        // With an anchor, both still build as before.
+        assert!(build_cloud_request(None, "ws1", "hi", None, "note", Some("n1"), None).is_ok());
+        assert!(
+            build_cloud_request(None, "ws1", "hi", None, "folder", Some("n1"), Some("f1")).is_ok()
+        );
+    }
+
     #[test]
     fn request_carries_remote_id_and_title_when_present() {
         let b =
-            build_cloud_request(Some("srv123"), "ws1", "hi", Some("Kickoff"), "note", "n1", None)
+            build_cloud_request(Some("srv123"), "ws1", "hi", Some("Kickoff"), "note", Some("n1"), None)
                 .unwrap();
         assert_eq!(b["conversation_id"], "srv123");
         assert_eq!(b["title"], "Kickoff");
         // Empty strings are dropped, not sent.
-        let b2 = build_cloud_request(Some(""), "ws1", "hi", Some(""), "note", "n1", None).unwrap();
+        let b2 = build_cloud_request(Some(""), "ws1", "hi", Some(""), "note", Some("n1"), None).unwrap();
         assert!(b2.get("conversation_id").is_none());
         assert!(b2.get("title").is_none());
     }
@@ -399,7 +453,7 @@ mod tests {
     #[test]
     fn request_folder_breadth_carries_the_folder_id() {
         let with =
-            build_cloud_request(None, "ws1", "hi", None, "folder", "n1", Some("f1")).unwrap();
+            build_cloud_request(None, "ws1", "hi", None, "folder", Some("n1"), Some("f1")).unwrap();
         assert_eq!(with["scope"], json!({ "breadth": "folder", "note_id": "n1", "folder_id": "f1" }));
     }
 
@@ -408,20 +462,20 @@ mod tests {
         // Issue #58: no silent degradation. The desktop heals the folder-less
         // case to "note" upstream, so this strict guard shouldn't fire — but if
         // it's reached it errors loudly rather than quietly narrowing to note.
-        let err = build_cloud_request(None, "ws1", "hi", None, "folder", "n1", None).unwrap_err();
+        let err = build_cloud_request(None, "ws1", "hi", None, "folder", Some("n1"), None).unwrap_err();
         assert!(err.to_lowercase().contains("folder"), "names the missing folder: {err}");
     }
 
     #[test]
     fn request_unrecognized_breadth_is_an_error() {
         // Issue #58: the former `_ => {}` fall-through silently clamped to note.
-        let err = build_cloud_request(None, "ws1", "hi", None, "everything", "n1", None).unwrap_err();
+        let err = build_cloud_request(None, "ws1", "hi", None, "everything", Some("n1"), None).unwrap_err();
         assert!(err.contains("everything"), "the offending value is surfaced: {err}");
     }
 
     #[test]
     fn request_all_breadth_keeps_the_grounding_anchor() {
-        let b = build_cloud_request(None, "ws1", "hi", None, "all", "n1", None).unwrap();
+        let b = build_cloud_request(None, "ws1", "hi", None, "all", Some("n1"), None).unwrap();
         assert_eq!(b["scope"], json!({ "breadth": "all", "note_id": "n1" }));
     }
 

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -43,6 +43,37 @@ pub fn validate_breadth(breadth: &str) -> Result<&str, String> {
     }
 }
 
+/// The breadth a target's first-ever conversation starts at. A library-wide
+/// conversation has no anchor to narrow to, so it is always `all` (#82 fixed v1 at
+/// all-notes-only); a Note's defaults to itself.
+///
+/// Lives here rather than on `ChatTarget` so the breadth vocabulary and its
+/// defaults stay in the module that owns `validate_breadth` — `db` shouldn't mint
+/// breadth strings it can't validate.
+pub fn default_breadth(target: &crate::db::ChatTarget) -> &'static str {
+    match target {
+        crate::db::ChatTarget::Note(_) => "note",
+        crate::db::ChatTarget::Global => "all",
+    }
+}
+
+/// Whether a breadth can run without an anchor note, in ONE place (#93).
+///
+/// Two server rules make this exact (humla-cloud#26): a note-less create must be
+/// breadth `all`, and a malformed `note_id` is a 400 under *every* breadth — so an
+/// anchor-less `note`/`folder` turn is our bug and must be caught before it
+/// becomes a failed request. Both request builders and the local resolver funnel
+/// through here so the message exists once, matching the discipline
+/// `validate_breadth` already sets.
+pub fn check_anchor(breadth: &str, has_anchor: bool) -> Result<(), String> {
+    if has_anchor || validate_breadth(breadth)? == "all" {
+        return Ok(());
+    }
+    Err(format!(
+        "chat breadth {breadth:?} needs an anchor note; only \"all\" can run without one"
+    ))
+}
+
 // ── Typed message parts ─────────────────────────────────────────────────────
 // `messages.content` is a JSON array of these, ordered by the row's `seq`. Only
 // `Text` exists in this slice; `reasoning` / `tool` variants (see the wire
@@ -711,6 +742,39 @@ mod tests {
         for bad in ["", "everything", "Note", "all_notes", "workspace"] {
             let err = validate_breadth(bad).unwrap_err();
             assert!(err.contains(&format!("{bad:?}")), "surfaces the bad value: {err}");
+        }
+    }
+
+    /// #93: the anchor rule has three callers (both cloud request builders and the
+    /// local resolver). This is its single owner, so the contract is asserted here
+    /// rather than three times over.
+    #[test]
+    fn check_anchor_allows_only_all_to_run_without_a_note() {
+        // With an anchor, every breadth is fine.
+        for b in ["note", "folder", "all"] {
+            assert!(check_anchor(b, true).is_ok(), "{b} with an anchor");
+        }
+        // Without one, only "all" — a note-less create of any other breadth is a
+        // 400 server-side (humla-cloud#26), so it's caught as our bug first.
+        assert!(check_anchor("all", false).is_ok());
+        for b in ["note", "folder"] {
+            let err = check_anchor(b, false).unwrap_err();
+            assert!(err.contains("needs an anchor note"), "{b}: {err}");
+        }
+        // Garbage still funnels through validate_breadth's message, not a second one.
+        let err = check_anchor("everything", false).unwrap_err();
+        assert!(err.contains("Unrecognized chat scope"), "got: {err}");
+    }
+
+    #[test]
+    fn a_library_wide_conversation_defaults_to_all_and_a_notes_to_note() {
+        use crate::db::ChatTarget;
+        assert_eq!(default_breadth(&ChatTarget::Global), "all");
+        assert_eq!(default_breadth(&ChatTarget::Note("n1".into())), "note");
+        // Both defaults must be values `validate_breadth` accepts — the reason this
+        // lives here rather than on `ChatTarget` in `db`.
+        for t in [ChatTarget::Global, ChatTarget::Note("n1".into())] {
+            assert!(validate_breadth(default_breadth(&t)).is_ok());
         }
     }
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -7,7 +7,7 @@
 
 use super::{DEFAULT_LOCAL_LLM_BASE_URL, DEFAULT_SUMMARY_MODEL};
 use crate::chat::{self, ChatCtx, ChatEvent, Citation, ToolScope};
-use crate::db::{self, CHAT_SCOPE_NOTE, CHAT_TENANT_PERSONAL};
+use crate::db::{self, ChatTarget, CHAT_TENANT_PERSONAL};
 use crate::embed::{self, EmbeddingAdapter, OLLAMA_EMBED_MODEL, OPENAI_EMBED_MODEL};
 use crate::openai;
 use crate::AppState;
@@ -189,19 +189,93 @@ fn heal_and_read_breadth(
     Ok(breadth.to_string())
 }
 
+/// The library-wide counterpart: a global conversation is all-notes-only in v1
+/// (#82), so "note" and "folder" are meaningless — it has no anchor to mean them
+/// by. Heal rather than error, matching the folder-heal above: a corrupt row must
+/// not be able to break the user's chat.
+///
+/// A separate function rather than an `Option<&Note>` arm on the one above,
+/// because `None` there would hide a whole policy branch behind a nullable
+/// parameter — a reader couldn't tell "library-wide" from "note not loaded".
+fn heal_and_read_global_breadth(
+    conn: &rusqlite::Connection,
+    conversation_id: &str,
+    stored: &str,
+) -> Result<String, String> {
+    if chat::validate_breadth(stored)? != "all" {
+        db::set_conversation_breadth(conn, conversation_id, "all").map_err(|e| e.to_string())?;
+    }
+    Ok("all".into())
+}
+
+/// Effective breadth for whichever target a turn is on — the one place the two
+/// heal policies are chosen between.
+fn effective_breadth(
+    conn: &rusqlite::Connection,
+    conversation_id: &str,
+    stored: &str,
+    note: Option<&db::Note>,
+) -> Result<String, String> {
+    match note {
+        Some(note) => heal_and_read_breadth(conn, conversation_id, stored, note),
+        None => heal_and_read_global_breadth(conn, conversation_id, stored),
+    }
+}
+
+/// Load a turn's anchor note, or None for a library-wide turn. There is
+/// deliberately no fallback note (#82) — a global turn runs on retrieval alone.
+fn anchor_note(
+    conn: &rusqlite::Connection,
+    target: &ChatTarget,
+) -> Result<Option<db::Note>, String> {
+    match target.note_id() {
+        Some(id) => db::get_note(conn, id).map(Some).map_err(|e| e.to_string()),
+        None => Ok(None),
+    }
+}
+
+/// The reference block for a turn, plus the anchor's plain-text body when there is
+/// one (the caller reindexes it). A library-wide turn gets NO grounding at all —
+/// `assemble_prompt` skips an empty block, and nothing was truncated because
+/// nothing was injected.
+fn turn_grounding(note: Option<&db::Note>) -> (chat::Grounding, Option<String>) {
+    match note {
+        Some(note) => {
+            let body_text = crate::html_text::html_to_text(&note.body);
+            let grounding =
+                chat::build_grounding(&body_text, &note.transcript, &note.summary);
+            (grounding, Some(body_text))
+        }
+        None => (chat::Grounding { text: String::new(), truncated: false }, None),
+    }
+}
+
 /// Resolve an (already-effective) breadth into a server-enforced `ToolScope`.
 /// "folder" resolves to the anchor Note's folder. Unrecognised breadths and a
 /// folder breadth without a folder are loud errors (issue #58) rather than a
 /// silent clamp to Note — in practice `heal_and_read_breadth` heals the
 /// folder-less case upstream, so those arms are belt-and-suspenders.
-fn resolve_scope(breadth: &str, note: &db::Note) -> Result<ToolScope, String> {
+///
+/// `note` is `None` for a library-wide turn (#93), which resolves straight to
+/// `All` without reaching for an anchor — the retrieval tools carry it alone.
+fn resolve_scope(breadth: &str, note: Option<&db::Note>) -> Result<ToolScope, String> {
     match chat::validate_breadth(breadth)? {
         "all" => Ok(ToolScope::All),
-        "folder" => match note.folder_id.as_deref() {
+        "folder" => match note.and_then(|n| n.folder_id.as_deref()) {
             Some(folder_id) if !folder_id.is_empty() => Ok(ToolScope::Folder(folder_id.to_string())),
             _ => Err("This note isn't in a folder, so \"Folder\" scope isn't available.".into()),
         },
-        _ => Ok(ToolScope::Note(note.id.clone())),
+        // A "note" breadth with no note can only be a corrupt global row.
+        // `heal_and_read_global_breadth` rewrites those to "all" before a turn ever
+        // reaches here, so this is unreachable in practice — and it errors rather
+        // than widening to the whole library, which would silently search
+        // everything on the strength of a bad row. Loud, like every other arm.
+        _ => match note {
+            Some(n) => Ok(ToolScope::Note(n.id.clone())),
+            None => Err(
+                "This conversation has no anchor note, so only \"All notes\" scope applies.".into(),
+            ),
+        },
     }
 }
 
@@ -443,78 +517,91 @@ fn conversation_meta(
     })
 }
 
-/// The breadth a new session inherits (issue #61): the Note's most-recent
-/// session's breadth, or "note" for the Note's first-ever session.
-fn inherited_breadth(conn: &rusqlite::Connection, tenant: &str, note_id: &str) -> String {
-    db::latest_conversation(conn, tenant, CHAT_SCOPE_NOTE, note_id)
+/// The breadth a new session inherits (issue #61): the target's most-recent
+/// session's breadth, or the target's own default for its first-ever session
+/// ("note" for a Note, "all" for the library — a global thread has no anchor to
+/// narrow to).
+fn inherited_breadth(conn: &rusqlite::Connection, tenant: &str, target: &ChatTarget) -> String {
+    db::latest_conversation(conn, tenant, target.scope(), target.scope_id())
         .ok()
         .flatten()
         .map(|c| c.breadth)
-        .unwrap_or_else(|| "note".to_string())
+        .unwrap_or_else(|| chat::default_breadth(target).to_string())
 }
 
 /// Resolve the session a command targets WITHOUT creating one (None when the
 /// Note has no session yet). `explicit` targets a specific session; otherwise
 /// the most-recently-updated one is the active session.
 ///
-/// An explicit id is validated to belong to the expected (tenant, note) scope —
-/// a mismatched id is a clean error, never a silent cross-scope operation (which
-/// would, e.g., heal breadth against the wrong Note). A not-found explicit id is
-/// treated as "no session" (None) so the caller falls back to the active one.
+/// An explicit id is validated to belong to the expected (tenant, scope,
+/// scope_id) — a mismatched id is a clean error, never a silent cross-scope
+/// operation (which would, e.g., heal breadth against the wrong Note, or splice
+/// a note thread into the library list). A not-found explicit id is treated as
+/// "no session" (None) so the caller falls back to the active one.
 fn resolve_existing(
     conn: &rusqlite::Connection,
     tenant: &str,
-    note_id: &str,
+    target: &ChatTarget,
     explicit: Option<&str>,
 ) -> Result<Option<db::Conversation>, String> {
     if let Some(id) = explicit {
         let Some(c) = db::get_conversation_by_id(conn, id).map_err(|e| e.to_string())? else {
             return Ok(None);
         };
-        if c.tenant != tenant || c.scope != CHAT_SCOPE_NOTE || c.scope_id != note_id {
-            return Err("That chat session doesn't belong to this note.".into());
+        if c.tenant != tenant || c.scope != target.scope() || c.scope_id != target.scope_id() {
+            return Err(match target {
+                ChatTarget::Note(_) => "That chat session doesn't belong to this note.".into(),
+                ChatTarget::Global => "That chat session isn't a library-wide one.".to_string(),
+            });
         }
         return Ok(Some(c));
     }
-    db::latest_conversation(conn, tenant, CHAT_SCOPE_NOTE, note_id).map_err(|e| e.to_string())
-}
-
-/// Resolve the active session, lazily creating the Note's FIRST session when
-/// none exists (breadth defaults to "note"). Used by send + set-breadth so the
-/// first turn / first breadth write materialises the session on demand.
-fn resolve_or_create(
-    conn: &rusqlite::Connection,
-    tenant: &str,
-    note_id: &str,
-    explicit: Option<&str>,
-) -> Result<db::Conversation, String> {
-    if let Some(c) = resolve_existing(conn, tenant, note_id, explicit)? {
-        return Ok(c);
-    }
-    let breadth = inherited_breadth(conn, tenant, note_id);
-    db::create_conversation(conn, tenant, CHAT_SCOPE_NOTE, note_id, &breadth)
+    db::latest_conversation(conn, tenant, target.scope(), target.scope_id())
         .map_err(|e| e.to_string())
 }
 
-/// Resolve the "new session" for a Note in the personal scope (issue #61),
+/// Resolve the active session, lazily creating the target's FIRST session when
+/// none exists (breadth defaults to the target's own). Used by send + set-breadth
+/// so the first turn / first breadth write materialises the session on demand.
+fn resolve_or_create(
+    conn: &rusqlite::Connection,
+    tenant: &str,
+    target: &ChatTarget,
+    explicit: Option<&str>,
+) -> Result<db::Conversation, String> {
+    if let Some(c) = resolve_existing(conn, tenant, target, explicit)? {
+        return Ok(c);
+    }
+    let breadth = inherited_breadth(conn, tenant, target);
+    db::create_conversation(conn, tenant, target.scope(), target.scope_id(), &breadth)
+        .map_err(|e| e.to_string())
+}
+
+/// Resolve the "new session" for a target in the personal scope (issue #61),
 /// honoring the no-op guard: if the most-recent session has no messages, reuse
 /// it instead of piling up empty sessions; otherwise create a fresh one that
 /// inherits breadth from the most-recent session.
 fn new_personal_conversation(
     conn: &rusqlite::Connection,
-    note_id: &str,
+    target: &ChatTarget,
 ) -> Result<db::Conversation, String> {
     if let Some(latest) =
-        db::latest_conversation(conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, note_id)
+        db::latest_conversation(conn, CHAT_TENANT_PERSONAL, target.scope(), target.scope_id())
             .map_err(|e| e.to_string())?
     {
         if db::conversation_message_count(conn, &latest.id).map_err(|e| e.to_string())? == 0 {
             return Ok(latest);
         }
     }
-    let breadth = inherited_breadth(conn, CHAT_TENANT_PERSONAL, note_id);
-    db::create_conversation(conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, note_id, &breadth)
-        .map_err(|e| e.to_string())
+    let breadth = inherited_breadth(conn, CHAT_TENANT_PERSONAL, target);
+    db::create_conversation(
+        conn,
+        CHAT_TENANT_PERSONAL,
+        target.scope(),
+        target.scope_id(),
+        &breadth,
+    )
+    .map_err(|e| e.to_string())
 }
 
 /// List a Note's chat sessions, most-recently-updated first (issue #61).
@@ -523,8 +610,9 @@ fn new_personal_conversation(
 #[tauri::command]
 pub async fn chat_list_conversations(
     app: AppHandle,
-    note_id: String,
+    note_id: Option<String>,
 ) -> Result<Vec<ConversationMeta>, String> {
+    let target = ChatTarget::from_note_id(note_id)?;
     let state: State<AppState> = app.state();
     let ctx = {
         let conn = state.db.lock();
@@ -533,23 +621,28 @@ pub async fn chat_list_conversations(
     match ctx.workspace() {
         None => {
             let conn = state.db.lock();
-            let convs =
-                db::list_conversations(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, &note_id)
-                    .map_err(|e| e.to_string())?;
+            let convs = db::list_conversations(
+                &conn,
+                CHAT_TENANT_PERSONAL,
+                target.scope(),
+                target.scope_id(),
+            )
+            .map_err(|e| e.to_string())?;
             convs.iter().map(|c| conversation_meta(&conn, c)).collect()
         }
-        Some(ws) => list_conversations_cloud(&state, ws, &note_id).await,
+        Some(ws) => list_conversations_cloud(&state, ws, &target).await,
     }
 }
 
-/// Create a fresh chat session for a Note (issue #61). Personal creates a local
+/// Create a fresh chat session for a target (issue #61). Personal creates a local
 /// row (with the no-op guard reusing an empty most-recent session); a workspace
 /// delegates to the server (see [`new_conversation_cloud`]).
 #[tauri::command]
 pub async fn chat_new_conversation(
     app: AppHandle,
-    note_id: String,
+    note_id: Option<String>,
 ) -> Result<ConversationMeta, String> {
+    let target = ChatTarget::from_note_id(note_id)?;
     let state: State<AppState> = app.state();
     let ctx = {
         let conn = state.db.lock();
@@ -558,10 +651,10 @@ pub async fn chat_new_conversation(
     match ctx.workspace() {
         None => {
             let conn = state.db.lock();
-            let conv = new_personal_conversation(&conn, &note_id)?;
+            let conv = new_personal_conversation(&conn, &target)?;
             conversation_meta(&conn, &conv)
         }
-        Some(ws) => new_conversation_cloud(&state, ws, &note_id).await,
+        Some(ws) => new_conversation_cloud(&state, ws, &target).await,
     }
 }
 
@@ -574,16 +667,23 @@ pub async fn chat_new_conversation(
 #[tauri::command]
 pub fn chat_set_breadth(
     app: AppHandle,
-    note_id: String,
+    note_id: Option<String>,
     conversation_id: Option<String>,
     breadth: String,
 ) -> Result<(), String> {
     chat::validate_breadth(&breadth)?;
+    let target = ChatTarget::from_note_id(note_id)?;
+    if matches!(target, ChatTarget::Global) && breadth != "all" {
+        // #82 fixed the library surface at all-notes-only for v1, so there is no
+        // picker to send this — reject rather than store a breadth that
+        // `heal_and_read_breadth` would immediately undo.
+        return Err("A library-wide chat always searches all notes.".into());
+    }
     let state: State<AppState> = app.state();
     let conn = state.db.lock();
     let ctx = ChatContext::load(&conn);
     let conversation =
-        resolve_or_create(&conn, ctx.tenant(), &note_id, conversation_id.as_deref())?;
+        resolve_or_create(&conn, ctx.tenant(), &target, conversation_id.as_deref())?;
     db::set_conversation_breadth(&conn, &conversation.id, &breadth).map_err(|e| e.to_string())
 }
 
@@ -598,23 +698,25 @@ pub fn chat_set_breadth(
 #[tauri::command]
 pub fn chat_get_breadth(
     app: AppHandle,
-    note_id: String,
+    note_id: Option<String>,
     conversation_id: Option<String>,
 ) -> Result<String, String> {
+    let target = ChatTarget::from_note_id(note_id)?;
     let state: State<AppState> = app.state();
     let conn = state.db.lock();
     let ctx = ChatContext::load(&conn);
     let Some(conversation) =
-        resolve_existing(&conn, ctx.tenant(), &note_id, conversation_id.as_deref())?
+        resolve_existing(&conn, ctx.tenant(), &target, conversation_id.as_deref())?
     else {
-        // No session yet → the Note's first conversation defaults to "note",
-        // which is also what `inherited_breadth` returns here (its
-        // `latest_conversation` read would be redundant — `resolve_existing`
-        // just established there's no session).
-        return Ok("note".into());
+        // No session yet → report the target's own default WITHOUT creating a row,
+        // which is also what `inherited_breadth` would return here (its
+        // `latest_conversation` read would be redundant — `resolve_existing` just
+        // established there's no session).
+        return Ok(chat::default_breadth(&target).into());
     };
-    let note = db::get_note(&conn, &note_id).map_err(|e| e.to_string())?;
-    heal_and_read_breadth(&conn, &conversation.id, &conversation.breadth, &note)
+    // A library-wide conversation has no anchor to heal against.
+    let note = anchor_note(&conn, &target)?;
+    effective_breadth(&conn, &conversation.id, &conversation.breadth, note.as_ref())
 }
 
 /// Workspace turn-allowance for the composer meter (issue #69). Personal chat is
@@ -800,9 +902,12 @@ impl Drop for TurnCancel {
 /// dropped, but the server finishes generating and the tokens are really spent,
 /// so a metered turn still counts. A server-side cancel is the follow-up.
 #[tauri::command]
-pub fn chat_cancel(app: AppHandle, note_id: String) -> Result<(), String> {
+pub fn chat_cancel(app: AppHandle, note_id: Option<String>) -> Result<(), String> {
     let state: State<AppState> = app.state();
-    if let Some(flag) = state.chat_cancels.lock().get(&note_id) {
+    // Panes are keyed by `scope_id`, which is the note id for a note pane and the
+    // global sentinel for the library pane — so the two can't stop each other.
+    let target = ChatTarget::from_note_id(note_id)?;
+    if let Some(flag) = state.chat_cancels.lock().get(target.scope_id()) {
         flag.cancel();
     }
     Ok(())
@@ -811,10 +916,11 @@ pub fn chat_cancel(app: AppHandle, note_id: String) -> Result<(), String> {
 #[tauri::command]
 pub async fn chat_send(
     app: AppHandle,
-    note_id: String,
+    note_id: Option<String>,
     conversation_id: Option<String>,
     message: String,
 ) -> Result<ChatSendResult, String> {
+    let target = ChatTarget::from_note_id(note_id)?;
     let state: State<AppState> = app.state();
     // Chat is pinned to the loaded context (issue #58): a loaded workspace →
     // the Teams (cloud) path; Personal (no workspace) → the on-device path
@@ -824,7 +930,7 @@ pub async fn chat_send(
         ChatContext::load(&conn).workspace().is_some()
     };
     if in_workspace {
-        return chat_send_cloud(app, note_id, conversation_id, message).await;
+        return chat_send_cloud(app, target, conversation_id, message).await;
     }
 
     // Keychain read out of band — not inside the DB lock. Chat reuses the
@@ -833,42 +939,47 @@ pub async fn chat_send(
 
     let (grounding, resolved, conversation_id, tool_scope, workspace) = {
         let conn = state.db.lock();
-        let note = db::get_note(&conn, &note_id).map_err(|e| e.to_string())?;
+        let note = anchor_note(&conn, &target)?;
         // We branched to the Personal path above (no active workspace), so the
         // tenant is Personal and there's no workspace to scope tools to.
         let workspace = String::new();
         let resolved = resolve_chat(&conn, openai_api_key).map_err(|e| e.to_string())?;
         // Resolve the target session (issue #61): an explicit id, else the
-        // active/most-recent one, lazily creating the Note's first session on
+        // active/most-recent one, lazily creating the target's first session on
         // the first send. Breadth is a persisted live filter within it.
         let conversation =
-            resolve_or_create(&conn, CHAT_TENANT_PERSONAL, &note_id, conversation_id.as_deref())?;
+            resolve_or_create(&conn, CHAT_TENANT_PERSONAL, &target, conversation_id.as_deref())?;
         // Set the personal session's title once, from its first user message
         // (issue #61). Guarded on an empty title so later turns never rewrite it.
         if resolved_title_is_unset(&conversation) {
             let title = chat::derive_title(Some(&message), conversation.created_at);
             let _ = db::set_conversation_title(&conn, &conversation.id, &title);
         }
+        let (grounding, body_text) = turn_grounding(note.as_ref());
         // Keep the anchor Note searchable — reindex it now so "this Note" and
         // any broader search always find the note the user is looking at, even
-        // if a content-settled checkpoint hasn't fired yet.
-        let body_text = crate::html_text::html_to_text(&note.body);
-        let _ = db::reindex_note(&conn, &note.id, &body_text, &note.transcript, &note.summary);
+        // if a content-settled checkpoint hasn't fired yet. Nothing to do for a
+        // library-wide turn: every note is reindexed at its own checkpoints.
+        if let (Some(note), Some(body_text)) = (note.as_ref(), body_text.as_deref()) {
+            let _ = db::reindex_note(&conn, &note.id, body_text, &note.transcript, &note.summary);
+        }
         // Breadth is read from the conversation row (single source of truth),
         // self-healed against the Note's current folder.
         let breadth =
-            heal_and_read_breadth(&conn, &conversation.id, &conversation.breadth, &note)?;
-        let tool_scope = resolve_scope(&breadth, &note)?;
-        let grounding = chat::build_grounding(&body_text, &note.transcript, &note.summary);
+            effective_breadth(&conn, &conversation.id, &conversation.breadth, note.as_ref())?;
+        let tool_scope = resolve_scope(&breadth, note.as_ref())?;
         (grounding, resolved, conversation.id, tool_scope, workspace)
     };
 
     // Embed the anchor Note now (best-effort, cached) so semantic search works
     // for the note the user is chatting about on the very first question. Other
-    // notes are embedded at their own checkpoints (issue #48).
+    // notes are embedded at their own checkpoints (issue #48) — so a library-wide
+    // turn has nothing to pre-embed and skips straight to the loop.
     let embed_cfg = resolve_embed(&resolved);
     let embedder = embed_cfg.adapter();
-    embed_note(&state.db, &embedder, &note_id).await;
+    if let Some(anchor) = target.note_id() {
+        embed_note(&state.db, &embedder, anchor).await;
+    }
 
     let adapter = chat::build_chat_adapter(&resolved.provider);
     let conv_for_sink = conversation_id.clone();
@@ -912,7 +1023,7 @@ pub async fn chat_send(
 
     // Register the stop signal for this pane; dropped (and cleared) when the
     // turn finishes, however it finishes (issue #80).
-    let turn = TurnCancel::register(&state, &note_id);
+    let turn = TurnCancel::register(&state, target.scope_id());
     let ctx = ChatCtx {
         model: &resolved.model,
         api_key: resolved.api_key.as_deref(),
@@ -970,7 +1081,7 @@ struct CloudTurn {
 /// workspace, so a turn can never reach a different tenant (story 5/19).
 async fn chat_send_cloud(
     app: AppHandle,
-    note_id: String,
+    target: ChatTarget,
     conversation_id: Option<String>,
     message: String,
 ) -> Result<ChatSendResult, String> {
@@ -981,16 +1092,24 @@ async fn chat_send_cloud(
         let Some(workspace) = ctx.workspace() else {
             return Err("No workspace selected — switch to a workspace to use Team chat.".into());
         };
-        let note = db::get_note(&conn, &note_id).map_err(|e| e.to_string())?;
+        let note = anchor_note(&conn, &target)?;
         // Resolve the target workspace-handle session (issue #61): an explicit
         // id, else the active/most-recent handle, lazily creating one (remote_id
         // filled from the server's response below) on the first turn.
-        let conversation = resolve_or_create(&conn, workspace, &note_id, conversation_id.as_deref())?;
+        let conversation = resolve_or_create(&conn, workspace, &target, conversation_id.as_deref())?;
         // Breadth is read from the (workspace) conversation row and self-healed
         // against the Note's folder, exactly like the Personal path (issue #58).
         let breadth =
-            heal_and_read_breadth(&conn, &conversation.id, &conversation.breadth, &note)?;
-        (workspace.to_string(), note.folder_id.clone(), note.title.clone(), conversation, breadth)
+            effective_breadth(&conn, &conversation.id, &conversation.breadth, note.as_ref())?;
+        (
+            workspace.to_string(),
+            note.as_ref().and_then(|n| n.folder_id.clone()),
+            // The server derives a global conversation's title from the first
+            // message, the same as Personal; there's no note title to send.
+            note.as_ref().map(|n| n.title.clone()).unwrap_or_default(),
+            conversation,
+            breadth,
+        )
     };
 
     let body = chat::cloud::build_cloud_request(
@@ -999,7 +1118,7 @@ async fn chat_send_cloud(
         &message,
         Some(&title),
         &breadth,
-        &note_id,
+        target.note_id(),
         folder_id.as_deref(),
     )?;
 
@@ -1010,7 +1129,7 @@ async fn chat_send_cloud(
     // generating and finishes the turn, so a metered turn still counts and the
     // history reload afterwards shows the server's complete answer rather than
     // the partial. A server-side cancel is the follow-up (humla-cloud#26).
-    let turn_cancel = TurnCancel::register(&state, &note_id);
+    let turn_cancel = TurnCancel::register(&state, target.scope_id());
     let mut attempt = 0u8;
     let outcome = loop {
         let (base, token) = super::cloud::cloud_session(&state).await?;
@@ -1191,9 +1310,10 @@ pub struct ChatMessageDto {
 #[tauri::command]
 pub async fn chat_history(
     app: AppHandle,
-    note_id: String,
+    note_id: Option<String>,
     conversation_id: Option<String>,
 ) -> Result<ChatHistoryResult, String> {
+    let target = ChatTarget::from_note_id(note_id)?;
     let state: State<AppState> = app.state();
     // Chat follows the loaded context (issue #58): a loaded workspace reads its
     // server-authoritative conversation; Personal reads the local table.
@@ -1208,7 +1328,7 @@ pub async fn chat_history(
         // conversations). No handle → nothing persisted yet, so empty + None.
         let handle = {
             let conn = state.db.lock();
-            resolve_existing(&conn, workspace, &note_id, conversation_id.as_deref())?
+            resolve_existing(&conn, workspace, &target, conversation_id.as_deref())?
         };
         let Some(handle) = handle else {
             return Ok(ChatHistoryResult { conversation_id: None, messages: Vec::new() });
@@ -1225,7 +1345,7 @@ pub async fn chat_history(
 
     let conn = state.db.lock();
     let Some(conversation) =
-        resolve_existing(&conn, CHAT_TENANT_PERSONAL, &note_id, conversation_id.as_deref())?
+        resolve_existing(&conn, CHAT_TENANT_PERSONAL, &target, conversation_id.as_deref())?
     else {
         return Ok(ChatHistoryResult { conversation_id: None, messages: Vec::new() });
     };
@@ -1320,7 +1440,7 @@ fn map_remote_message(rec: &serde_json::Value) -> Option<ChatMessageDto> {
 fn ensure_workspace_handle(
     conn: &rusqlite::Connection,
     workspace: &str,
-    note_id: &str,
+    target: &ChatTarget,
     remote_id: &str,
     breadth: &str,
 ) -> Result<db::Conversation, String> {
@@ -1329,9 +1449,10 @@ fn ensure_workspace_handle(
     {
         return Ok(c);
     }
-    let breadth = chat::validate_breadth(breadth).unwrap_or("note");
-    let handle = db::create_conversation(conn, workspace, CHAT_SCOPE_NOTE, note_id, breadth)
-        .map_err(|e| e.to_string())?;
+    let breadth = chat::validate_breadth(breadth).unwrap_or_else(|_| chat::default_breadth(target));
+    let handle =
+        db::create_conversation(conn, workspace, target.scope(), target.scope_id(), breadth)
+            .map_err(|e| e.to_string())?;
     db::set_conversation_remote_id(conn, &handle.id, remote_id).map_err(|e| e.to_string())?;
     Ok(handle)
 }
@@ -1352,17 +1473,18 @@ fn pb_timestamp_ms(v: Option<&serde_json::Value>) -> i64 {
 fn cloud_conversation_meta(
     state: &State<AppState>,
     workspace: &str,
-    note_id: &str,
+    target: &ChatTarget,
     item: &serde_json::Value,
 ) -> Result<ConversationMeta, String> {
     let remote_id = item
         .get("id")
         .and_then(|v| v.as_str())
         .ok_or("Team chat returned a conversation without an id")?;
-    let breadth = item.get("breadth").and_then(|v| v.as_str()).unwrap_or("note");
+    let breadth =
+        item.get("breadth").and_then(|v| v.as_str()).unwrap_or_else(|| chat::default_breadth(target));
     let handle = {
         let conn = state.db.lock();
-        ensure_workspace_handle(&conn, workspace, note_id, remote_id, breadth)?
+        ensure_workspace_handle(&conn, workspace, target, remote_id, breadth)?
     };
     Ok(ConversationMeta {
         id: handle.id,
@@ -1396,22 +1518,53 @@ fn unlisted_legacy_handles<'a>(
 /// handle, then UNIONS in local handles the server omitted (pre-#19 threads not
 /// yet adopted — their message count is read through). Most-recently-updated
 /// first.
+/// Query params for the conversations route. `note_id` is optional (humla-cloud#26)
+/// and its ABSENCE is what selects the library-wide list — the server keys that off
+/// its own `scope` field, so the param must be omitted rather than sent as a
+/// sentinel it would reject as malformed.
+fn conversation_route_params<'a>(
+    workspace: &'a str,
+    target: &'a ChatTarget,
+) -> Vec<(&'a str, &'a str)> {
+    let mut params = vec![("workspace_id", workspace)];
+    if let Some(id) = target.note_id() {
+        params.push(("note_id", id));
+    }
+    params
+}
+
+/// Body for creating a conversation server-side. Same rule as the params above,
+/// plus the anchor-less-must-be-`all` check in its one owner.
+fn new_conversation_body(
+    workspace: &str,
+    target: &ChatTarget,
+    breadth: &str,
+) -> Result<serde_json::Value, String> {
+    chat::check_anchor(breadth, target.note_id().is_some())?;
+    let mut body = serde_json::json!({ "workspace_id": workspace, "breadth": breadth });
+    if let Some(id) = target.note_id() {
+        body["note_id"] = serde_json::json!(id);
+    }
+    Ok(body)
+}
+
 async fn list_conversations_cloud(
     state: &State<'_, AppState>,
     workspace: &str,
-    note_id: &str,
+    target: &ChatTarget,
 ) -> Result<Vec<ConversationMeta>, String> {
+    let params = conversation_route_params(workspace, target);
     let val = match super::cloud::cloud_get_json(
         state,
         "/api/humla/chat/conversations",
-        &[("workspace_id", workspace), ("note_id", note_id)],
+        &params,
     )
     .await
     {
         Ok(val) => val,
         // Route absent (pre-#19 server) → the single-handle fallback.
         Err(e) if e.is_not_found() => {
-            return legacy_workspace_sessions(state, workspace, note_id).await
+            return legacy_workspace_sessions(state, workspace, target).await
         }
         Err(e) => return Err(e.message(chat::cloud::cloud_chat_error_message)),
     };
@@ -1423,7 +1576,7 @@ async fn list_conversations_cloud(
         if let Some(rid) = item.get("id").and_then(|v| v.as_str()) {
             server_remote_ids.insert(rid.to_string());
         }
-        metas.push(cloud_conversation_meta(state, workspace, note_id, item)?);
+        metas.push(cloud_conversation_meta(state, workspace, target, item)?);
     }
 
     // Union: local handles the server GET omitted (pre-#19, not yet adopted).
@@ -1432,7 +1585,8 @@ async fn list_conversations_cloud(
     let legacy: Vec<(String, String, String, i64, String)> = {
         let conn = state.db.lock();
         let local_handles =
-            db::list_conversations(&conn, workspace, CHAT_SCOPE_NOTE, note_id).map_err(|e| e.to_string())?;
+            db::list_conversations(&conn, workspace, target.scope(), target.scope_id())
+                .map_err(|e| e.to_string())?;
         unlisted_legacy_handles(&server_remote_ids, &local_handles)
             .into_iter()
             .map(|h| {
@@ -1467,11 +1621,11 @@ async fn list_conversations_cloud(
 async fn legacy_workspace_sessions(
     state: &State<'_, AppState>,
     workspace: &str,
-    note_id: &str,
+    target: &ChatTarget,
 ) -> Result<Vec<ConversationMeta>, String> {
     let handle = {
         let conn = state.db.lock();
-        db::latest_conversation(&conn, workspace, CHAT_SCOPE_NOTE, note_id)
+        db::latest_conversation(&conn, workspace, target.scope(), target.scope_id())
             .map_err(|e| e.to_string())?
     };
     let Some(handle) = handle else { return Ok(Vec::new()) };
@@ -1500,28 +1654,24 @@ async fn legacy_workspace_sessions(
 async fn new_conversation_cloud(
     state: &State<'_, AppState>,
     workspace: &str,
-    note_id: &str,
+    target: &ChatTarget,
 ) -> Result<ConversationMeta, String> {
     // Client-side no-op guard: reuse the empty most-recent session if there is
     // one (the list already unions server + legacy and is most-recent-first).
-    let existing = list_conversations_cloud(state, workspace, note_id).await?;
+    let existing = list_conversations_cloud(state, workspace, target).await?;
     if let Some(most_recent) = existing.into_iter().next() {
         if most_recent.message_count == 0 {
             return Ok(most_recent);
         }
     }
 
-    // Inherit breadth from the Note's most-recent session in THIS workspace,
-    // just like the personal path ("note" only when there's no prior session).
+    // Inherit breadth from the target's most-recent session in THIS workspace,
+    // just like the personal path (the target's own default when there's none).
     let breadth = {
         let conn = state.db.lock();
-        inherited_breadth(&conn, workspace, note_id)
+        inherited_breadth(&conn, workspace, target)
     };
-    let body = serde_json::json!({
-        "workspace_id": workspace,
-        "note_id": note_id,
-        "breadth": breadth,
-    });
+    let body = new_conversation_body(workspace, target, &breadth)?;
     // The POST response is the conversation object itself — no wrapper.
     let val = match super::cloud::cloud_post_json(state, "/api/humla/chat/conversations", &body)
         .await
@@ -1534,12 +1684,15 @@ async fn new_conversation_cloud(
         }
         Err(e) => return Err(e.message(chat::cloud::cloud_chat_error_message)),
     };
-    cloud_conversation_meta(state, workspace, note_id, &val)
+    cloud_conversation_meta(state, workspace, target, &val)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Production code derives the scope from a `ChatTarget`; the tests still name
+    // it directly to assert the stored value is what we think it is.
+    use crate::db::CHAT_SCOPE_NOTE;
 
     /// Insert a Note with an explicit folder assignment, for scope tests.
     fn note_in_folder(conn: &rusqlite::Connection, folder: Option<&str>) -> db::Note {
@@ -1558,16 +1711,168 @@ mod tests {
         let with_folder = note_in_folder(&conn, Some(&folder.id));
         let no_folder = note_in_folder(&conn, None);
 
-        assert!(matches!(resolve_scope("all", &no_folder).unwrap(), ToolScope::All));
-        assert!(matches!(resolve_scope("note", &no_folder).unwrap(), ToolScope::Note(_)));
-        match resolve_scope("folder", &with_folder).unwrap() {
+        assert!(matches!(resolve_scope("all", Some(&no_folder)).unwrap(), ToolScope::All));
+        assert!(matches!(resolve_scope("note", Some(&no_folder)).unwrap(), ToolScope::Note(_)));
+        match resolve_scope("folder", Some(&with_folder)).unwrap() {
             ToolScope::Folder(id) => assert_eq!(id, folder.id),
             other => panic!("expected Folder scope, got {other:?}"),
         }
         // Unknown breadth is loud (issue #58) — the old `_ => Note` clamp is gone.
-        assert!(resolve_scope("everything", &no_folder).is_err());
+        assert!(resolve_scope("everything", Some(&no_folder)).is_err());
         // Folder breadth on a folder-less note errors rather than clamping.
-        assert!(resolve_scope("folder", &no_folder).is_err());
+        assert!(resolve_scope("folder", Some(&no_folder)).is_err());
+    }
+
+    // ── #93: library-wide (global) scope ────────────────────────────────────
+
+    /// A library-wide turn resolves straight to `All` without an anchor — the
+    /// retrieval tools carry it alone (#82: no fallback note is substituted).
+    #[test]
+    fn resolve_scope_resolves_a_library_wide_turn_without_a_note() {
+        assert!(matches!(resolve_scope("all", None).unwrap(), ToolScope::All));
+        // Every anchor-requiring breadth is LOUD without an anchor rather than
+        // widening to the whole library — a corrupt global row must not silently
+        // search everything. `heal_and_read_global_breadth` rewrites such rows to
+        // "all" before a turn gets here, so these arms are belt-and-suspenders.
+        for breadth in ["note", "folder"] {
+            assert!(resolve_scope(breadth, None).is_err(), "{breadth} should not widen silently");
+        }
+        // Garbage is still loud.
+        assert!(resolve_scope("everything", None).is_err());
+    }
+
+    /// #93's proof is Rust tests, so the two cloud shapes are asserted directly
+    /// rather than left to inspection inside async command bodies. Both encode the
+    /// same humla-cloud#26 rule: the absence of `note_id` is what selects the
+    /// library-wide list, so a sentinel would be rejected as malformed.
+    #[test]
+    fn the_cloud_conversation_routes_omit_the_anchor_for_a_library_wide_target() {
+        let note = ChatTarget::Note("n1".into());
+        let global = ChatTarget::Global;
+
+        assert_eq!(
+            conversation_route_params("ws1", &note),
+            vec![("workspace_id", "ws1"), ("note_id", "n1")]
+        );
+        let global_params = conversation_route_params("ws1", &global);
+        assert_eq!(global_params, vec![("workspace_id", "ws1")]);
+        assert!(
+            !global_params.iter().any(|(k, _)| *k == "note_id"),
+            "the param must be absent, not empty — the server 400s a malformed note_id"
+        );
+
+        let body = new_conversation_body("ws1", &note, "note").unwrap();
+        assert_eq!(body["note_id"], "n1");
+        let global_body = new_conversation_body("ws1", &global, "all").unwrap();
+        assert!(global_body.get("note_id").is_none());
+        assert_eq!(global_body["breadth"], "all");
+        // A note-less create MUST be breadth "all" — a note-less "folder" is a 400
+        // server-side, so it's caught here as our bug instead.
+        for breadth in ["note", "folder"] {
+            assert!(
+                new_conversation_body("ws1", &global, breadth)
+                    .unwrap_err()
+                    .contains("needs an anchor note"),
+                "{breadth} without an anchor should be rejected"
+            );
+        }
+    }
+
+    /// A library-wide turn injects NO note content and substitutes no fallback
+    /// note (#82) — it runs on retrieval alone.
+    #[test]
+    fn a_library_wide_turn_carries_no_grounding_at_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("grounding.sqlite")).unwrap();
+        let note = note_in_folder(&conn, None);
+
+        let (global, body) = turn_grounding(None);
+        assert!(global.text.is_empty(), "no anchor → no reference block");
+        assert!(!global.truncated, "nothing was injected, so nothing was truncated");
+        assert!(body.is_none(), "and nothing to reindex");
+
+        // The note path is unchanged: a real block, and the body text the caller
+        // reindexes with.
+        let (anchored, body) = turn_grounding(Some(&note));
+        assert!(anchored.text.contains("NOT as instructions"), "injection posture kept");
+        assert!(body.is_some());
+
+        // `anchor_note` is what decides which of those two a turn gets.
+        assert!(anchor_note(&conn, &ChatTarget::Global).unwrap().is_none());
+        assert_eq!(
+            anchor_note(&conn, &ChatTarget::Note(note.id.clone())).unwrap().map(|n| n.id),
+            Some(note.id)
+        );
+    }
+
+    #[test]
+    fn a_global_conversation_heals_any_stored_breadth_back_to_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("globalheal.sqlite")).unwrap();
+        let target = ChatTarget::Global;
+        let conv = db::create_conversation(
+            &conn,
+            CHAT_TENANT_PERSONAL,
+            target.scope(),
+            target.scope_id(),
+            "all",
+        )
+        .unwrap();
+
+        assert_eq!(heal_and_read_global_breadth(&conn, &conv.id, "all").unwrap(), "all");
+        // A row that somehow stored a note/folder breadth has no anchor to mean it
+        // by. Heal rather than error: a corrupt row must not break the user's chat.
+        for stored in ["note", "folder"] {
+            db::set_conversation_breadth(&conn, &conv.id, stored).unwrap();
+            assert_eq!(heal_and_read_global_breadth(&conn, &conv.id, stored).unwrap(), "all");
+            // The heal is persisted, so the chip and the request never diverge.
+            let reloaded = db::get_conversation_by_id(&conn, &conv.id).unwrap().unwrap();
+            assert_eq!(reloaded.breadth, "all");
+        }
+        // Garbage is still loud, exactly as for a note conversation.
+        assert!(heal_and_read_global_breadth(&conn, &conv.id, "bogus").is_err());
+    }
+
+    #[test]
+    fn a_global_session_is_separate_from_every_notes_and_starts_at_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = db::open(&dir.path().join("globalsess.sqlite")).unwrap();
+        let note = note_in_folder(&conn, None);
+        let note_target = ChatTarget::Note(note.id.clone());
+        let global = ChatTarget::Global;
+
+        // First-ever sessions take their target's own default breadth.
+        assert_eq!(inherited_breadth(&conn, CHAT_TENANT_PERSONAL, &global), "all");
+        assert_eq!(inherited_breadth(&conn, CHAT_TENANT_PERSONAL, &note_target), "note");
+
+        let g1 = new_personal_conversation(&conn, &global).unwrap();
+        assert_eq!(g1.breadth, "all");
+        assert_eq!(g1.scope, db::CHAT_SCOPE_GLOBAL);
+        // The no-op guard applies to the library pane too: an empty most-recent
+        // session is reused rather than piling up.
+        assert_eq!(new_personal_conversation(&conn, &global).unwrap().id, g1.id);
+
+        // A note's session is a different row and doesn't appear in the library
+        // list (nor the reverse).
+        let n1 = new_personal_conversation(&conn, &note_target).unwrap();
+        assert_ne!(n1.id, g1.id);
+        let listed = |t: &ChatTarget| {
+            db::list_conversations(&conn, CHAT_TENANT_PERSONAL, t.scope(), t.scope_id())
+                .unwrap()
+                .into_iter()
+                .map(|c| c.id)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(listed(&global), vec![g1.id.clone()]);
+        assert_eq!(listed(&note_target), vec![n1.id.clone()]);
+
+        // An explicit id from the other scope is a clean error, never a silent
+        // cross-scope read.
+        let err = resolve_existing(&conn, CHAT_TENANT_PERSONAL, &global, Some(&n1.id)).unwrap_err();
+        assert!(err.contains("library-wide"), "got: {err}");
+        assert!(resolve_existing(&conn, CHAT_TENANT_PERSONAL, &note_target, Some(&g1.id))
+            .unwrap_err()
+            .contains("this note"));
     }
 
     #[test]
@@ -1646,7 +1951,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let conn = db::open(&dir.path().join("first.sqlite")).unwrap();
         // A Note with no sessions → the first new session defaults to "note".
-        let conv = new_personal_conversation(&conn, "n1").unwrap();
+        let conv = new_personal_conversation(&conn, &ChatTarget::Note("n1".into())).unwrap();
         assert_eq!(conv.breadth, "note");
         assert_eq!(db::conversation_message_count(&conn, &conv.id).unwrap(), 0);
     }
@@ -1662,7 +1967,7 @@ mod tests {
         // The most-recent session has messages, so the guard doesn't reuse it.
         add_user_message(&conn, &first.id, "hi");
 
-        let second = new_personal_conversation(&conn, "n1").unwrap();
+        let second = new_personal_conversation(&conn, &ChatTarget::Note("n1".into())).unwrap();
         assert_ne!(second.id, first.id, "a genuinely new session was created");
         assert_eq!(second.breadth, "all", "breadth is inherited from the most recent session");
     }
@@ -1675,7 +1980,7 @@ mod tests {
             db::create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "n1", "note")
                 .unwrap();
         // No messages on the most-recent session → "new chat" returns it as-is.
-        let again = new_personal_conversation(&conn, "n1").unwrap();
+        let again = new_personal_conversation(&conn, &ChatTarget::Note("n1".into())).unwrap();
         assert_eq!(again.id, first.id, "an empty most-recent session is reused, not duplicated");
         assert_eq!(
             db::list_conversations(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "n1").unwrap().len(),
@@ -1691,13 +1996,13 @@ mod tests {
         // Note has no prior session in that tenant.
         let dir = tempfile::tempdir().unwrap();
         let conn = db::open(&dir.path().join("wsbreadth.sqlite")).unwrap();
-        assert_eq!(inherited_breadth(&conn, "wsA", "n1"), "note", "first-ever session defaults to note");
+        assert_eq!(inherited_breadth(&conn, "wsA", &ChatTarget::Note("n1".into())), "note", "first-ever session defaults to note");
         let conv =
             db::create_conversation(&conn, "wsA", CHAT_SCOPE_NOTE, "n1", "note").unwrap();
         db::set_conversation_breadth(&conn, &conv.id, "all").unwrap();
-        assert_eq!(inherited_breadth(&conn, "wsA", "n1"), "all", "inherits the workspace session's breadth");
+        assert_eq!(inherited_breadth(&conn, "wsA", &ChatTarget::Note("n1".into())), "all", "inherits the workspace session's breadth");
         // A different tenant's breadth doesn't leak across.
-        assert_eq!(inherited_breadth(&conn, CHAT_TENANT_PERSONAL, "n1"), "note");
+        assert_eq!(inherited_breadth(&conn, CHAT_TENANT_PERSONAL, &ChatTarget::Note("n1".into())), "note");
     }
 
     #[test]
@@ -1709,14 +2014,14 @@ mod tests {
         let n1 = db::create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "n1", "note").unwrap();
 
         // Matching (tenant, note) resolves.
-        let ok = resolve_existing(&conn, CHAT_TENANT_PERSONAL, "n1", Some(&n1.id)).unwrap();
+        let ok = resolve_existing(&conn, CHAT_TENANT_PERSONAL, &ChatTarget::Note("n1".into()), Some(&n1.id)).unwrap();
         assert_eq!(ok.unwrap().id, n1.id);
         // Wrong note → error.
-        assert!(resolve_existing(&conn, CHAT_TENANT_PERSONAL, "n2", Some(&n1.id)).is_err());
+        assert!(resolve_existing(&conn, CHAT_TENANT_PERSONAL, &ChatTarget::Note("n2".into()), Some(&n1.id)).is_err());
         // Wrong tenant → error.
-        assert!(resolve_existing(&conn, "wsA", "n1", Some(&n1.id)).is_err());
+        assert!(resolve_existing(&conn, "wsA", &ChatTarget::Note("n1".into()), Some(&n1.id)).is_err());
         // An unknown id is not an error — falls back to the active session (None).
-        assert!(resolve_existing(&conn, CHAT_TENANT_PERSONAL, "n1", Some("missing")).unwrap().is_none());
+        assert!(resolve_existing(&conn, CHAT_TENANT_PERSONAL, &ChatTarget::Note("n1".into()), Some("missing")).unwrap().is_none());
     }
 
     #[test]
@@ -1796,7 +2101,7 @@ mod tests {
             "In one sentence, what is this workspace about?",
             Some("roundtrip test"),
             "all",
-            "roundtrip-anchor",
+            Some("roundtrip-anchor"),
             None,
         )
         .expect("all-breadth request builds");

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -926,12 +926,71 @@ fn map_summary_prompt(row: &rusqlite::Row) -> rusqlite::Result<SummaryPrompt> {
 // Persistence for the chat skeleton: conversations + messages. See the schema
 // note in `open()` for the storage-shape rationale (opencode v2 model).
 
-/// General chat scope. Only `Note` is used in this slice; the enum exists so
-/// the string stored in `conversations.scope` is chosen in one place and later
-/// breadths (folder/client/workspace) add variants without touching call sites.
+/// General chat scope — the string stored in `conversations.scope`, chosen in
+/// one place so later scopes (folder/client) add variants without touching call
+/// sites. `global` arrived with #93; folder and client are still unbuilt.
 pub const CHAT_SCOPE_NOTE: &str = "note";
+pub const CHAT_SCOPE_GLOBAL: &str = "global";
+/// `scope_id` for the one global conversation set per tenant. A fixed sentinel
+/// rather than an empty string: the composite key is `(tenant, scope, scope_id)`,
+/// and an empty id already reads as "absent" in too many places to also mean
+/// "the whole library". Never shown to the user, never sent to the server — the
+/// cloud carries its own `scope` field (humla-cloud#26).
+pub const CHAT_GLOBAL_SCOPE_ID: &str = "__global__";
 /// Only Personal is used in this slice; workspace tenants arrive with Teams.
 pub const CHAT_TENANT_PERSONAL: &str = "personal";
+
+/// What a chat conversation is *about*: one Note, or the whole library.
+///
+/// This is the single place `(scope, scope_id)` is derived, so a caller can no
+/// longer accidentally pair a global scope with a note's id. Constructed from the
+/// IPC boundary via [`ChatTarget::from_note_id`], where **absent** means global
+/// and **empty** is an error — the distinction that keeps `""` from quietly
+/// becoming "everything" (the same trap humla-cloud#26 avoided server-side).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChatTarget {
+    Note(String),
+    Global,
+}
+
+impl ChatTarget {
+    /// Parse the optional note id an IPC command received.
+    pub fn from_note_id(note_id: Option<String>) -> Result<Self, String> {
+        match note_id {
+            None => Ok(Self::Global),
+            Some(id) if id.trim().is_empty() => Err(
+                "A chat target needs a note id, or none at all for the whole library — \
+                 an empty id is neither."
+                    .into(),
+            ),
+            Some(id) => Ok(Self::Note(id)),
+        }
+    }
+
+    pub fn scope(&self) -> &'static str {
+        match self {
+            Self::Note(_) => CHAT_SCOPE_NOTE,
+            Self::Global => CHAT_SCOPE_GLOBAL,
+        }
+    }
+
+    pub fn scope_id(&self) -> &str {
+        match self {
+            Self::Note(id) => id,
+            Self::Global => CHAT_GLOBAL_SCOPE_ID,
+        }
+    }
+
+    /// The anchor note id, or None for a global target. Callers that genuinely
+    /// need a note (grounding, folder breadth) go through this and handle None
+    /// rather than reaching for `scope_id`.
+    pub fn note_id(&self) -> Option<&str> {
+        match self {
+            Self::Note(id) => Some(id),
+            Self::Global => None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Conversation {
@@ -2981,6 +3040,85 @@ mod tests {
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].id, *recent);
         assert_ne!(listed[0].id, *ancient);
+    }
+
+    // ── #93: global chat scope ──────────────────────────────────────────────
+
+    #[test]
+    fn chat_target_derives_scope_and_scope_id_together() {
+        let note = ChatTarget::Note("n1".into());
+        assert_eq!((note.scope(), note.scope_id()), (CHAT_SCOPE_NOTE, "n1"));
+        assert_eq!((ChatTarget::Global.scope(), ChatTarget::Global.scope_id()), (CHAT_SCOPE_GLOBAL, CHAT_GLOBAL_SCOPE_ID));
+        // A global target has no anchor; callers needing one must handle None.
+        assert_eq!(note.note_id(), Some("n1"));
+        assert_eq!(ChatTarget::Global.note_id(), None);
+    }
+
+    /// Absent means global; EMPTY is an error. Letting `""` mean global is the
+    /// trap humla-cloud#26 avoided server-side — a typo must not silently become
+    /// a library-wide conversation.
+    #[test]
+    fn an_absent_note_id_is_global_but_an_empty_one_is_an_error() {
+        assert_eq!(ChatTarget::from_note_id(None).unwrap(), ChatTarget::Global);
+        assert_eq!(
+            ChatTarget::from_note_id(Some("n1".into())).unwrap(),
+            ChatTarget::Note("n1".into())
+        );
+        for empty in ["", "   ", "\t"] {
+            let err = ChatTarget::from_note_id(Some(empty.into())).unwrap_err();
+            assert!(err.contains("empty id"), "got: {err}");
+        }
+    }
+
+    /// The composite key is `(tenant, scope, scope_id)`, so a global thread and a
+    /// note thread never see each other even within one tenant — and a note whose
+    /// id somehow equalled the sentinel still wouldn't collide, because the scope
+    /// differs.
+    #[test]
+    fn global_and_note_conversations_do_not_leak_into_each_other() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = open(&dir.path().join("scopes.sqlite")).unwrap();
+
+        let note = ChatTarget::Note("n1".into());
+        let global = ChatTarget::Global;
+        let mk = |t: &ChatTarget| {
+            create_conversation(&conn, CHAT_TENANT_PERSONAL, t.scope(), t.scope_id(), "all")
+                .unwrap()
+        };
+        let note_conv = mk(&note);
+        let global_conv = mk(&global);
+        assert_ne!(note_conv.id, global_conv.id);
+
+        let listed = |t: &ChatTarget| {
+            list_conversations(&conn, CHAT_TENANT_PERSONAL, t.scope(), t.scope_id())
+                .unwrap()
+                .into_iter()
+                .map(|c| c.id)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(listed(&note), vec![note_conv.id.clone()]);
+        assert_eq!(listed(&global), vec![global_conv.id.clone()]);
+
+        // …and the same holds per tenant: a workspace's global set is its own.
+        let ws_global =
+            create_conversation(&conn, "wsA", global.scope(), global.scope_id(), "all").unwrap();
+        assert_eq!(listed(&global), vec![global_conv.id.clone()], "personal is unaffected");
+        assert_eq!(
+            list_conversations(&conn, "wsA", global.scope(), global.scope_id()).unwrap().len(),
+            1
+        );
+        assert_eq!(
+            latest_conversation(&conn, "wsA", global.scope(), global.scope_id())
+                .unwrap()
+                .unwrap()
+                .id,
+            ws_global.id
+        );
+        // A note id colliding with the sentinel still can't reach the global set.
+        let collide = ChatTarget::Note(CHAT_GLOBAL_SCOPE_ID.into());
+        let collide_conv = mk(&collide);
+        assert_eq!(listed(&collide), vec![collide_conv.id]);
+        assert_eq!(listed(&global), vec![global_conv.id], "the scope column separates them");
     }
 
     #[test]


### PR DESCRIPTION
Closes #93. Child 1 of 3 under #82 → #94 → #95. **Backend only** — no route, no UI, nothing a user can reach yet. Rust tests are the proof.

## The seam

`scope` was hardcoded to `CHAT_SCOPE_NOTE` at 35 call sites, so every conversation had to be anchored to a note. `db::ChatTarget` (`Note(id)` | `Global`) is now the single place `(scope, scope_id)` is derived — which is what the schema comment at `db.rs:929` promised and the call sites had quietly broken. Every production reference to the constant is gone; the survivors are the const itself, the one mapping inside `ChatTarget::scope()`, and tests asserting stored values.

`ChatTarget::from_note_id` parses the IPC boundary: **absent means global, empty is an error**. That distinction is the point — humla-cloud#26 records the server having avoided exactly this trap, because an empty id already means "legacy, not yet adopted" there. A typo must not silently become a library-wide conversation.

`CHAT_GLOBAL_SCOPE_ID = "__global__"` is a storage detail with no consumer outside `db.rs`. A note whose id equalled the sentinel still can't collide, because the scope column differs — asserted.

## Cloud wire shape

A note-less turn omits `note_id` **entirely** rather than sending a sentinel: the server 400s a malformed `note_id` under every breadth including `all`, so a sentinel would be rejected, not ignored. All three call sites covered — turn body, conversations GET params, create POST body — and the note-less-must-be-`all` rule has one owner (`chat::check_anchor`) with one message.

## Grounding

A global turn injects nothing and substitutes no fallback note (#82). `assemble_prompt` already skips an empty block, so nothing changed there — which is why #81 had to land first.

## Review outcomes folded in

Both axes independently flagged the same defect, and the spec axis was right to call it wrong: **`resolve_scope("note", None)` returned `ToolScope::All`**, silently widening a corrupt global row's retrieval to the entire library — inside a function whose own doc says unknown breadths are loud, and whose sibling `("folder", None)` arm errors. It errors now, failing closed rather than open.

Also: the anchor rule was re-decided in four places with three behaviours and one message copied verbatim (→ `check_anchor`); `heal_and_read_breadth`'s `Option<&Note>` hid a policy branch behind a nullable param (split, `effective_breadth` chooses); `default_breadth` moved off `ChatTarget` into `chat`, since db shouldn't mint breadth strings it can't validate; the anchor load was duplicated ×3 (→ `anchor_note`); and `build_cloud_request` treated `Some("")` as absent while `from_note_id` rejected it — both reject now.

The spec axis also noted the two cloud shapes and the grounding decision were covered only by inspection, in an issue that says tests are the proof. Extracted as pure helpers (`conversation_route_params`, `new_conversation_body`, `turn_grounding`) and asserted directly.

## Worth a reviewer's eye

Two changes are beyond #93's stated IPC list, both necessary: `chat_cancel` also takes `Option<String>` (panes key their stop flag by `scope_id`, so otherwise the note and library panes would stop each other), and `chat_set_breadth` rejects a non-`all` breadth for a global target rather than storing one the heal would immediately undo.

**Not covered:** the workspace half of "created, listed, loaded and appended to in Personal *and* in a workspace" is proven at the DB layer and through the pure request builders only. Driving `chat_send_cloud` end-to-end needs a Tauri `State` this test setup can't build — the same gap that left #72's retry loop untested. #95's `pnpm tauri dev` pass is where it gets exercised.

356 Rust tests green (12 new). 289 frontend tests untouched and `tsc` clean — the evidence that this really is invisible. Of the existing Rust tests, only call signatures moved; not one assertion changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)