### PR TITLE
fix(chat): keep text already streamed when a tool-using turn is stopped (#98)

### DIFF
--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -531,8 +531,9 @@ async fn agentic_loop(
     // Turn scope, not step scope: a stop usually lands during the tool phase,
     // and by then the model may already have streamed prose. In that branch no
     // step return value exists to fall back on, so this trail is the only record
-    // of what was on screen (issue #98).
-    let streamed = std::sync::Arc::new(parking_lot::Mutex::new(String::new()));
+    // of what was on screen (issue #98). Borrowed by each step's delta closure
+    // rather than shared through an `Arc` — one owner outliving every borrower.
+    let streamed = Mutex::new(String::new());
 
     let max_steps = max_steps_for(scope);
     for step in 0..max_steps {
@@ -558,7 +559,7 @@ async fn agentic_loop(
         let step_result = {
             let msg_id = assistant_id.to_string();
             let block = answer_block.to_string();
-            let seen = std::sync::Arc::clone(&streamed);
+            let seen = &streamed;
             let mut on_event = |ev: ChatStreamEvent| {
                 if let ChatStreamEvent::TextDelta(delta) = ev {
                     seen.lock().push_str(&delta);
@@ -673,17 +674,22 @@ async fn agentic_loop(
     // persists whatever was on screen, preamble included. #80's principle wins
     // here — they stopped because they'd read enough, and deleting the text they
     // just read would be hostile. The two rules genuinely conflict; this is the
-    // one place the stop rule takes precedence.
+    // one place the stop rule takes precedence. A consequence worth knowing:
+    // whether preamble survives depends on where the stop landed — kept if it
+    // landed in the tool phase, dropped if the answering step got far enough to
+    // return its own text. Both are defensible, and neither drops anything the
+    // user hadn't already read.
     if cancelled && answer.trim().is_empty() {
         answer = streamed.lock().clone();
-    }
 
-    // A stop before any text arrived has nothing worth keeping — report it as
-    // empty parts and let the caller drop the placeholder. Notably this does NOT
-    // fall through to the "couldn't find an answer" text below: the user stopped
-    // it, so claiming a failed search would be a lie (issue #80).
-    if cancelled && answer.trim().is_empty() {
-        return Ok(LoopOut { parts: Vec::new(), cancelled });
+        // Still nothing: a stop before any text arrived has nothing worth
+        // keeping, so report empty parts and let the caller drop the
+        // placeholder. Notably this does NOT fall through to the "couldn't find
+        // an answer" text below — the user stopped it, so claiming a failed
+        // search would be a lie (issue #80).
+        if answer.trim().is_empty() {
+            return Ok(LoopOut { parts: Vec::new(), cancelled });
+        }
     }
 
     let final_text = if answer.trim().is_empty() {
@@ -1326,6 +1332,59 @@ mod tests {
         assert!(
             matches!(parts.last(), Some(Part::Text { text, .. }) if text == "Half an answer"),
             "persisted the partial verbatim, got {parts:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_returned_final_step_outranks_the_delta_trail() {
+        // Issue #98 pins the ordering: the fallback to the trail applies only
+        // when the stop left no clean step text. Here the answering step got far
+        // enough to return, so its own text is the answer — the earlier
+        // narration is NOT spliced onto the front of it. Without the ordering
+        // (an unconditional fallback) the persisted answer would read
+        // "Let me search your notes…Half an answer".
+        let dir = tempfile::tempdir().unwrap();
+        let (dbh, _path) = temp_db(&dir);
+        seed_note(&dbh, "Anything", "some searchable content here");
+        let conv_id = conv(&dbh, "all");
+
+        let flag = CancelFlag::new();
+        let adapter = FakeChatAdapter::scripted(vec![
+            FakeChatAdapter::narrated_tool_step(
+                "Let me search your notes…",
+                "c1",
+                "search_notes",
+                r#"{"query":"content"}"#,
+            ),
+            FakeChatAdapter::text_step("Half an answer"),
+        ]);
+        run_chat(
+            &dbh,
+            &adapter,
+            cancellable_ctx(&flag),
+            &conv_id,
+            "",
+            &ToolScope::All,
+            "",
+            None,
+            "narrate, search, answer, then stop",
+            // Stop only once the answering step is streaming — cancelling on the
+            // narration would land in the tool phase instead.
+            |ev| {
+                if matches!(&ev, ChatEvent::TextDelta { delta, .. } if delta.starts_with("Half")) {
+                    flag.cancel();
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        let conn = dbh.lock();
+        let msgs = db::list_chat_messages(&conn, &conv_id).unwrap();
+        let parts = parse_parts(&msgs[1].content);
+        assert!(
+            matches!(parts.last(), Some(Part::Text { text, .. }) if text == "Half an answer"),
+            "the returned step's text alone, no narration prefix — got {parts:?}",
         );
     }
 

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -527,6 +527,13 @@ async fn agentic_loop(
     let mut answer = String::new();
     let mut cancelled = false;
 
+    // Every delta the user has seen this TURN, appended to across all steps.
+    // Turn scope, not step scope: a stop usually lands during the tool phase,
+    // and by then the model may already have streamed prose. In that branch no
+    // step return value exists to fall back on, so this trail is the only record
+    // of what was on screen (issue #98).
+    let streamed = std::sync::Arc::new(parking_lot::Mutex::new(String::new()));
+
     let max_steps = max_steps_for(scope);
     for step in 0..max_steps {
         // Stopped between steps (issue #80) — most likely during a tool call.
@@ -545,10 +552,9 @@ async fn agentic_loop(
         // tool-call events are handled from the returned ChatStep below.
         //
         // Deltas are also accumulated into `streamed`, which lives OUTSIDE the
-        // step future. That matters for the stop path below: if the future is
+        // step future. That matters for the stop paths below: if the future is
         // dropped mid-flight its return value is lost, but whatever the user
-        // already saw on screen is still here to persist (issue #80).
-        let streamed = std::sync::Arc::new(parking_lot::Mutex::new(String::new()));
+        // already saw on screen is still here to persist (issues #80, #98).
         let step_result = {
             let msg_id = assistant_id.to_string();
             let block = answer_block.to_string();
@@ -575,8 +581,8 @@ async fn agentic_loop(
             }
         };
         let Some(step_result) = step_result else {
-            // Aborted mid-step: keep what the user already read.
-            answer = streamed.lock().clone();
+            // Aborted mid-step: the future's return value is lost, so there is no
+            // clean step text — the fallback after the loop recovers the trail.
             cancelled = true;
             break;
         };
@@ -655,6 +661,21 @@ async fn agentic_loop(
                 is_error: outcome.is_error,
             });
         }
+    }
+
+    // Any stop that left no clean step text falls back to the delta trail — what
+    // the user actually read (issue #98). Ordering matters: a step that returned
+    // normally hands us its own final text, which is tidier than the raw trail
+    // (no earlier preamble spliced onto the answer), so that wins when present.
+    //
+    // This deliberately breaks the preamble-not-baked rule (#63): a turn that
+    // finishes persists only its final answer, but a turn the user STOPPED
+    // persists whatever was on screen, preamble included. #80's principle wins
+    // here — they stopped because they'd read enough, and deleting the text they
+    // just read would be hostile. The two rules genuinely conflict; this is the
+    // one place the stop rule takes precedence.
+    if cancelled && answer.trim().is_empty() {
+        answer = streamed.lock().clone();
     }
 
     // A stop before any text arrived has nothing worth keeping — report it as
@@ -1209,6 +1230,61 @@ mod tests {
         assert!(
             !msgs.iter().any(|m| m.content.contains("THIS STEP MUST NOT RUN")),
             "the loop stopped instead of running the next step",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stop_during_the_tool_phase_keeps_earlier_streamed_text() {
+        // Issue #98: the model narrated before its tool call, so text was on
+        // screen when the stop landed between steps. That branch assigns no
+        // answer of its own, so only the turn-scoped delta trail can save it —
+        // and the trail is what the user read, preamble or not.
+        let dir = tempfile::tempdir().unwrap();
+        let (dbh, _path) = temp_db(&dir);
+        seed_note(&dbh, "Anything", "some searchable content here");
+        let conv_id = conv(&dbh, "all");
+
+        let flag = CancelFlag::new();
+        let adapter = FakeChatAdapter::scripted(vec![
+            FakeChatAdapter::narrated_tool_step(
+                "Let me search your notes…",
+                "c1",
+                "search_notes",
+                r#"{"query":"content"}"#,
+            ),
+            FakeChatAdapter::text_step("THIS STEP MUST NOT RUN"),
+        ]);
+        run_chat(
+            &dbh,
+            &adapter,
+            cancellable_ctx(&flag),
+            &conv_id,
+            "",
+            &ToolScope::All,
+            "",
+            None,
+            "narrate, search, then stop",
+            // The tool finished; stop before the next step is dispatched.
+            |ev| {
+                if matches!(ev, ChatEvent::ToolActivity { .. }) {
+                    flag.cancel();
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        let conn = dbh.lock();
+        let msgs = db::list_chat_messages(&conn, &conv_id).unwrap();
+        assert_eq!(msgs.len(), 2, "text had streamed, so the partial turn is kept");
+        let parts = parse_parts(&msgs[1].content);
+        assert!(
+            matches!(parts.last(), Some(Part::Text { text, .. }) if text == "Let me search your notes…"),
+            "kept the narration the user read, got {parts:?}",
+        );
+        assert!(
+            !msgs.iter().any(|m| m.content.contains("THIS STEP MUST NOT RUN")),
+            "the loop still stopped instead of running the next step",
         );
     }
 

--- a/src-tauri/src/chat/providers.rs
+++ b/src-tauri/src/chat/providers.rs
@@ -254,6 +254,13 @@ impl FakeChatAdapter {
         }
     }
 
+    /// A tool step that narrates first — a real provider streams prose like
+    /// "Let me search your notes…" alongside its tool call, and that prose has
+    /// already reached the UI by the time the tool runs (issue #98).
+    pub fn narrated_tool_step(text: &str, id: &str, name: &str, arguments: &str) -> ChatStep {
+        ChatStep { text: text.into(), ..Self::tool_step(id, name, arguments) }
+    }
+
     pub fn text_step(text: &str) -> ChatStep {
         ChatStep { text: text.into(), tool_calls: Vec::new() }
     }
@@ -283,6 +290,11 @@ impl ChatAdapter for FakeChatAdapter {
         // offer; on the forced final step (tools dropped) fall back to its text
         // so the loop always terminates with an answer.
         if !step.tool_calls.is_empty() && !tools.is_empty() {
+            // Prose accompanying a tool call streams before the call, same as a
+            // real provider's SSE ordering.
+            if !step.text.is_empty() {
+                on_event(ChatStreamEvent::TextDelta(step.text.clone()));
+            }
             for tc in &step.tool_calls {
                 on_event(ChatStreamEvent::ToolCall(tc.clone()));
             }


### PR DESCRIPTION
Closes #98.

## The bug

`agentic_loop` created its delta accumulator **inside** the step loop, so it only ever held the *current* step's text. The between-steps cancel branch — the common one for a turn that uses tools, since it fires while tools run — assigned no `answer` at all. `run_chat` then saw empty parts, read that as "nothing streamed", and deleted the placeholder.

So a stop during the tool phase didn't merely lose the tail of an answer: it deleted the entire assistant turn, narration included. Reported from manual testing of #94 — *"stopping mid-stream discards the streamed message"* — on a turn that browsed and read 13 notes, i.e. one that spent nearly all its wall clock in exactly that branch.

## The fix

Hoist the accumulator to **turn** scope and fall back to it on any stop path that left no clean step text. A step that returned normally still wins, so:

- #80's mid-answer behaviour is byte-identical, and
- no earlier narration gets spliced onto the front of a final answer.

"Nothing streamed at all → drop the placeholder" is preserved, and a stopped turn still never falls through to the "I couldn't find an answer" fallback — the user stopped it; claiming a failed search would be a lie.

This is the one place the stop rule outranks #63's preamble-not-baked rule: a *stopped* turn persists what was on screen. Commented where it applies, including the fact that preamble survival is timing-dependent by design (kept if the stop lands in the tool phase, dropped if the answering step got far enough to return its own text).

## Why #80's three stop tests all passed

They covered exactly the branches that *assign* `answer` and missed the one that doesn't — and they could not have reached it, because `FakeChatAdapter` never emitted text on a tool step. A real provider streams prose alongside its tool call, so the fake now does too; without that, no test could put text on screen before the tool phase.

Both new tests were falsified rather than trusted green:

- remove the fallback → the branch-(1) test drops to one surviving message, reproducing the reported symptom exactly;
- invert the ordering → the persisted answer reads `"Let me search your notes…Half an answer"`.

## Review findings folded in (second commit)

- The spec's ordering rule had **no test** — inverting it to an unconditional fallback left all 358 tests green. Now pinned.
- Collapsed the two identical `cancelled && answer.trim().is_empty()` predicates.
- Dropped a needless `Arc`: the accumulator now outlives every closure that borrows it.

Standards axis cleared the concurrency question: no `parking_lot` guard crosses an `.await`, and `streamed`/`db` never nest, so no lock cycle is possible.

## Knowingly not fixed

On a tool-phase stop the persisted parts are `[Tool, Text(narration)]`, so a reload renders the narration *below* the tool chip it originally preceded. Cosmetic, outside #98, and fixing it means reordering parts on a path where the order is otherwise right.

Out of scope per the issue: the workspace/cloud path (the server finishes the turn regardless) and Ollama (buffered, so a stop before its single text has genuinely nothing to keep — the UI showed nothing either).

## Verification

- 358 Rust tests, 297 frontend tests, `tsc --noEmit` clean.
- Clippy is not installed on this toolchain, so that axis was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)