### PR TITLE
refactor(chat): parameterise ChatPanel by a discriminated chat target (#94)

### DIFF
--- a/src/components/ChatPanel.focus.test.tsx
+++ b/src/components/ChatPanel.focus.test.tsx
@@ -25,7 +25,7 @@ import { ChatPanel } from "./ChatPanel";
 function panel() {
   return (
     <MemoryRouter>
-      <ChatPanel noteId="n1" />
+      <ChatPanel target={{ kind: "note", noteId: "n1" }} />
     </MemoryRouter>
   );
 }

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -109,7 +109,7 @@ function history(messages: ChatMessageDto[] = []) {
 function renderPanel(noteId = "n1") {
   return render(
     <MemoryRouter>
-      <ChatPanel noteId={noteId} />
+      <ChatPanel target={{ kind: "note", noteId }} />
     </MemoryRouter>,
   );
 }
@@ -122,7 +122,7 @@ function renderWithControls(noteId = "n1") {
   render(
     <MemoryRouter>
       <ChatPanel
-        noteId={noteId}
+        target={{ kind: "note", noteId }}
         onControls={(c) => {
           captured.current = c;
         }}
@@ -436,6 +436,117 @@ describe("ChatPanel scope breadth (#58)", () => {
     fireEvent.click(await screen.findByText("All notes"));
     await waitFor(() => expect(setArgs?.breadth).toBe("all"));
     expect(setArgs?.noteId).toBe("n1");
+  });
+});
+
+// #94: the panel is parameterised by a target, so a library-wide pane renders
+// from the same component. No route reaches one yet (#95), so it's exercised
+// here — the refactor's whole claim is that this works without a second
+// implementation.
+describe("ChatPanel with a library-wide target (#94)", () => {
+  function renderGlobal() {
+    return render(
+      <MemoryRouter>
+        <ChatPanel target={{ kind: "global" }} />
+      </MemoryRouter>,
+    );
+  }
+
+  it("sends a null anchor to every chat command, never an empty string", async () => {
+    // `null` is the wire value that means "the whole library"; the backend
+    // REJECTS "" outright (#93), so an empty string here would be a hard error.
+    const seen: Record<string, unknown> = {};
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: (args) => {
+        seen.history = args;
+        return history();
+      },
+      chat_get_breadth: (args) => {
+        seen.breadth = args;
+        return "all";
+      },
+      chat_list_conversations: (args) => {
+        seen.list = args;
+        return [];
+      },
+    });
+    renderGlobal();
+
+    await waitFor(() => expect(seen.history).toBeDefined());
+    for (const [name, args] of Object.entries(seen)) {
+      expect((args as { noteId?: unknown }).noteId, `${name} anchor`).toBeNull();
+    }
+  });
+
+  it("defaults its scope to all notes and offers no anchor-dependent option", async () => {
+    // A library-wide conversation has no anchor to narrow to, so BOTH "This note"
+    // and "Folder: …" are meaningless — and offering either would let the chip
+    // show a breadth the backend's `check_anchor` is guaranteed to reject, so the
+    // chip would end up lying about what the next turn will search. Seeding a note
+    // with a folder proves the options are absent because there's no ANCHOR, not
+    // because no folder exists.
+    seedNoteWithFolder();
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      // The backend can't be read → the pane must fall back to "all", not "note".
+      chat_get_breadth: () => {
+        throw new Error("unavailable");
+      },
+    });
+    renderGlobal();
+
+    const scopeButton = await screen.findByRole("button", { name: "Chat scope" });
+    await waitFor(() => expect(scopeButton).toHaveTextContent(/all notes/i));
+    fireEvent.click(scopeButton);
+    expect(screen.queryByText(/^Folder:/)).toBeNull();
+    expect(screen.queryByText("This note")).toBeNull();
+    // "All notes" is the only option (it appears twice — the trigger and the row).
+    expect(screen.getAllByText("All notes").length).toBeGreaterThan(0);
+  });
+
+  it("keeps the note pane's own scope options intact", async () => {
+    // The other half of the same rule: an anchored pane still offers everything it
+    // did before. This is the regression the suppression above could cause.
+    seedNoteWithFolder();
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_get_breadth: () => "note",
+    });
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Chat scope" }));
+    // "This note" appears twice (trigger + row); the other two once each.
+    await waitFor(() => expect(screen.getAllByText("This note").length).toBeGreaterThan(0));
+    expect(screen.getByText(/^Folder:/)).toBeInTheDocument();
+    expect(screen.getByText("All notes")).toBeInTheDocument();
+  });
+
+  it("publishes controls under a target key distinct from any note's", async () => {
+    // The header's stale-projection guard compares this key, so a library pane's
+    // projection must never be mistaken for note "global"'s and vice versa.
+    const captured: { current: ChatSessionControls | null } = { current: null };
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => history(),
+      chat_get_breadth: () => "all",
+      chat_list_conversations: () => [],
+    });
+    render(
+      <MemoryRouter>
+        <ChatPanel
+          target={{ kind: "global" }}
+          onControls={(c) => {
+            captured.current = c;
+          }}
+        />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(captured.current).not.toBeNull());
+    expect(captured.current?.targetKey).toBe("global");
+    expect(captured.current?.targetKey).not.toBe("note:global");
   });
 });
 

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -33,6 +33,7 @@ import { useChatReadiness } from "./provider/useChatReadiness";
 import { SelectablePopover, type PopoverItem } from "./SelectablePopover";
 import { ChatKeyEntry } from "./ChatKeyEntry";
 import { usageTone, liveChatErrorCopy, groundingLikelyTruncated } from "../lib/chatSessions";
+import { targetNoteId, targetKey, targetDefaultScope, type ChatTarget } from "../lib/chatTarget";
 import { NOTE_PROMPTS, opensPromptPicker, type ChatPrompt } from "../lib/chatPrompts";
 import { RECOMMENDED_OLLAMA_MODEL } from "../lib/localModels";
 import { CommandSnippet } from "./CommandSnippet";
@@ -129,9 +130,10 @@ function toolPastLabel(name: string, count: number): string {
 // the sole owner of conversationId/messages; this is a read-only projection plus
 // action callbacks.
 export type ChatSessionControls = {
-  /** The note these controls belong to — lets the header ignore a stale
-   *  projection for one frame after a note switch. */
-  noteId: string;
+  /** The target these controls belong to, as a stable scalar (`targetKey`) — lets
+   *  the header ignore a stale projection for one frame after a switch. A key
+   *  rather than the target object because the comparison must be by value. */
+  targetKey: string;
   conversations: ConversationMeta[];
   activeConversationId: string | null;
   /** Lone-empty-conversation rule (#62): nothing worth browsing → header hides history. */
@@ -141,12 +143,20 @@ export type ChatSessionControls = {
 };
 
 export function ChatPanel({
-  noteId,
+  target,
   onControls,
 }: {
-  noteId: string;
+  target: ChatTarget;
   onControls?: (controls: ChatSessionControls | null) => void;
 }) {
+  // The anchor note id for IPC — null means the whole library (#93). This is also
+  // the pane's dependency identity: it's already a stable scalar and `null` is
+  // exactly "global", so a change in it is exactly a change of target. Depending on
+  // `target` itself would re-run the load effect forever, since the parent rebuilds
+  // the object on most renders.
+  const noteId = targetNoteId(target);
+  // Non-nullable identity for the projection the Note header compares by value.
+  const paneKey = targetKey(target);
   const { loading: readinessLoading, ready, hint, provider, model } = useChatReadiness();
   const [messages, setMessages] = useState<ChatMessageDto[]>([]);
   // This Note's conversations (issue #61/#62), most-recent first from the
@@ -172,7 +182,7 @@ export function ChatPanel({
   const [truncated, setTruncated] = useState(false);
   // Scope chip breadth. Display state only — the backend conversation row is the
   // source of truth (issue #58); this mirrors it and is (re)initialised from it.
-  const [scope, setScope] = useState<ChatScope>("note");
+  const [scope, setScope] = useState<ChatScope>(() => targetDefaultScope(target));
   // Prompt picker visibility (#80). Opened by typing "/" into an empty composer;
   // the picker owns the keys while it's up (it takes focus), so the composer's
   // own key handler doesn't need to know about Escape.
@@ -202,8 +212,11 @@ export function ChatPanel({
   // leak into the conversation the user switched to (#62).
   const switchGenRef = useRef(0);
 
-  // The anchor note's folder drives the "this folder" scope option.
+  // The anchor note's folder drives the "this folder" scope option. A library-wide
+  // pane has no anchor, so no folder option — the store lookup is skipped rather
+  // than searched for a null id.
   const folder = useNotesStore((s) => {
+    if (noteId === null) return null;
     const note = s.notes.find((n) => n.id === noteId);
     const fid = note?.folder_id;
     return fid ? s.folders.find((f) => f.id === fid) ?? null : null;
@@ -211,8 +224,12 @@ export function ChatPanel({
 
   // The anchor note itself, for the pre-emptive truncation hint (#80). Selected
   // as the stored object — a derived `{...}` literal would be a fresh snapshot
-  // on every call and spin useSyncExternalStore into an update loop.
-  const anchorNote = useNotesStore((s) => s.notes.find((n) => n.id === noteId) ?? null);
+  // on every call and spin useSyncExternalStore into an update loop. Null for a
+  // library-wide pane, which injects no note content and so can't overflow the
+  // grounding budget.
+  const anchorNote = useNotesStore((s) =>
+    noteId === null ? null : s.notes.find((n) => n.id === noteId) ?? null,
+  );
   const likelyTruncated = useMemo(() => {
     if (!anchorNote) return false;
     // Body is HTML in the store but plain text in the prompt — measure the text,
@@ -277,7 +294,7 @@ export function ChatPanel({
       if (gen !== switchGenRef.current || !meta) return;
       setConversationId(meta.id);
       setMessages([]);
-      setScope(meta.breadth ?? "note");
+      setScope(meta.breadth ?? targetDefaultScope(target));
       setConversations((prev) => [meta, ...prev.filter((c) => c.id !== meta.id)]);
       void reloadConversationList(gen);
     } catch (e) {
@@ -434,13 +451,15 @@ export function ChatPanel({
         if (!cancelled && gen === switchGenRef.current && b) setScope(b);
       })
       .catch(() => {
-        if (!cancelled && gen === switchGenRef.current) setScope("note");
+        if (!cancelled && gen === switchGenRef.current) setScope(targetDefaultScope(target));
       });
     void reloadConversationList(gen);
     void refreshActivation(gen);
     return () => {
       cancelled = true;
-      void ipc.chatReindexNote(noteId).catch(() => {});
+      // Keep the anchor searchable on the way out. A library-wide pane has no
+      // anchor to reindex — every note is reindexed at its own checkpoints.
+      if (noteId !== null) void ipc.chatReindexNote(noteId).catch(() => {});
     };
   }, [noteId, workspaceId, billingEnabled, reloadConversationList, refreshActivation, resetTransient]);
 
@@ -539,7 +558,7 @@ export function ChatPanel({
       conversations.some((c) => c.messageCount > 0) ||
       messages.length > 0;
     onControls({
-      noteId,
+      targetKey: paneKey,
       conversations,
       activeConversationId: conversationId,
       canBrowseHistory,
@@ -549,7 +568,7 @@ export function ChatPanel({
   }, [
     onControls,
     paneUsable,
-    noteId,
+    paneKey,
     conversations,
     conversationId,
     messages.length,
@@ -871,6 +890,8 @@ export function ChatPanel({
               scope={scope}
               onScope={selectBreadth}
               folderName={folder?.name ?? null}
+              hasAnchor={noteId !== null}
+              fallbackScope={targetDefaultScope(target)}
             />
             {/* Which model is about to answer (#80) — previously invisible
                 without opening Settings. Muted, not disabled: --color-text-
@@ -1059,15 +1080,32 @@ function BreadthPicker({
   scope,
   onScope,
   folderName,
+  hasAnchor,
+  fallbackScope,
 }: {
   scope: ChatScope;
   onScope: (s: ChatScope) => void;
   folderName: string | null;
+  /** False for a library-wide pane (#94), which has no anchor note — so neither
+   *  "This note" nor "Folder: …" is offerable. The backend enforces the same rule
+   *  (`chat::check_anchor`), so offering them would let the chip show a breadth
+   *  the next write is guaranteed to reject. */
+  hasAnchor: boolean;
+  /** Where an unselectable or vanished breadth falls back to. */
+  fallbackScope: ChatScope;
 }) {
   // Per-scope icons so the options read at a glance (#69). Colour inherited.
   const items: PopoverItem[] = [
-    { id: "note", label: "This note", icon: <FileText size={14} strokeWidth={1.7} aria-hidden="true" /> },
-    ...(folderName
+    ...(hasAnchor
+      ? [
+          {
+            id: "note",
+            label: "This note",
+            icon: <FileText size={14} strokeWidth={1.7} aria-hidden="true" />,
+          },
+        ]
+      : []),
+    ...(hasAnchor && folderName
       ? [
           {
             id: "folder",
@@ -1078,17 +1116,19 @@ function BreadthPicker({
       : []),
     { id: "all", label: "All notes", icon: <Files size={14} strokeWidth={1.7} aria-hidden="true" /> },
   ];
-  // If the folder disappears while "folder" is selected, fall back to "note".
-  const activeId = scope === "folder" && !folderName ? "note" : scope;
+  // If the folder disappears while "folder" is selected — or the pane has no
+  // anchor at all — fall back to the pane's own default.
+  const selectable = items.some((i) => i.id === scope);
+  const activeId = selectable ? scope : fallbackScope;
   const active = items.find((i) => i.id === activeId);
-  const label = active?.label ?? "This note";
+  const label = active?.label ?? "All notes";
 
   return (
     <SelectablePopover
       ariaLabel="Chat scope"
       items={items}
       activeId={activeId}
-      onSelect={(id) => onScope((id as ChatScope) ?? "note")}
+      onSelect={(id) => onScope((id as ChatScope) ?? fallbackScope)}
       trigger={
         <span className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] cursor-pointer hover:text-[var(--color-text)] transition-colors">
           {active?.icon}

--- a/src/lib/chatSessions.test.ts
+++ b/src/lib/chatSessions.test.ts
@@ -169,3 +169,4 @@ describe("groundingLikelyTruncated", () => {
     expect(groundingLikelyTruncated(parts(third, third, third))).toBe(true);
   });
 });
+

--- a/src/lib/chatSessions.ts
+++ b/src/lib/chatSessions.ts
@@ -3,6 +3,7 @@
 // enough to hoist to a shared module if a second caller ever appears; for now
 // the chat history list is its only consumer.
 
+
 // A short, human relative timestamp: "just now" / "5m ago" / "3h ago" /
 // "yesterday" / "4d ago", then a locale date past a week (with the year only
 // when it differs). `now` is injectable for deterministic tests.

--- a/src/lib/chatTarget.test.ts
+++ b/src/lib/chatTarget.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { targetNoteId, targetKey, targetDefaultScope } from "./chatTarget";
+describe("ChatTarget (#94)", () => {
+  const note = { kind: "note", noteId: "n1" } as const;
+  const global = { kind: "global" } as const;
+
+  it("maps a note to its id and the library to null, never an empty string", () => {
+    // null is what the backend reads as "the whole library"; "" is REJECTED there
+    // (#93), so the distinction is load-bearing rather than cosmetic.
+    expect(targetNoteId(note)).toBe("n1");
+    expect(targetNoteId(global)).toBeNull();
+  });
+
+  it("keys a note distinctly from the library, even a note called 'global'", () => {
+    expect(targetKey(note)).toBe("note:n1");
+    expect(targetKey(global)).toBe("global");
+    // Without the prefix these would collide, and the header's stale-projection
+    // guard would accept one pane's controls for the other.
+    expect(targetKey({ kind: "note", noteId: "global" })).not.toBe(targetKey(global));
+  });
+
+  it("is a stable scalar, so it can drive effect deps across fresh objects", () => {
+    // The parent rebuilds the target object on most renders; depending on the
+    // object would re-run the pane's load effect forever.
+    expect(targetKey({ kind: "note", noteId: "n1" })).toBe(targetKey({ ...note }));
+  });
+
+  it("defaults the library to all notes and a note to itself", () => {
+    // Mirrors `chat::default_breadth` on the Rust side — a library-wide
+    // conversation has no anchor to narrow to (#82 fixed v1 at all-notes-only).
+    expect(targetDefaultScope(global)).toBe("all");
+    expect(targetDefaultScope(note)).toBe("note");
+  });
+});

--- a/src/lib/chatTarget.ts
+++ b/src/lib/chatTarget.ts
@@ -1,0 +1,41 @@
+// What a chat pane is about (#94). Pure and framework-free so it unit-tests
+// without rendering — and its own module rather than a corner of chatSessions.ts,
+// which is display helpers for the history popover; this is domain + wire
+// semantics, and the two change for unrelated reasons.
+
+import type { ChatScope } from "./ipc";
+
+/** One Note, or the whole library.
+ *
+ *  A discriminated union rather than a nullable note id, so "the library" can
+ *  never be confused with "a note we haven't loaded yet" — and specifically NOT a
+ *  sentinel empty string, which is the ambiguity humla-cloud#26 records the server
+ *  having avoided and #93 mirrored on the Rust side. */
+export type ChatTarget = { kind: "note"; noteId: string } | { kind: "global" };
+
+/** The anchor note id for an IPC call, or null for a library-wide pane.
+ *
+ *  The backend reads an ABSENT note id as the global scope and REJECTS an empty
+ *  one (#93), so null is the only correct way to say "the whole library" over the
+ *  wire. This doubles as the pane's dependency identity: it is already a stable
+ *  scalar, and `null` ⟺ global, so a change in it is exactly a change of target. */
+export function targetNoteId(target: ChatTarget): string | null {
+  return target.kind === "note" ? target.noteId : null;
+}
+
+/** A non-nullable string identity, for the header's stale-projection guard.
+ *
+ *  The guard compares by value across a component boundary, where a nullable id
+ *  would make "the library" and "not loaded yet" indistinguishable. The prefix
+ *  keeps a note whose id is literally "global" from colliding with the library. */
+export function targetKey(target: ChatTarget): string {
+  return target.kind === "note" ? `note:${target.noteId}` : "global";
+}
+
+/** The breadth a pane falls back to when the persisted value can't be read or is
+ *  no longer offerable. Mirrors `chat::default_breadth` on the Rust side (#93): a
+ *  library-wide conversation has no anchor to narrow to, so it is always "all"
+ *  (#82 fixed v1 at all-notes-only). */
+export function targetDefaultScope(target: ChatTarget): ChatScope {
+  return target.kind === "global" ? "all" : "note";
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -401,26 +401,30 @@ export const ipc = {
   // conversation server-side — `chatSetBreadth` writes it, `chatGetBreadth` reads
   // it back to initialise the Scope chip. `chatSend` carries no scope: it reads
   // the persisted breadth, so the UI can never diverge from it.
-  chatSend: (noteId: string, conversationId: string | null, message: string) =>
+  // Every chat command takes `noteId: string | null`, where **null means the whole
+  // library** (#93). The backend reads an absent note id as the global scope and
+  // REJECTS an empty string, so null is the only correct way to say "no anchor" —
+  // never "".
+  chatSend: (noteId: string | null, conversationId: string | null, message: string) =>
     invoke<ChatSendResult>("chat_send", { noteId, conversationId, message }),
-  // Stop the turn streaming in a Note's pane (issue #80). A no-op when nothing
-  // is in flight, so a stray click can't error. Any text that already streamed
-  // is kept; a stop before the first token leaves only the user's message.
-  chatCancel: (noteId: string) => invoke<void>("chat_cancel", { noteId }),
-  chatHistory: (noteId: string, conversationId: string | null = null) =>
+  // Stop the turn streaming in a pane (issue #80). A no-op when nothing is in
+  // flight, so a stray click can't error. Any text that already streamed is kept;
+  // a stop before the first token leaves only the user's message.
+  chatCancel: (noteId: string | null) => invoke<void>("chat_cancel", { noteId }),
+  chatHistory: (noteId: string | null, conversationId: string | null = null) =>
     invoke<ChatHistory>("chat_history", { noteId, conversationId }),
-  // List / create chat sessions for a Note (issue #61). Personal reads local
+  // List / create chat sessions for a target (issue #61). Personal reads local
   // SQLite; a workspace reads/creates server-authoritative sessions. There is no
   // delete command — a deliberate v1 decision.
-  chatListConversations: (noteId: string) =>
+  chatListConversations: (noteId: string | null) =>
     invoke<ConversationMeta[]>("chat_list_conversations", { noteId }),
-  chatNewConversation: (noteId: string) =>
+  chatNewConversation: (noteId: string | null) =>
     invoke<ConversationMeta>("chat_new_conversation", { noteId }),
   // Persist / read the Scope chip's breadth on a conversation (issue #58/#61).
   // The single source of truth for retrieval breadth.
-  chatSetBreadth: (noteId: string, conversationId: string | null, breadth: ChatScope) =>
+  chatSetBreadth: (noteId: string | null, conversationId: string | null, breadth: ChatScope) =>
     invoke<void>("chat_set_breadth", { noteId, conversationId, breadth }),
-  chatGetBreadth: (noteId: string, conversationId: string | null = null) =>
+  chatGetBreadth: (noteId: string | null, conversationId: string | null = null) =>
     invoke<ChatScope>("chat_get_breadth", { noteId, conversationId }),
   // Workspace turn allowance for the composer meter (issue #69). null in personal
   // context, and on any unavailable/error/unmetered outcome — a meter never

--- a/src/pages/Note.tsx
+++ b/src/pages/Note.tsx
@@ -41,6 +41,7 @@ import { RecordingBar } from "../components/RecordingBar";
 import { ChatPanel, type ChatSessionControls } from "../components/ChatPanel";
 import { SelectablePopover } from "../components/SelectablePopover";
 import { conversationTitle, relativeTime } from "../lib/chatSessions";
+import { targetKey, type ChatTarget } from "../lib/chatTarget";
 import type { LayoutOutletContext } from "../components/Layout";
 import { SkeletonLines } from "../components/Skeleton";
 import { NoteEditor } from "../components/Editor";
@@ -134,6 +135,15 @@ export function Note() {
   // render purely from it. null = no chat chrome (provider not ready / no tab).
   const [chatControls, setChatControls] = useState<ChatSessionControls | null>(null);
   const handleChatControls = useCallback((c: ChatSessionControls | null) => setChatControls(c), []);
+  // This pane is always note-anchored (#94); the library-wide surface is #95.
+  // Memoised so the panel isn't handed a fresh object on every Note render, and
+  // null until the note loads — deliberately NOT `noteId: ""`, which is the
+  // sentinel #82's decision record forbids and #93's backend rejects outright.
+  const chatTarget = useMemo<ChatTarget | null>(
+    () => (draft ? { kind: "note", noteId: draft.id } : null),
+    [draft?.id],
+  );
+  const chatTargetKey = chatTarget ? targetKey(chatTarget) : null;
   const [panelWidth, setPanelWidth] = useState<number>(() => {
     const saved = typeof localStorage !== "undefined" ? Number(localStorage.getItem("humla.panelWidth")) : NaN;
     return saved >= 320 && saved <= 720 ? saved : 440;
@@ -838,7 +848,7 @@ export function Note() {
                 Chat
               </button>
             </div>
-            {activeTab === "chat" && chatControls?.noteId === draft.id && (
+            {activeTab === "chat" && chatControls?.targetKey === chatTargetKey && (
               <ChatHistoryControls controls={chatControls} />
             )}
             <button
@@ -929,7 +939,7 @@ export function Note() {
                 )}
               </div>
             ) : activeTab === "chat" ? (
-              <ChatPanel noteId={draft.id} onControls={handleChatControls} />
+              chatTarget && <ChatPanel target={chatTarget} onControls={handleChatControls} />
             ) : (
               <div className="flex-1 min-h-0 flex flex-col px-4 py-4">
                 <div className="flex flex-wrap items-center gap-2 mb-4 shrink-0">


### PR DESCRIPTION
Closes #94. Child 2 of 3 under #82 (#93 ✅ → **#94** → #95).

⚠️ **Not merged pending a manual `pnpm tauri dev` pass** — the owner is running it. See *Verification* below for what to exercise and why the automated suite can't stand in.

## What and why

`ChatPanel` was parameterised by a single `noteId: string`, with readiness, conversations, activation, breadth and grounding all derived from it internally — so there was no way to render it for a conversation with no anchor. It now takes:

```ts
type ChatTarget = { kind: "note"; noteId: string } | { kind: "global" }
```

One component serves both surfaces, so the activation pane, `/` prompt picker, citations, truncation banner, BYOK error taxonomy, streaming, stop and the a11y contract cannot drift between them — the drift that already bit Personal vs workspace chat once.

Explicitly **not** a sentinel `noteId=""`: that's the ambiguity humla-cloud#26 records the server avoiding and #93 mirrored in Rust. `null` over the wire means the library; `""` is rejected at both ends.

New `src/lib/chatTarget.ts` owns the type plus `targetNoteId` (the wire value, and the pane's dependency identity), `targetKey` (non-nullable identity for the projection the Note header compares by value) and `targetDefaultScope` (mirrors `chat::default_breadth`).

## Review outcomes folded in

The spec axis found **two real defects the tests didn't catch**:

1. **The breadth picker still offered "This note" for a library-wide pane.** Selecting it would set the chip optimistically, then `chat::check_anchor` would reject the write — leaving the chip lying about what the next turn searches. `BreadthPicker` now takes `hasAnchor` and suppresses both anchor-dependent options. My own new test had checked only the *folder* option, so it passed straight over this; it now asserts both, with a companion test that the note pane keeps all three (the regression the suppression could cause).
2. **`newChat` kept a note-only breadth default** (`meta.breadth ?? "note"`) — the one inheritance site missed while every other default was routed through `targetDefaultScope`.

Also: `Note.tsx` built `noteId: draft?.id ?? ""` (unreachable behind the existing null guard, but the exact shape the decision record forbids) → now `ChatTarget | null`, rendered conditionally. Dependency arrays used a derived `key` string where `noteId` is correct and exhaustive-deps-honest → indirection dropped; `paneKey` remains only for the controls projection and is no longer named `key`, React's reserved prop word. And the target type started in `chatSessions.ts`, whose header describes it as display helpers for the history popover — split into its own module.

## Verification

297 frontend tests green (8 new), `tsc` clean, production bundle builds. No Rust touched.

The strongest evidence for "no behaviour change" is the **test diff**: of the pre-existing ChatPanel tests, exactly three lines moved and all three are the render prop (`noteId="n1"` → `target={{ kind: "note", noteId: "n1" }}`). Not one assertion, expectation or test name was altered — #94 named that as a finding rather than a fix, and nothing needed changing. (Audited: no `-expect(` lines in the diff.)

**What still needs a human.** The pane sits behind Tauri IPC, so a bare Vite preview renders only the setup prompt (as #80 recorded) and nothing automated can drive the real app window. Worth exercising, in rough order of what this refactor could plausibly have broken:

- [ ] **Switch notes with the Chat tab open** — the stale-projection guard now compares `targetKey` instead of `noteId`. A bug here shows as the header's +/history buttons briefly belonging to the previous note.
- [ ] **The breadth chip** — open it on a note in a folder: all three options, correct one active. This is where the review found the defect.
- [ ] **Send a turn, then stop one mid-answer** (#80's paths; the cancel key moved to `scope_id`).
- [ ] **Open history and pick an older conversation.**
- [ ] **Switch to a workspace** — the activation pane if chat isn't activated there, otherwise a normal turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)