### PR TITLE
feat(chat): /chat route — library-wide chat surface with flat Recents (#95)

### DIFF
--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -1085,7 +1085,7 @@ mod tests {
             db::latest_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1").unwrap().unwrap();
         assert_eq!(latest.id, a.id, "the just-updated session is the active one");
         assert_eq!(
-            db::list_conversations(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1").unwrap().len(),
+            db::list_conversations(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "note-1", None).unwrap().len(),
             2
         );
     }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -611,8 +611,11 @@ fn new_personal_conversation(
 pub async fn chat_list_conversations(
     app: AppHandle,
     note_id: Option<String>,
+    limit: Option<u32>,
+    offset: Option<u32>,
 ) -> Result<Vec<ConversationMeta>, String> {
     let target = ChatTarget::from_note_id(note_id)?;
+    let page = conversation_page(limit, offset);
     let state: State<AppState> = app.state();
     let ctx = {
         let conn = state.db.lock();
@@ -626,12 +629,40 @@ pub async fn chat_list_conversations(
                 CHAT_TENANT_PERSONAL,
                 target.scope(),
                 target.scope_id(),
+                page,
             )
             .map_err(|e| e.to_string())?;
             convs.iter().map(|c| conversation_meta(&conn, c)).collect()
         }
-        Some(ws) => list_conversations_cloud(&state, ws, &target).await,
+        Some(ws) => {
+            let all = list_conversations_cloud(&state, ws, &target).await?;
+            Ok(apply_page(all, page))
+        }
     }
+}
+
+/// The requested window, or None for "everything" (issue #95).
+///
+/// A caller that omits `limit` gets the whole list — the Note header's history
+/// popover has always shown all of a note's conversations and there is no reason
+/// to change that. `offset` without `limit` is meaningless and ignored rather
+/// than errored: it can only come from our own frontend, and a dropped window is
+/// a longer list, never a wrong one.
+fn conversation_page(limit: Option<u32>, offset: Option<u32>) -> Option<db::Page> {
+    limit.map(|limit| db::Page { limit: limit.into(), offset: offset.unwrap_or(0).into() })
+}
+
+/// Apply a window to an already-materialised list.
+///
+/// The Personal path pages in SQL; a workspace can't yet, because the server's
+/// list route takes no paging parameters and hard-caps at 200 rows
+/// (`chat_sessions.pb.js`). So the workspace list is fetched whole and windowed
+/// here: the UI stays lazy and the DOM stays small, but the request doesn't
+/// shrink and a workspace past 200 conversations would silently lose the tail.
+/// Real server paging is tracked separately — see humla-cloud#33.
+fn apply_page<T>(all: Vec<T>, page: Option<db::Page>) -> Vec<T> {
+    let Some(page) = page else { return all };
+    all.into_iter().skip(page.offset as usize).take(page.limit as usize).collect()
 }
 
 /// Create a fresh chat session for a target (issue #61). Personal creates a local
@@ -1585,7 +1616,7 @@ async fn list_conversations_cloud(
     let legacy: Vec<(String, String, String, i64, String)> = {
         let conn = state.db.lock();
         let local_handles =
-            db::list_conversations(&conn, workspace, target.scope(), target.scope_id())
+            db::list_conversations(&conn, workspace, target.scope(), target.scope_id(), None)
                 .map_err(|e| e.to_string())?;
         unlisted_legacy_handles(&server_remote_ids, &local_handles)
             .into_iter()
@@ -1857,7 +1888,7 @@ mod tests {
         let n1 = new_personal_conversation(&conn, &note_target).unwrap();
         assert_ne!(n1.id, g1.id);
         let listed = |t: &ChatTarget| {
-            db::list_conversations(&conn, CHAT_TENANT_PERSONAL, t.scope(), t.scope_id())
+            db::list_conversations(&conn, CHAT_TENANT_PERSONAL, t.scope(), t.scope_id(), None)
                 .unwrap()
                 .into_iter()
                 .map(|c| c.id)
@@ -1983,7 +2014,7 @@ mod tests {
         let again = new_personal_conversation(&conn, &ChatTarget::Note("n1".into())).unwrap();
         assert_eq!(again.id, first.id, "an empty most-recent session is reused, not duplicated");
         assert_eq!(
-            db::list_conversations(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "n1").unwrap().len(),
+            db::list_conversations(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_NOTE, "n1", None).unwrap().len(),
             1,
             "no empty duplicate session was created"
         );

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1069,19 +1069,35 @@ pub fn latest_conversation(
 
 /// All conversations for a scope, most-recently-updated first (issue #61) — the
 /// backing query for the session list.
+/// A window over a conversation list, most-recent first (issue #95).
+///
+/// `/chat` lists conversations in the sidebar with no cap — a workspace could
+/// accumulate hundreds — so the list is fetched a page at a time as the user
+/// scrolls rather than all at once.
+#[derive(Debug, Clone, Copy)]
+pub struct Page {
+    pub limit: i64,
+    pub offset: i64,
+}
+
 pub fn list_conversations(
     conn: &Connection,
     tenant: &str,
     scope: &str,
     scope_id: &str,
+    page: Option<Page>,
 ) -> Result<Vec<Conversation>> {
+    // SQLite reads a negative LIMIT as "no limit", so an absent page needs no
+    // second query shape — one prepared statement serves both callers.
+    let (limit, offset) = page.map_or((-1, 0), |p| (p.limit, p.offset));
     let mut stmt = conn.prepare_cached(&format!(
         "SELECT {CONVERSATION_COLS} FROM conversations
          WHERE tenant = ?1 AND scope = ?2 AND scope_id = ?3
-         ORDER BY updated_at DESC, created_at DESC, id DESC",
+         ORDER BY updated_at DESC, created_at DESC, id DESC
+         LIMIT ?4 OFFSET ?5",
     ))?;
     let rows = stmt
-        .query_map(params![tenant, scope, scope_id], map_conversation)?
+        .query_map(params![tenant, scope, scope_id, limit, offset], map_conversation)?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows)
 }
@@ -2233,7 +2249,7 @@ mod tests {
         // The existing thread is preserved as the note's single (first) session.
         let latest = latest_conversation(&conn, "personal", "note", "n1").unwrap().unwrap();
         assert_eq!(latest.id, "conv1");
-        assert_eq!(list_conversations(&conn, "personal", "note", "n1").unwrap().len(), 1);
+        assert_eq!(list_conversations(&conn, "personal", "note", "n1", None).unwrap().len(), 1);
         // The empty conversation gets the date fallback (created_at = epoch 0).
         let conv2 = get_conversation_by_id(&conn, "conv2").unwrap().unwrap();
         assert_eq!(conv2.title.as_deref(), Some("Chat 1970-01-01"));
@@ -3070,6 +3086,56 @@ mod tests {
         }
     }
 
+    /// `/chat` lists conversations uncapped, so it fetches them a page at a time
+    /// (#95). The window must ride on the SAME ordering the unpaged list uses, or
+    /// scrolling would repeat and skip rows.
+    #[test]
+    fn conversation_pages_tile_the_list_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = open(&dir.path().join("pages.sqlite")).unwrap();
+
+        // Six global conversations, stamped so the intended order is unambiguous —
+        // rows created in one test share a timestamp, which would otherwise leave
+        // the tie broken only by id.
+        let mut ids = Vec::new();
+        for i in 0..6 {
+            let c =
+                create_conversation(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_GLOBAL, CHAT_GLOBAL_SCOPE_ID, "all")
+                    .unwrap();
+            conn.execute("UPDATE conversations SET updated_at = ?1 WHERE id = ?2", params![1_000 + i, c.id])
+                .unwrap();
+            ids.push(c.id);
+        }
+        ids.reverse(); // most-recently-updated first
+
+        let page = |limit: i64, offset: i64| {
+            list_conversations(
+                &conn,
+                CHAT_TENANT_PERSONAL,
+                CHAT_SCOPE_GLOBAL,
+                CHAT_GLOBAL_SCOPE_ID,
+                Some(Page { limit, offset }),
+            )
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect::<Vec<_>>()
+        };
+
+        // Successive pages tile the list exactly: no gap, no repeat.
+        assert_eq!([page(4, 0), page(4, 4)].concat(), ids);
+        // A page past the end is empty rather than an error — that's how the
+        // frontend learns to stop asking.
+        assert!(page(4, 8).is_empty());
+        // And no page at all still means everything.
+        assert_eq!(
+            list_conversations(&conn, CHAT_TENANT_PERSONAL, CHAT_SCOPE_GLOBAL, CHAT_GLOBAL_SCOPE_ID, None)
+                .unwrap()
+                .len(),
+            6,
+        );
+    }
+
     /// The composite key is `(tenant, scope, scope_id)`, so a global thread and a
     /// note thread never see each other even within one tenant — and a note whose
     /// id somehow equalled the sentinel still wouldn't collide, because the scope
@@ -3090,7 +3156,7 @@ mod tests {
         assert_ne!(note_conv.id, global_conv.id);
 
         let listed = |t: &ChatTarget| {
-            list_conversations(&conn, CHAT_TENANT_PERSONAL, t.scope(), t.scope_id())
+            list_conversations(&conn, CHAT_TENANT_PERSONAL, t.scope(), t.scope_id(), None)
                 .unwrap()
                 .into_iter()
                 .map(|c| c.id)
@@ -3104,7 +3170,7 @@ mod tests {
             create_conversation(&conn, "wsA", global.scope(), global.scope_id(), "all").unwrap();
         assert_eq!(listed(&global), vec![global_conv.id.clone()], "personal is unaffected");
         assert_eq!(
-            list_conversations(&conn, "wsA", global.scope(), global.scope_id()).unwrap().len(),
+            list_conversations(&conn, "wsA", global.scope(), global.scope_id(), None).unwrap().len(),
             1
         );
         assert_eq!(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState } from "react";
 import { Layout } from "./components/Layout";
 import { Home } from "./pages/Home";
 import { AllNotes } from "./pages/AllNotes";
-import Chat from "./pages/Chat";
+import { Chat } from "./pages/Chat";
 import { Note } from "./pages/Note";
 import { Folder } from "./pages/Folder";
 import { Trash } from "./pages/Trash";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { Layout } from "./components/Layout";
 import { Home } from "./pages/Home";
 import { AllNotes } from "./pages/AllNotes";
+import Chat from "./pages/Chat";
 import { Note } from "./pages/Note";
 import { Folder } from "./pages/Folder";
 import { Trash } from "./pages/Trash";
@@ -121,6 +122,8 @@ function AppRoutes() {
         <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
           <Route path="/all-notes" element={<AllNotes />} />
+          {/* Library-level destination, same tier as "All notes" (#95). */}
+          <Route path="/chat" element={<Chat />} />
           <Route path="/note/:id" element={<Note />} />
           <Route path="/folder/:id" element={<Folder />} />
           <Route path="/trash" element={<Trash />} />

--- a/src/components/ChatConversations.test.tsx
+++ b/src/components/ChatConversations.test.tsx
@@ -26,6 +26,7 @@ function publish(over: Partial<ChatSessionControls> = {}) {
     newChat: vi.fn(async () => {}),
     openConversation: vi.fn(async () => {}),
     loadMore: vi.fn(async () => {}),
+    status: null,
     ...over,
   };
   useGlobalChatStore.setState({ controls });

--- a/src/components/ChatConversations.test.tsx
+++ b/src/components/ChatConversations.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ChatConversations } from "./ChatConversations";
+import { useGlobalChatStore } from "../lib/globalChat";
+import type { ChatSessionControls } from "./ChatPanel";
+import type { ConversationMeta } from "../lib/ipc";
+
+// The `/chat` conversation list, as rendered in the sidebar (issue #95). It reads
+// only what ChatPanel publishes, so these tests seed the projection directly —
+// no IPC, no panel, no route.
+
+const HOUR = 3_600_000;
+
+function conversation(over: Partial<ConversationMeta> & { id: string }): ConversationMeta {
+  return { title: "Untitled", breadth: "all", updatedAt: 1, messageCount: 2, ...over };
+}
+
+function publish(over: Partial<ChatSessionControls> = {}) {
+  const controls: ChatSessionControls = {
+    targetKey: "global",
+    conversations: [],
+    activeConversationId: null,
+    canBrowseHistory: true,
+    hasMore: false,
+    loadingMore: false,
+    newChat: vi.fn(async () => {}),
+    openConversation: vi.fn(async () => {}),
+    loadMore: vi.fn(async () => {}),
+    ...over,
+  };
+  useGlobalChatStore.setState({ controls });
+  return controls;
+}
+
+// jsdom has no IntersectionObserver. Stub it and keep the callback so a test can
+// fire the intersection itself rather than faking a scroll.
+let fireIntersection: (() => void) | null = null;
+function stubIntersectionObserver() {
+  class Stub {
+    constructor(private cb: IntersectionObserverCallback) {
+      fireIntersection = () =>
+        this.cb([{ isIntersecting: true } as IntersectionObserverEntry], this as never);
+    }
+    observe() {}
+    disconnect() {
+      fireIntersection = null;
+    }
+    unobserve() {}
+    takeRecords() {
+      return [];
+    }
+    root = null;
+    rootMargin = "";
+    thresholds = [];
+  }
+  vi.stubGlobal("IntersectionObserver", Stub);
+}
+
+beforeEach(() => {
+  useGlobalChatStore.setState({ controls: null });
+  fireIntersection = null;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ChatConversations", () => {
+  it("renders nothing but the header until a projection arrives", () => {
+    render(<ChatConversations />);
+
+    expect(screen.getByText("Conversations")).toBeInTheDocument();
+    // "No conversations yet" would be a claim we can't make yet — the pane may
+    // still be mounting, or chat may not be configured.
+    expect(screen.queryByText("No conversations yet")).toBeNull();
+    expect(screen.getByLabelText("New chat")).toBeDisabled();
+  });
+
+  it("lists conversations most-recent first and marks the active one", () => {
+    const now = Date.now();
+    publish({
+      activeConversationId: "c-mid",
+      conversations: [
+        conversation({ id: "c-old", title: "Budget questions", updatedAt: now - 50 * HOUR }),
+        conversation({ id: "c-new", title: "This week", updatedAt: now - 1 * HOUR }),
+        conversation({ id: "c-mid", title: "Client status", updatedAt: now - 5 * HOUR }),
+      ],
+    });
+    render(<ChatConversations />);
+
+    const rows = screen.getAllByRole("listitem");
+    expect(rows.map((r) => r.textContent)).toEqual([
+      "This week1h ago",
+      "Client status5h ago",
+      "Budget questions2d ago",
+    ]);
+    const current = screen.getAllByRole("button", { current: true });
+    expect(current).toHaveLength(1);
+    expect(current[0].textContent).toContain("Client status");
+  });
+
+  it("does not cap the list", () => {
+    // A workspace could accumulate hundreds; the list is uncapped and pages in
+    // instead. 40 rows would have been truncated to 10 by the earlier design.
+    const now = Date.now();
+    publish({
+      conversations: Array.from({ length: 40 }, (_, i) =>
+        conversation({ id: `c${i}`, title: `Chat ${i}`, updatedAt: now - i * HOUR }),
+      ),
+    });
+    render(<ChatConversations />);
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(40);
+  });
+
+  it("says so when there is no history worth browsing", () => {
+    // The lone-empty-conversation rule (#62), reused rather than reimplemented.
+    publish({ canBrowseHistory: false, conversations: [conversation({ id: "c1", title: "" })] });
+    render(<ChatConversations />);
+
+    expect(screen.getByText("No conversations yet")).toBeInTheDocument();
+    expect(screen.queryByRole("listitem")).toBeNull();
+  });
+
+  it("loads the conversation whose row is clicked, and starts a new one from +", () => {
+    const controls = publish({
+      conversations: [conversation({ id: "c-a", title: "Alpha", updatedAt: 2 })],
+    });
+    render(<ChatConversations />);
+
+    fireEvent.click(screen.getByText("Alpha"));
+    expect(controls.openConversation).toHaveBeenCalledWith("c-a");
+
+    fireEvent.click(screen.getByLabelText("New chat"));
+    expect(controls.newChat).toHaveBeenCalled();
+  });
+
+  describe("paging", () => {
+    it("asks for the next page when the end of the list comes into view", async () => {
+      stubIntersectionObserver();
+      const controls = publish({
+        hasMore: true,
+        conversations: [conversation({ id: "c1", title: "One" })],
+      });
+      render(<ChatConversations />);
+
+      expect(fireIntersection).not.toBeNull();
+      fireIntersection!();
+      await waitFor(() => expect(controls.loadMore).toHaveBeenCalled());
+    });
+
+    it("stops watching once the list is exhausted", () => {
+      stubIntersectionObserver();
+      publish({ hasMore: false, conversations: [conversation({ id: "c1", title: "One" })] });
+      render(<ChatConversations />);
+
+      // No sentinel, so no observer: nothing left to ask for.
+      expect(fireIntersection).toBeNull();
+      expect(screen.queryByText("Loading…")).toBeNull();
+    });
+
+    it("says a page is on the way while one is in flight", () => {
+      stubIntersectionObserver();
+      publish({ hasMore: true, loadingMore: true, conversations: [] });
+      render(<ChatConversations />);
+
+      expect(screen.getByText("Loading…")).toBeInTheDocument();
+    });
+
+    it("renders without an IntersectionObserver at all", () => {
+      // Absent in jsdom and in old webviews. The list keeps the pages it has
+      // rather than throwing; the popover fallback still reaches them.
+      vi.stubGlobal("IntersectionObserver", undefined);
+      publish({ hasMore: true, conversations: [conversation({ id: "c1", title: "One" })] });
+
+      expect(() => render(<ChatConversations />)).not.toThrow();
+      expect(screen.getByText("One")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ChatConversations.test.tsx
+++ b/src/components/ChatConversations.test.tsx
@@ -74,7 +74,15 @@ describe("ChatConversations", () => {
     // "No conversations yet" would be a claim we can't make yet — the pane may
     // still be mounting, or chat may not be configured.
     expect(screen.queryByText("No conversations yet")).toBeNull();
-    expect(screen.getByLabelText("New chat")).toBeDisabled();
+  });
+
+  it("offers no actions of its own — the app bar owns those", () => {
+    // The section is the list. "New chat" lives in the title-bar row with the
+    // other actions, so it isn't rendered twice on one screen.
+    publish({ conversations: [conversation({ id: "c-a", title: "Alpha" })] });
+    render(<ChatConversations />);
+
+    expect(screen.queryByLabelText("New chat")).toBeNull();
   });
 
   it("lists conversations most-recent first and marks the active one", () => {
@@ -123,7 +131,7 @@ describe("ChatConversations", () => {
     expect(screen.queryByRole("listitem")).toBeNull();
   });
 
-  it("loads the conversation whose row is clicked, and starts a new one from +", () => {
+  it("loads the conversation whose row is clicked", () => {
     const controls = publish({
       conversations: [conversation({ id: "c-a", title: "Alpha", updatedAt: 2 })],
     });
@@ -131,9 +139,6 @@ describe("ChatConversations", () => {
 
     fireEvent.click(screen.getByText("Alpha"));
     expect(controls.openConversation).toHaveBeenCalledWith("c-a");
-
-    fireEvent.click(screen.getByLabelText("New chat"));
-    expect(controls.newChat).toHaveBeenCalled();
   });
 
   describe("paging", () => {

--- a/src/components/ChatConversations.tsx
+++ b/src/components/ChatConversations.tsx
@@ -1,0 +1,120 @@
+// The conversation list for `/chat`, rendered in the SIDEBAR (issue #95).
+//
+// It lives in the left nav rather than a right-hand rail because it is
+// navigation — a list of things you switch between, the same role the note list
+// plays for the notes routes. The right panel in this app means "context about
+// the thing on screen" (this note's summary, this note's transcript), which a
+// conversation list is not.
+//
+// It replaces the Folders section rather than displacing the nav items, so the
+// route swaps a *section* and not the whole sidebar: the "Chat" item you clicked
+// stays where it is and no back affordance is needed.
+//
+// No cap — a workspace could accumulate hundreds — so pages arrive as the list
+// scrolls. `ChatPanel` owns the list and the paging; this renders what it
+// publishes and asks for more when the bottom comes into view.
+
+import { useEffect, useRef } from "react";
+import { Plus } from "lucide-react";
+import { useGlobalChatStore } from "../lib/globalChat";
+import { conversationRows } from "../lib/chatSessions";
+import { cn } from "../lib/cn";
+
+export function ChatConversations() {
+  const controls = useGlobalChatStore((s) => s.controls);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  // Read through a ref so the observer below can be set up once, rather than torn
+  // down and rebuilt every time a page lands (which is itself a state change).
+  const loadMoreRef = useRef<(() => Promise<void>) | null>(null);
+  loadMoreRef.current = controls?.loadMore ?? null;
+
+  const hasMore = controls?.hasMore ?? false;
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    // `IntersectionObserver` is absent in jsdom and in very old webviews. Nothing
+    // to fall back to and nothing to break: the list keeps the pages it has, and
+    // the popover fallback still reaches them.
+    if (!el || !hasMore || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) void loadMoreRef.current?.();
+      },
+      // A little early, so the next page is usually already in by the time the
+      // user reaches the end.
+      { rootMargin: "120px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasMore]);
+
+  // Nothing published yet (the pane is still mounting, or chat isn't configured).
+  // Render the header only: "No conversations yet" would be a claim we can't make.
+  const rows = controls?.canBrowseHistory
+    ? conversationRows(controls.conversations, controls.activeConversationId)
+    : [];
+
+  return (
+    <>
+      <div className="nd-label flex items-center justify-between px-2 pb-1.5">
+        <span>Conversations</span>
+        <button
+          type="button"
+          onClick={() => void controls?.newChat()}
+          disabled={!controls}
+          aria-label="New chat"
+          title="New chat"
+          className={cn(
+            "grid place-items-center w-5 h-5 rounded-full text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-pill-hover)] transition-colors",
+            !controls && "opacity-40 pointer-events-none",
+          )}
+        >
+          <Plus size={14} strokeWidth={2} />
+        </button>
+      </div>
+
+      {controls && rows.length === 0 && (
+        <div className="px-2 py-3 text-xs text-[var(--color-text-disabled)]">
+          No conversations yet
+        </div>
+      )}
+
+      {rows.length > 0 && (
+        // Read-only rows: selecting one loads it, and "+" is the only other move.
+        // No rename or delete — in a workspace, who may remove a conversation
+        // every member can see is still an open question (#60).
+        <ul className="list-none">
+          {rows.map((row) => (
+            <li key={row.id}>
+              <button
+                type="button"
+                onClick={() => void controls?.openConversation(row.id)}
+                aria-current={row.active ? "true" : undefined}
+                title={row.label}
+                className={cn(
+                  "no-drag w-full flex flex-col gap-0.5 px-2.5 py-1.5 rounded-[var(--radius)] text-left transition-colors",
+                  row.active
+                    ? "bg-[var(--color-sidebar-active)] text-[var(--color-text)] font-medium shadow-[0_1px_2px_rgba(0,0,0,0.05)]"
+                    : "text-[var(--color-text-muted)] hover:bg-[var(--color-pill-hover)] hover:text-[var(--color-text)]",
+                )}
+              >
+                <span className="w-full truncate text-[13.5px]">{row.label}</span>
+                <span className="w-full truncate text-[11px] text-[var(--color-text-disabled)] tabular-nums">
+                  {row.description}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Paging tail: the sentinel the observer watches, plus an honest line while
+          a page is in flight. Both only exist while there might be more. */}
+      {hasMore && (
+        <div ref={sentinelRef} className="px-2 py-2 text-xs text-[var(--color-text-disabled)]">
+          {controls?.loadingMore ? "Loading…" : ""}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ChatConversations.tsx
+++ b/src/components/ChatConversations.tsx
@@ -15,7 +15,6 @@
 // publishes and asks for more when the bottom comes into view.
 
 import { useEffect, useRef } from "react";
-import { Plus } from "lucide-react";
 import { useGlobalChatStore } from "../lib/globalChat";
 import { conversationRows } from "../lib/chatSessions";
 import { cn } from "../lib/cn";
@@ -56,22 +55,9 @@ export function ChatConversations() {
 
   return (
     <>
-      <div className="nd-label flex items-center justify-between px-2 pb-1.5">
-        <span>Conversations</span>
-        <button
-          type="button"
-          onClick={() => void controls?.newChat()}
-          disabled={!controls}
-          aria-label="New chat"
-          title="New chat"
-          className={cn(
-            "grid place-items-center w-5 h-5 rounded-full text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-pill-hover)] transition-colors",
-            !controls && "opacity-40 pointer-events-none",
-          )}
-        >
-          <Plus size={14} strokeWidth={2} />
-        </button>
-      </div>
+      {/* Label only. "New chat" lives in the app bar with the other actions, the
+          way the Note view puts its actions there — the sidebar is the list. */}
+      <div className="nd-label px-2 pb-1.5">Conversations</div>
 
       {controls && rows.length === 0 && (
         <div className="px-2 py-3 text-xs text-[var(--color-text-disabled)]">
@@ -80,9 +66,9 @@ export function ChatConversations() {
       )}
 
       {rows.length > 0 && (
-        // Read-only rows: selecting one loads it, and "+" is the only other move.
-        // No rename or delete — in a workspace, who may remove a conversation
-        // every member can see is still an open question (#60).
+        // Read-only rows: selecting one loads it, and "new chat" in the app bar is
+        // the only other move. No rename or delete — in a workspace, who may remove
+        // a conversation every member can see is still an open question (#60).
         <ul className="list-none">
           {rows.map((row) => (
             <li key={row.id}>

--- a/src/components/ChatHistoryControls.tsx
+++ b/src/components/ChatHistoryControls.tsx
@@ -1,0 +1,60 @@
+// Compact chat session chrome (issue #62): a "+" that starts a fresh
+// conversation, and a history button opening a popover of the target's
+// conversations (title + relative date, most recent first, current one marked).
+// Selecting one loads it.
+//
+// Extracted from Note.tsx in #95, where `/chat` needed the same chrome for the
+// case its sidebar list can't cover — a collapsed sidebar. The alternative was a
+// third rendering of the same list, which is what `conversationRows` exists to
+// prevent.
+//
+// The history button hides for a lone empty conversation; the panel decides that
+// via `canBrowseHistory`. All state lives in ChatPanel — this renders the
+// projection it publishes and nothing else.
+
+import { History, Plus } from "lucide-react";
+import { SelectablePopover } from "./SelectablePopover";
+import type { ChatSessionControls } from "./ChatPanel";
+import { conversationRows } from "../lib/chatSessions";
+
+export function ChatHistoryControls({ controls }: { controls: ChatSessionControls }) {
+  const { conversations, activeConversationId, canBrowseHistory, newChat, openConversation } =
+    controls;
+  // Same projection the `/chat` sidebar list renders from (#95) — ordering, the
+  // empty-title fallback and the relative date are decided in one place. The
+  // popover takes its own `activeId`, so it ignores each row's `active`.
+  //
+  // Deliberately NOT paged: this popover is the fallback view, and a popover is a
+  // poor place to scroll for more. It shows the pages already loaded, which for a
+  // note is everything and for `/chat` is at least the most recent 30.
+  const items = conversationRows(conversations, activeConversationId);
+  return (
+    <div className="flex items-center gap-0.5">
+      <button
+        type="button"
+        onClick={() => void newChat()}
+        title="New chat"
+        aria-label="New chat"
+        className="nd-btn-icon"
+      >
+        <Plus size={16} strokeWidth={1.7} aria-hidden="true" />
+      </button>
+      {canBrowseHistory && (
+        <SelectablePopover
+          ariaLabel="Chat history"
+          align="end"
+          items={items}
+          activeId={activeConversationId}
+          onSelect={(id) => {
+            if (id) void openConversation(id);
+          }}
+          trigger={
+            <span className="nd-btn-icon" title="Chat history">
+              <History size={16} strokeWidth={1.7} aria-hidden="true" />
+            </span>
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ChatHistoryControls.tsx
+++ b/src/components/ChatHistoryControls.tsx
@@ -17,7 +17,18 @@ import { SelectablePopover } from "./SelectablePopover";
 import type { ChatSessionControls } from "./ChatPanel";
 import { conversationRows } from "../lib/chatSessions";
 
-export function ChatHistoryControls({ controls }: { controls: ChatSessionControls }) {
+export function ChatHistoryControls({
+  controls,
+  showHistory = true,
+}: {
+  controls: ChatSessionControls;
+  /** Whether to offer the history popover alongside "+" (#95).
+   *
+   *  `/chat` sets this false while its sidebar list is visible: that list already
+   *  IS the history, and a popover beside it would be the same thing rendered
+   *  twice. The Note header has no list, so it keeps the default. */
+  showHistory?: boolean;
+}) {
   const { conversations, activeConversationId, canBrowseHistory, newChat, openConversation } =
     controls;
   // Same projection the `/chat` sidebar list renders from (#95) — ordering, the
@@ -39,7 +50,7 @@ export function ChatHistoryControls({ controls }: { controls: ChatSessionControl
       >
         <Plus size={16} strokeWidth={1.7} aria-hidden="true" />
       </button>
-      {canBrowseHistory && (
+      {showHistory && canBrowseHistory && (
         <SelectablePopover
           ariaLabel="Chat history"
           align="end"

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -286,6 +286,93 @@ describe("ChatPanel sessions (#62)", () => {
     expect(controls.current?.activeConversationId).toBe("c1");
   });
 
+  // Paging (#95): `/chat` lists conversations uncapped in the sidebar, so the
+  // panel fetches them a page at a time. It owns the list, so it owns the paging.
+  describe("paging", () => {
+    const page = (from: number, count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: `c${from + i}`,
+        title: `Chat ${from + i}`,
+        breadth: "all" as const,
+        updatedAt: 1000 - (from + i),
+        messageCount: 2,
+      }));
+
+    // The panel's page size, inferred from the first request rather than hardcoded
+    // here — the constant is the panel's business, the tiling is what matters.
+    async function firstPage() {
+      let size = 0;
+      const seen: number[] = [];
+      mockTauri({
+        provider_key_get: () => "sk-test",
+        chat_history: () => history(),
+        chat_list_conversations: (args) => {
+          const { limit, offset } = args as { limit: number; offset: number };
+          size = limit;
+          seen.push(offset);
+          // A full page while rows remain, then a short one: that's how the panel
+          // learns where the end is, with no total count anywhere.
+          if (offset === 0) return page(0, limit);
+          if (offset === limit) return page(limit, 2);
+          return [];
+        },
+      });
+      const controls = renderWithControls();
+      await screen.findByPlaceholderText(/Ask about your notes/);
+      await waitFor(() => expect(controls.current?.conversations.length).toBe(size));
+      return { controls, size, seen };
+    }
+
+    it("appends the next page and then reports the end", async () => {
+      const { controls, size } = await firstPage();
+      expect(controls.current?.hasMore).toBe(true);
+
+      await act(async () => {
+        await controls.current!.loadMore();
+      });
+      await waitFor(() => expect(controls.current?.conversations.length).toBe(size + 2));
+      // A short page means the end; nothing further is requested.
+      expect(controls.current?.hasMore).toBe(false);
+      const before = controls.current!.conversations.length;
+      await act(async () => {
+        await controls.current!.loadMore();
+      });
+      expect(controls.current?.conversations.length).toBe(before);
+    });
+
+    it("asks for each page exactly once for one gesture", async () => {
+      const { controls, seen, size } = await firstPage();
+      // A scroll observer fires repeatedly; a second call while the first is in
+      // flight must not fetch the same window twice.
+      await act(async () => {
+        await Promise.all([controls.current!.loadMore(), controls.current!.loadMore()]);
+      });
+      expect(seen.filter((o) => o === size)).toHaveLength(1);
+    });
+
+    it("does not list a conversation twice when one is bumped between pages", async () => {
+      // A thread that gets a new message moves to page one, shifting the window —
+      // so page two can hand back a row already on screen.
+      mockTauri({
+        provider_key_get: () => "sk-test",
+        chat_history: () => history(),
+        chat_list_conversations: (args) => {
+          const { limit, offset } = args as { limit: number; offset: number };
+          return offset === 0 ? page(0, limit) : [...page(limit - 1, 1), ...page(limit, 1)];
+        },
+      });
+      const controls = renderWithControls();
+      await screen.findByPlaceholderText(/Ask about your notes/);
+      await waitFor(() => expect(controls.current!.conversations.length).toBeGreaterThan(0));
+
+      await act(async () => {
+        await controls.current!.loadMore();
+      });
+      const ids = controls.current!.conversations.map((c) => c.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
   it("'+' starts a fresh conversation and switches the pane to it", async () => {
     let created = false;
     mockTauri({

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -479,31 +479,31 @@ describe("ChatPanel with a library-wide target (#94)", () => {
     }
   });
 
-  it("defaults its scope to all notes and offers no anchor-dependent option", async () => {
+  it("shows no breadth chrome at all, so no anchor-dependent option can appear", async () => {
     // A library-wide conversation has no anchor to narrow to, so BOTH "This note"
-    // and "Folder: …" are meaningless — and offering either would let the chip
-    // show a breadth the backend's `check_anchor` is guaranteed to reject, so the
-    // chip would end up lying about what the next turn will search. Seeding a note
-    // with a folder proves the options are absent because there's no ANCHOR, not
-    // because no folder exists.
+    // and "Folder: …" are meaningless — offering either would let the chip show a
+    // breadth the backend's `check_anchor` is guaranteed to reject, i.e. lie about
+    // what the next turn will search. #94 suppressed those two options, which left
+    // a one-option picker; #95 removed the picker itself, since a dropdown whose
+    // only entry is "All notes" is noise. Seeding a note WITH a folder proves the
+    // options are gone because there's no anchor, not because no folder exists.
     seedNoteWithFolder();
     mockTauri({
       provider_key_get: () => "sk-test",
       chat_history: () => history(),
-      // The backend can't be read → the pane must fall back to "all", not "note".
+      // Unreadable stored breadth: the pane must still come up (falling back to
+      // "all"), not error or stall.
       chat_get_breadth: () => {
         throw new Error("unavailable");
       },
     });
     renderGlobal();
 
-    const scopeButton = await screen.findByRole("button", { name: "Chat scope" });
-    await waitFor(() => expect(scopeButton).toHaveTextContent(/all notes/i));
-    fireEvent.click(scopeButton);
+    await screen.findByPlaceholderText(/Ask about your notes/);
+    expect(screen.queryByRole("button", { name: "Chat scope" })).toBeNull();
     expect(screen.queryByText(/^Folder:/)).toBeNull();
     expect(screen.queryByText("This note")).toBeNull();
-    // "All notes" is the only option (it appears twice — the trigger and the row).
-    expect(screen.getAllByText("All notes").length).toBeGreaterThan(0);
+    expect(screen.queryByText("All notes")).toBeNull();
   });
 
   it("keeps the note pane's own scope options intact", async () => {

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -34,7 +34,7 @@ import { SelectablePopover, type PopoverItem } from "./SelectablePopover";
 import { ChatKeyEntry } from "./ChatKeyEntry";
 import { usageTone, liveChatErrorCopy, groundingLikelyTruncated } from "../lib/chatSessions";
 import { targetNoteId, targetKey, targetDefaultScope, type ChatTarget } from "../lib/chatTarget";
-import { NOTE_PROMPTS, opensPromptPicker, type ChatPrompt } from "../lib/chatPrompts";
+import { opensPromptPicker, promptsFor, type ChatPrompt } from "../lib/chatPrompts";
 import { RECOMMENDED_OLLAMA_MODEL } from "../lib/localModels";
 import { CommandSnippet } from "./CommandSnippet";
 import { cn } from "../lib/cn";
@@ -230,6 +230,21 @@ export function ChatPanel({
   const anchorNote = useNotesStore((s) =>
     noteId === null ? null : s.notes.find((n) => n.id === noteId) ?? null,
   );
+  // Nothing in the library to retrieve from, so the standing invitation would
+  // invite a question whose only honest answer is "I couldn't find anything" —
+  // and in a metered workspace that costs a turn to discover (#95).
+  //
+  // Three conditions, each load-bearing. A NOTE pane can't be affected: its
+  // anchor is grounding, so there is always something to answer from. In a
+  // WORKSPACE, retrieval runs server-side over the workspace index, so a local
+  // store that looks empty may simply not have synced yet — whether that index is
+  // genuinely empty or still backfilling is `index_state`'s to report, with its
+  // own copy, not this pane's to guess from local rows. And `loaded` separates an
+  // empty library from one whose first load hasn't landed.
+  // (`inWorkspace` isn't in scope until the cloud selectors below, so the flag
+  // itself is derived there.)
+  const libraryEmpty = useNotesStore((s) => s.loaded && s.notes.length === 0);
+
   const likelyTruncated = useMemo(() => {
     if (!anchorNote) return false;
     // Body is HTML in the store but plain text in the prompt — measure the text,
@@ -360,6 +375,8 @@ export function ChatPanel({
   // workspace chat does NOT — it runs on the workspace key, so a member without
   // a personal key still reaches the pane (composer or activation state, #76).
   const paneUsable = inWorkspace || ready;
+  // See `libraryEmpty` above for why all three conditions are needed.
+  const nothingToSearch = target.kind === "global" && !inWorkspace && libraryEmpty;
 
   // Activation gating (#76). Only on the managed server + a workspace. While the
   // key metadata is still loading (undefined) show neither composer nor pane, so
@@ -739,7 +756,9 @@ export function ChatPanel({
           <div className="flex-1 flex flex-col items-center justify-center gap-3 px-6 text-center">
             <MessageCircle size={22} strokeWidth={1.5} className="text-[var(--color-text-disabled)]" />
             <p className="text-sm text-[var(--color-text-muted)]">
-              Ask anything about your notes — it searches, reads, and cites them to answer.
+              {nothingToSearch
+                ? "No notes yet. Record or import a meeting, then ask about it here."
+                : "Ask anything about your notes — it searches, reads, and cites them to answer."}
             </p>
           </div>
         ) : (
@@ -822,7 +841,7 @@ export function ChatPanel({
             fixed-width panel, so this needs no portal or flip logic either. */}
         {promptsOpen && (
           <PromptPicker
-            prompts={NOTE_PROMPTS}
+            prompts={promptsFor(target)}
             onPick={applyPrompt}
             onDismiss={() => {
               setPromptsOpen(false);
@@ -847,10 +866,19 @@ export function ChatPanel({
             onKeyDown={onKeyDown}
             rows={1}
             // Stays enabled while a turn streams so Enter can stop it (#80) —
-            // `send` no-ops on `sending`, so this can't queue a second turn.
-            placeholder={sending ? "Streaming — press Enter to stop" : "Ask about your notes…"}
+            // `send` no-ops on `sending`, so this can't queue a second turn. An
+            // empty library is the one case that does disable it (#95): there is
+            // nothing to retrieve, so every question has the same dead end.
+            disabled={nothingToSearch}
+            placeholder={
+              nothingToSearch
+                ? "Nothing to search yet"
+                : sending
+                  ? "Streaming — press Enter to stop"
+                  : "Ask about your notes…"
+            }
             aria-label="Ask about your notes"
-            className="block w-full resize-none max-h-40 bg-transparent text-sm leading-relaxed pl-2 pr-11 py-2 outline-none placeholder:text-[var(--color-text-muted)]"
+            className="block w-full resize-none max-h-40 bg-transparent text-sm leading-relaxed pl-2 pr-11 py-2 outline-none placeholder:text-[var(--color-text-muted)] disabled:cursor-not-allowed"
           />
           {/* Send morphs into Stop while streaming (#80), so the same spot is
               always the turn's primary control. */}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -892,7 +892,16 @@ export function ChatPanel({
                 Suppressed when there's nothing to retrieve — offering four
                 questions with the same dead-end answer would be a tease. */}
             {onPage && !composerHeld && (
-              <PromptCards prompts={promptsFor(target)} onPick={applyPrompt} />
+              <>
+                <PromptCards prompts={promptsFor(target)} onPick={applyPrompt} />
+                {/* The "/" menu has been reachable since #80 and mentioned
+                    nowhere, so nobody who didn't read the changelog knows it
+                    exists. The new-chat screen is where it's worth saying: the
+                    cards are right there to give "these" a referent. */}
+                <p className="text-xs text-[var(--color-text-disabled)]">
+                  Type <span className="font-medium">/</span> in the composer for these any time.
+                </p>
+              </>
             )}
           </div>
         ) : (

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -44,6 +44,12 @@ import { cn } from "../lib/cn";
 // its answer, and cites the notes it drew from. A Scope popover controls how
 // broadly it searches (this note / this folder / all notes) as a live filter.
 
+// Conversations fetched per request (issue #95). `/chat` lists them uncapped in
+// the sidebar, so they arrive a page at a time as it scrolls. Sized to overfill
+// a tall sidebar on first paint — the point is to avoid loading hundreds, not to
+// make the common case take two round-trips.
+const PAGE_SIZE = 30;
+
 const Markdown = memo(function Markdown({ source }: { source: string }) {
   return <ReactMarkdown remarkPlugins={[remarkGfm]}>{source}</ReactMarkdown>;
 });
@@ -138,8 +144,17 @@ export type ChatSessionControls = {
   activeConversationId: string | null;
   /** Lone-empty-conversation rule (#62): nothing worth browsing → header hides history. */
   canBrowseHistory: boolean;
+  /** Whether another page of conversations might exist (#95). False once a short
+   *  page has come back, so a list viewer knows when to stop asking. */
+  hasMore: boolean;
+  /** A page fetch is in flight — for a "loading…" line, and so a viewer doesn't
+   *  need its own guard against firing twice. */
+  loadingMore: boolean;
   newChat: () => Promise<void>;
   openConversation: (id: string) => Promise<void>;
+  /** Append the next page. Safe to call repeatedly: it no-ops while a fetch is in
+   *  flight or once the end is known, which a scroll observer relies on. */
+  loadMore: () => Promise<void>;
 };
 
 export function ChatPanel({
@@ -164,6 +179,16 @@ export function ChatPanel({
   // the history popover and the history-visibility rule. Reset to [] on note /
   // workspace switch so the header hides until the fresh list is known.
   const [conversations, setConversations] = useState<ConversationMeta[]>([]);
+  // Paging state for that list (#95). `hasMore` starts true so the first "load
+  // more" is allowed to try; it settles on the first short page.
+  const [hasMoreConversations, setHasMoreConversations] = useState(true);
+  const [loadingMoreConversations, setLoadingMoreConversations] = useState(false);
+  // Refs, not state, for the two values `loadMoreConversations` reads at call
+  // time: a ref can't hand a stale closure the wrong offset, and the in-flight
+  // flag has to be set synchronously to swallow a repeat call in the same tick.
+  const conversationsRef = useRef<ConversationMeta[]>([]);
+  conversationsRef.current = conversations;
+  const loadingMoreRef = useRef(false);
   // The session the panel is on (issue #61). Single-threaded for now: it tracks
   // the note's active/most-recent conversation, captured from the history load
   // and the send result. null until resolved (or when the note has none yet).
@@ -249,20 +274,57 @@ export function ChatPanel({
     });
   }, [anchorNote]);
 
-  // Re-fetch the note's conversation list. Guarded by the switch gen so a slow
-  // list load can't clobber the list after a note/workspace switch. Stable per
-  // note so the callbacks and publish effect below keep stable identities.
+  // Re-fetch the FIRST page of the target's conversation list. Guarded by the
+  // switch gen so a slow list load can't clobber the list after a note/workspace
+  // switch. Stable per note so the callbacks and publish effect below keep stable
+  // identities.
+  //
+  // Always page one: every caller is a "something changed, show me the top of the
+  // list again" moment (initial load, "+", a send that retitled a thread), and the
+  // list is ordered most-recent first, so page one is where the change landed.
   const reloadConversationList = useCallback(
     async (gen: number) => {
       try {
-        const list = await ipc.chatListConversations(noteId);
-        if (gen === switchGenRef.current && Array.isArray(list)) setConversations(list);
+        const list = await ipc.chatListConversations(noteId, { limit: PAGE_SIZE, offset: 0 });
+        if (gen !== switchGenRef.current || !Array.isArray(list)) return;
+        setConversations(list);
+        setHasMoreConversations(list.length === PAGE_SIZE);
       } catch {
         /* keep the prior list */
       }
     },
     [noteId],
   );
+
+  // Append the next page (issue #95). A short page means the end: the backend
+  // returns fewer rows than asked for, and an empty page past the end, so this
+  // converges without needing a total count.
+  //
+  // Guarded three ways — an in-flight fetch, a known end, and the switch gen —
+  // because the sidebar's scroll observer can fire repeatedly for one gesture.
+  const loadMoreConversations = useCallback(async () => {
+    if (loadingMoreRef.current || !hasMoreConversations) return;
+    loadingMoreRef.current = true;
+    const gen = switchGenRef.current;
+    setLoadingMoreConversations(true);
+    try {
+      const offset = conversationsRef.current.length;
+      const next = await ipc.chatListConversations(noteId, { limit: PAGE_SIZE, offset });
+      if (gen !== switchGenRef.current || !Array.isArray(next)) return;
+      // De-dupe by id: a conversation that got bumped to page one between the two
+      // fetches would otherwise appear twice.
+      setConversations((prev) => {
+        const seen = new Set(prev.map((c) => c.id));
+        return [...prev, ...next.filter((c) => !seen.has(c.id))];
+      });
+      setHasMoreConversations(next.length === PAGE_SIZE);
+    } catch {
+      /* keep what we have; the observer will retry on the next scroll */
+    } finally {
+      loadingMoreRef.current = false;
+      setLoadingMoreConversations(false);
+    }
+  }, [noteId, hasMoreConversations]);
 
   // Clear the transient per-turn UI (streaming/activity/errors) and stop
   // accepting stream deltas. Shared by the note-switch load effect and every
@@ -588,8 +650,11 @@ export function ChatPanel({
       conversations,
       activeConversationId: conversationId,
       canBrowseHistory,
+      hasMore: hasMoreConversations,
+      loadingMore: loadingMoreConversations,
       newChat,
       openConversation,
+      loadMore: loadMoreConversations,
     });
   }, [
     onControls,
@@ -598,8 +663,11 @@ export function ChatPanel({
     conversations,
     conversationId,
     messages.length,
+    hasMoreConversations,
+    loadingMoreConversations,
     newChat,
     openConversation,
+    loadMoreConversations,
   ]);
 
   async function send() {

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -660,6 +660,23 @@ export function ChatPanel({
     }
   }, [paneUsable, notActivated, activationLoading]);
 
+  // Grow the composer with the text. `rows={1}` sets the floor and `max-h-40` the
+  // ceiling, but nothing in between: without this a wrapped question scrolls
+  // inside a one-line box, so the user can't see what they're about to send.
+  // Height has to be measured, hence an effect rather than CSS — `field-sizing`
+  // isn't available in this webview. Reset to `auto` first so the box shrinks back
+  // when text is deleted or cleared after a send; `max-height` still caps it, and
+  // the textarea scrolls past that.
+  //
+  // Not unit-tested on purpose: jsdom reports `scrollHeight` as 0, so any
+  // assertion here would pass for the wrong reason.
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [input]);
+
   // Publish the session controls to the owner (Note header) whenever the list,
   // the active conversation, or its emptiness changes. Only while ready — no
   // chat chrome before a provider is configured. `null` tells the header to

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -230,19 +230,10 @@ export function ChatPanel({
   const anchorNote = useNotesStore((s) =>
     noteId === null ? null : s.notes.find((n) => n.id === noteId) ?? null,
   );
-  // Nothing in the library to retrieve from, so the standing invitation would
-  // invite a question whose only honest answer is "I couldn't find anything" —
-  // and in a metered workspace that costs a turn to discover (#95).
-  //
-  // Three conditions, each load-bearing. A NOTE pane can't be affected: its
-  // anchor is grounding, so there is always something to answer from. In a
-  // WORKSPACE, retrieval runs server-side over the workspace index, so a local
-  // store that looks empty may simply not have synced yet — whether that index is
-  // genuinely empty or still backfilling is `index_state`'s to report, with its
-  // own copy, not this pane's to guess from local rows. And `loaded` separates an
-  // empty library from one whose first load hasn't landed.
-  // (`inWorkspace` isn't in scope until the cloud selectors below, so the flag
-  // itself is derived there.)
+  // Is there anything at all to retrieve from? `loaded` matters as much as the
+  // count: `notes: []` on its own also means "the first load hasn't landed", and
+  // acting on that would fire for a frame on every launch. (The full rule is
+  // derived below as `nothingToSearch`, once the cloud selectors are in scope.)
   const libraryEmpty = useNotesStore((s) => s.loaded && s.notes.length === 0);
 
   const likelyTruncated = useMemo(() => {
@@ -375,8 +366,26 @@ export function ChatPanel({
   // workspace chat does NOT — it runs on the workspace key, so a member without
   // a personal key still reaches the pane (composer or activation state, #76).
   const paneUsable = inWorkspace || ready;
-  // See `libraryEmpty` above for why all three conditions are needed.
-  const nothingToSearch = target.kind === "global" && !inWorkspace && libraryEmpty;
+
+  // A library-wide pane with nothing to retrieve from would otherwise show the
+  // standing invitation — inviting a question whose only honest answer is "I
+  // couldn't find anything", which in a metered workspace costs a turn to
+  // discover (#95). So the composer holds instead, in one of two states.
+  //
+  // A NOTE pane never reaches either: its anchor note IS grounding, so there is
+  // always something to answer from.
+  //
+  // `syncing` splits them. A workspace pulls its notes down after a switch, so a
+  // local mirror that looks empty mid-pull isn't evidence of an empty workspace —
+  // that gets the still-arriving copy rather than a claim about the library. This
+  // is a client-side stand-in for the server's `index_state`, which reports
+  // "empty" (backfilling) vs "quarantined" vs "ready" authoritatively but isn't
+  // wired to the client yet; until it is, sync state is the honest local proxy.
+  const syncing = useCloudStore((s) => s.syncStatus) === "syncing";
+  const globalPane = target.kind === "global";
+  const nothingToSearch = globalPane && libraryEmpty && !syncing;
+  const notesStillArriving = globalPane && libraryEmpty && syncing;
+  const composerHeld = nothingToSearch || notesStillArriving;
 
   // Activation gating (#76). Only on the managed server + a workspace. While the
   // key metadata is still loading (undefined) show neither composer nor pane, so
@@ -756,9 +765,11 @@ export function ChatPanel({
           <div className="flex-1 flex flex-col items-center justify-center gap-3 px-6 text-center">
             <MessageCircle size={22} strokeWidth={1.5} className="text-[var(--color-text-disabled)]" />
             <p className="text-sm text-[var(--color-text-muted)]">
-              {nothingToSearch
-                ? "No notes yet. Record or import a meeting, then ask about it here."
-                : "Ask anything about your notes — it searches, reads, and cites them to answer."}
+              {notesStillArriving
+                ? "Still syncing your notes — this will be ready in a moment."
+                : nothingToSearch
+                  ? "No notes yet. Record or import a meeting, then ask about it here."
+                  : "Ask anything about your notes — it searches, reads, and cites them to answer."}
             </p>
           </div>
         ) : (
@@ -866,19 +877,27 @@ export function ChatPanel({
             onKeyDown={onKeyDown}
             rows={1}
             // Stays enabled while a turn streams so Enter can stop it (#80) —
-            // `send` no-ops on `sending`, so this can't queue a second turn. An
-            // empty library is the one case that does disable it (#95): there is
-            // nothing to retrieve, so every question has the same dead end.
-            disabled={nothingToSearch}
+            // `send` no-ops on `sending`, so this can't queue a second turn.
+            //
+            // Nothing to retrieve from is the one case that closes the composer
+            // (#95). `readOnly` + `aria-disabled` rather than `disabled`, because
+            // `disabled` drops the control out of the tab order — a keyboard or
+            // screen-reader user would then never reach the placeholder saying
+            // WHY they can't type. Nothing can be entered either way, so `send`
+            // stays unreachable: it no-ops on empty input.
+            readOnly={composerHeld}
+            aria-disabled={composerHeld || undefined}
             placeholder={
-              nothingToSearch
-                ? "Nothing to search yet"
-                : sending
-                  ? "Streaming — press Enter to stop"
-                  : "Ask about your notes…"
+              notesStillArriving
+                ? "Syncing your notes…"
+                : nothingToSearch
+                  ? "Nothing to search yet"
+                  : sending
+                    ? "Streaming — press Enter to stop"
+                    : "Ask about your notes…"
             }
             aria-label="Ask about your notes"
-            className="block w-full resize-none max-h-40 bg-transparent text-sm leading-relaxed pl-2 pr-11 py-2 outline-none placeholder:text-[var(--color-text-muted)] disabled:cursor-not-allowed"
+            className="block w-full resize-none max-h-40 bg-transparent text-sm leading-relaxed pl-2 pr-11 py-2 outline-none placeholder:text-[var(--color-text-muted)] read-only:cursor-not-allowed"
           />
           {/* Send morphs into Stop while streaming (#80), so the same spot is
               always the turn's primary control. */}
@@ -1144,6 +1163,13 @@ function BreadthPicker({
       : []),
     { id: "all", label: "All notes", icon: <Files size={14} strokeWidth={1.7} aria-hidden="true" /> },
   ];
+  // One option is not a choice: a picker whose only entry is "All notes" is noise,
+  // so a library-wide pane shows no breadth chrome at all (#95). Narrowing is
+  // still available there — as a tool argument the model chooses (#81), not as a
+  // control. A pane WITH an anchor always has at least "This note" + "All notes",
+  // so this never hides the picker where it does work.
+  if (items.length < 2) return null;
+
   // If the folder disappears while "folder" is selected — or the pane has no
   // anchor at all — fall back to the pane's own default.
   const selectable = items.some((i) => i.id === scope);

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -476,6 +476,13 @@ export function ChatPanel({
   const nothingToSearch = globalPane && libraryEmpty && !syncing;
   const notesStillArriving = globalPane && libraryEmpty && syncing;
   const composerHeld = nothingToSearch || notesStillArriving;
+  // Does the composer's control row have anything in it? The breadth picker needs
+  // an anchor to offer a second option (#95), the model chip is panel-only and
+  // Personal-only (#80), the truncation hint needs an anchor note, and the turn
+  // meter needs a metered workspace (#69). On `/chat` in Personal that's nothing
+  // at all — so don't render the row and leave a gap where content isn't.
+  const showComposerControls =
+    noteId !== null || (!onPage && !inWorkspace && !!model) || !!usage;
 
   // Activation gating (#76). Only on the managed server + a workspace. While the
   // key metadata is still loading (undefined) show neither composer nor pane, so
@@ -1012,7 +1019,7 @@ export function ChatPanel({
             // box, so the two don't nest into a double border.
             onPage
               ? ""
-              : "border border-[var(--color-line)] transition-colors focus-within:border-[var(--color-text-muted)]",
+              : "border border-transparent transition-colors focus-within:border-[var(--color-text-muted)]",
           )}
         >
           <textarea
@@ -1042,14 +1049,17 @@ export function ChatPanel({
                     : "Ask about your notes…"
             }
             aria-label="Ask about your notes"
-            // `.nd-bare` is the documented opt-out from the global
-            // `select, textarea` surface in globals.css — an UNLAYERED rule, so it
-            // beat every utility here: this textarea has been carrying its own 1px
-            // border, input background and 8px/12px padding all along, which is why
-            // the page variant's composer box read as double-bordered and why the
-            // padding utilities below looked ignored. The wrapper owns the surface
-            // (see the focus-visible comment above); the field itself is bare.
-            className="nd-bare block w-full resize-none max-h-40 text-sm leading-relaxed pl-2 pr-11 py-2 outline-none placeholder:text-[var(--color-text-muted)] read-only:cursor-not-allowed"
+            // The global `select, textarea` rule in globals.css is UNLAYERED, so it
+            // outranks every utility here and hands this field a border, a fill and
+            // 8px/12px padding whether we ask or not. In the PANEL that lands inside
+            // the wrapper's own transparent border and has been the Note tab's look
+            // since #46 — so leave it exactly alone. On the PAGE the composer box is
+            // the surface, so the field opts out through a rule of the same kind
+            // (`.nd-chat-input`), which also owns its padding.
+            className={cn(
+              "block w-full resize-none max-h-40 text-sm leading-relaxed outline-none placeholder:text-[var(--color-text-muted)] read-only:cursor-not-allowed",
+              onPage ? "nd-chat-input" : "bg-transparent pl-2 pr-11 py-2",
+            )}
           />
           {/* Send morphs into Stop while streaming (#80), so the same spot is
               always the turn's primary control. */}
@@ -1082,7 +1092,12 @@ export function ChatPanel({
         {/* Composer control row: breadth picker bottom-left, workspace turn
             allowance bottom-right (#69). The meter shows only in a metered
             workspace — `usage` is null in personal context and on any
-            unavailable/error/unmetered outcome, so nothing renders then. */}
+            unavailable/error/unmetered outcome, so nothing renders then.
+            Skipped entirely when every one of its children would be absent, which
+            on `/chat` in Personal is all of them: an empty flex row still costs
+            the container's gap, and that showed up as an unexplained band under
+            the composer that looked like space reserved for something. */}
+        {showComposerControls && (
         <div className="flex items-center justify-between gap-2 px-1">
           <div className="flex min-w-0 items-center gap-2">
             <BreadthPicker
@@ -1139,6 +1154,7 @@ export function ChatPanel({
             </span>
           )}
         </div>
+        )}
       </div>
       )}
     </div>

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -155,6 +155,14 @@ export type ChatSessionControls = {
   /** Append the next page. Safe to call repeatedly: it no-ops while a fetch is in
    *  flight or once the end is known, which a scroll observer relies on. */
   loadMore: () => Promise<void>;
+  /** What the pane is about to answer with (#95), for a host that shows it in its
+   *  own header chrome instead of the composer row — `/chat` does.
+   *
+   *  Published rather than re-derived: `useChatReadiness` polls a local Ollama
+   *  server every 2s, so a second caller would double that probe to show one
+   *  label. Null in a workspace, where the turn runs on the SERVER's model and
+   *  this local setting would name something that isn't answering (#80). */
+  status: { provider: string; model: string } | null;
 };
 
 /** Which host the panel is rendering into (issue #95).
@@ -675,6 +683,7 @@ export function ChatPanel({
       newChat,
       openConversation,
       loadMore: loadMoreConversations,
+      status: inWorkspace || !model ? null : { provider, model },
     });
   }, [
     onControls,
@@ -688,6 +697,9 @@ export function ChatPanel({
     newChat,
     openConversation,
     loadMoreConversations,
+    inWorkspace,
+    provider,
+    model,
   ]);
 
   async function send() {
@@ -847,7 +859,7 @@ export function ChatPanel({
         aria-live="polite"
         aria-busy={bulkLoading}
         aria-label="Chat messages"
-        className={cn("flex-1 min-h-0 overflow-y-auto py-4 flex flex-col gap-3", gutter)}
+        className={cn("nd-scroll-hidden flex-1 min-h-0 overflow-y-auto py-4 flex flex-col gap-3", gutter)}
       >
         {messages.length === 0 && !sending ? (
           <div
@@ -1000,7 +1012,7 @@ export function ChatPanel({
             // box, so the two don't nest into a double border.
             onPage
               ? ""
-              : "border border-transparent transition-colors focus-within:border-[var(--color-text-muted)]",
+              : "border border-[var(--color-line)] transition-colors focus-within:border-[var(--color-text-muted)]",
           )}
         >
           <textarea
@@ -1030,7 +1042,14 @@ export function ChatPanel({
                     : "Ask about your notes…"
             }
             aria-label="Ask about your notes"
-            className="block w-full resize-none max-h-40 bg-transparent text-sm leading-relaxed pl-2 pr-11 py-2 outline-none placeholder:text-[var(--color-text-muted)] read-only:cursor-not-allowed"
+            // `.nd-bare` is the documented opt-out from the global
+            // `select, textarea` surface in globals.css — an UNLAYERED rule, so it
+            // beat every utility here: this textarea has been carrying its own 1px
+            // border, input background and 8px/12px padding all along, which is why
+            // the page variant's composer box read as double-bordered and why the
+            // padding utilities below looked ignored. The wrapper owns the surface
+            // (see the focus-visible comment above); the field itself is bare.
+            className="nd-bare block w-full resize-none max-h-40 text-sm leading-relaxed pl-2 pr-11 py-2 outline-none placeholder:text-[var(--color-text-muted)] read-only:cursor-not-allowed"
           />
           {/* Send morphs into Stop while streaming (#80), so the same spot is
               always the turn's primary control. */}
@@ -1078,8 +1097,11 @@ export function ChatPanel({
                 disabled fails contrast on interactive text (see #65).
                 Personal only: a workspace turn runs on the server's model, and
                 `model` here is the LOCAL chat_model setting, so showing it in a
-                workspace would name a model that isn't answering. */}
-            {!inWorkspace && model && (
+                workspace would name a model that isn't answering.
+                Not on the page, where it's published upward and shown in the
+                header's pill row — the same fact twice on one screen is clutter,
+                and the header is where that surface keeps its identity info. */}
+            {!onPage && !inWorkspace && model && (
               <span
                 data-testid="chat-model-indicator"
                 title={`Answering with ${model} (${provider}) — change it in Settings → Chat`}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -157,13 +157,33 @@ export type ChatSessionControls = {
   loadMore: () => Promise<void>;
 };
 
+/** Which host the panel is rendering into (issue #95).
+ *
+ *  `panel` is the Note's right-hand context card: narrow, already inside a
+ *  bordered surface, and the only place its own tenant line can go — so it keeps
+ *  its internal gutters and hairlines.
+ *
+ *  `page` is the `/chat` route: the page owns the gutter and the header, so the
+ *  panel drops both its horizontal padding and its separators and lets the
+ *  content run edge to edge. Wide enough, too, for the prompt cards a narrow
+ *  panel can't fit.
+ *
+ *  A variant rather than a scatter of booleans: every difference below follows
+ *  from which host is responsible for the chrome, and that's one fact. */
+export type ChatPanelVariant = "panel" | "page";
+
 export function ChatPanel({
   target,
   onControls,
+  variant = "panel",
 }: {
   target: ChatTarget;
   onControls?: (controls: ChatSessionControls | null) => void;
+  variant?: ChatPanelVariant;
 }) {
+  const onPage = variant === "page";
+  // The page supplies its own gutter, so the panel's own padding would double it.
+  const gutter = onPage ? "" : "px-4";
   // The anchor note id for IPC — null means the whole library (#93). This is also
   // the pane's dependency identity: it's already a stable scalar and `null` is
   // exactly "global", so a change in it is exactly a change of target. Depending on
@@ -813,7 +833,7 @@ export function ChatPanel({
           bubbles butt straight up against the text with no separation. No
           breadth/tenant chrome here — breadth moved to the composer, and the
           tenant is pinned to the loaded workspace (#58). */}
-      {workspaceName && (
+      {workspaceName && !onPage && (
         <div className="shrink-0 px-4 py-2 border-b border-[var(--color-line)] text-xs text-[var(--color-text-muted)]">
           Chatting in {workspaceName} · visible to members
         </div>
@@ -827,10 +847,15 @@ export function ChatPanel({
         aria-live="polite"
         aria-busy={bulkLoading}
         aria-label="Chat messages"
-        className="flex-1 min-h-0 overflow-y-auto px-4 py-4 flex flex-col gap-3"
+        className={cn("flex-1 min-h-0 overflow-y-auto py-4 flex flex-col gap-3", gutter)}
       >
         {messages.length === 0 && !sending ? (
-          <div className="flex-1 flex flex-col items-center justify-center gap-3 px-6 text-center">
+          <div
+            className={cn(
+              "flex-1 flex flex-col items-center justify-center gap-3 text-center",
+              onPage ? "gap-5" : "px-6",
+            )}
+          >
             <MessageCircle size={22} strokeWidth={1.5} className="text-[var(--color-text-disabled)]" />
             <p className="text-sm text-[var(--color-text-muted)]">
               {notesStillArriving
@@ -839,6 +864,17 @@ export function ChatPanel({
                   ? "No notes yet. Record or import a meeting, then ask about it here."
                   : "Ask anything about your notes — it searches, reads, and cites them to answer."}
             </p>
+            {/* The same prompts the "/" menu offers (#80), shown up front on a new
+                chat — a blank page tells a first-time user nothing about what this
+                can do, and on a library-wide surface the useful questions are the
+                least guessable ones. Cards only in the page variant: the Note's
+                context panel can be 320px wide, where a grid of them would be
+                unreadable, and its "/" menu is a keystroke away regardless.
+                Suppressed when there's nothing to retrieve — offering four
+                questions with the same dead-end answer would be a tease. */}
+            {onPage && !composerHeld && (
+              <PromptCards prompts={promptsFor(target)} onPick={applyPrompt} />
+            )}
           </div>
         ) : (
           <ul className="flex flex-col gap-3 list-none">
@@ -879,7 +915,12 @@ export function ChatPanel({
       </div>
 
       {!notActivated && errorView && (
-        <div className="mx-4 mb-2 flex items-start gap-2 rounded-[var(--radius)] bg-[var(--color-accent-soft)] px-3 py-2 text-xs text-[var(--color-accent-text)]">
+        <div
+          className={cn(
+            "mb-2 flex items-start gap-2 rounded-[var(--radius)] bg-[var(--color-accent-soft)] px-3 py-2 text-xs text-[var(--color-accent-text)]",
+            onPage ? "" : "mx-4",
+          )}
+        >
           <AlertTriangle size={13} strokeWidth={1.7} className="mt-px shrink-0" />
           <span>{errorView}</span>
         </div>
@@ -889,14 +930,19 @@ export function ChatPanel({
           warning ("may omit"), this is the confirmation that it actually
           happened. Suppressing it would leave the user unsure which. */}
       {truncated && !error && (
-        <div className="mx-4 mb-2 text-xs text-[var(--color-text-muted)]">
+        <div className={cn("mb-2 text-xs text-[var(--color-text-muted)]", onPage ? "" : "mx-4")}>
           Note content was truncated to fit the context budget — the answer may miss details near
           the end.
         </div>
       )}
 
       {activationLoading ? (
-        <div className="shrink-0 border-t border-[var(--color-line)] p-4 text-sm text-[var(--color-text-muted)]">
+        <div
+          className={cn(
+            "shrink-0 p-4 text-sm text-[var(--color-text-muted)]",
+            onPage ? "" : "border-t border-[var(--color-line)]",
+          )}
+        >
           Checking chat activation…
         </div>
       ) : notActivated ? (
@@ -911,7 +957,17 @@ export function ChatPanel({
           onActivated={handleActivated}
         />
       ) : (
-      <div className="relative shrink-0 border-t border-[var(--color-line)] p-2.5 flex flex-col gap-1.5">
+      <div
+        className={cn(
+          "relative shrink-0 p-2.5 flex flex-col gap-1.5",
+          // On the page the composer is its own rounded box — the Codex/Claude
+          // Desktop shape — instead of a hairline drawn across the whole pane.
+          // A box reads as "type here"; a separator just divides two empty areas.
+          onPage
+            ? "rounded-[var(--radius-card)] border border-[var(--color-line-visible)] bg-[var(--color-surface)] transition-colors focus-within:border-[var(--color-text-muted)]"
+            : "border-t border-[var(--color-line)]",
+        )}
+      >
         {/* Prompt picker (#80). Rendered in-flow above the composer rather than
             through SelectablePopover: that component is a click-to-select value
             picker with no controlled-open and no arrow-key nav, and bending it
@@ -937,7 +993,16 @@ export function ChatPanel({
             variant (28px) fits comfortably inside without touching the edges.
             The textarea has no native outline, so a token-based focus-within
             border on the wrapper makes keyboard focus visible (#64). */}
-        <div className="relative rounded-[var(--radius)] border border-transparent transition-colors focus-within:border-[var(--color-text-muted)]">
+        <div
+          className={cn(
+            "relative rounded-[var(--radius)]",
+            // The page variant hoists this focus treatment out to the composer
+            // box, so the two don't nest into a double border.
+            onPage
+              ? ""
+              : "border border-transparent transition-colors focus-within:border-[var(--color-text-muted)]",
+          )}
+        >
           <textarea
             ref={inputRef}
             value={input}
@@ -1108,6 +1173,41 @@ function ActivationPane({
 // Enter picks, Escape dismisses. Deliberately NOT SelectablePopover — that's a
 // click-to-select value picker with internal open state and no key nav; see the
 // call site for why sharing it would have been the wrong trade.
+// The prompt set as cards, for a new chat on the `/chat` page (issue #95, after
+// the Codex-style new-chat screen). Same prompts and same `onPick` as the "/"
+// menu — this is a second surface for one list, not a second list.
+//
+// Picking one FILLS the composer rather than sending it, exactly as the menu
+// does: these are starting points, and a card that spends a turn (a metered one,
+// in a workspace) on a question you hadn't finished thinking about would be a
+// trap. The user can edit and press Enter.
+function PromptCards({
+  prompts,
+  onPick,
+}: {
+  prompts: ChatPrompt[];
+  onPick: (p: ChatPrompt) => void;
+}) {
+  return (
+    <ul className="grid w-full max-w-[520px] grid-cols-2 gap-2 list-none">
+      {prompts.map((p) => (
+        <li key={p.label}>
+          <button
+            type="button"
+            onClick={() => onPick(p)}
+            className="h-full w-full rounded-[var(--radius-card)] border border-[var(--color-line)] bg-[var(--color-surface)] px-3 py-2.5 text-left transition-colors hover:border-[var(--color-line-visible)] hover:bg-[var(--color-pill-hover)]"
+          >
+            <span className="block text-[13px] font-medium text-[var(--color-text)]">{p.label}</span>
+            <span className="mt-0.5 block text-xs leading-snug text-[var(--color-text-muted)]">
+              {p.description}
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 function PromptPicker({
   prompts,
   onPick,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Folder as FolderIcon,
   FolderPlus,
   Home as HomeIcon,
+  MessageCircle,
   Plus,
   Search,
   Settings as SettingsIcon,
@@ -208,6 +209,14 @@ export function Sidebar({ onCollapse }: { onCollapse: () => void }) {
             label="All notes"
             active={location.pathname === "/all-notes"}
             count={notes.length}
+          />
+          {/* Chat sits directly under "All notes" — both are library-level
+              destinations, so they belong on the same tier (#95). */}
+          <NavItem
+            to="/chat"
+            icon={MessageCircle}
+            label="Chat"
+            active={location.pathname === "/chat"}
           />
           <button
             type="button"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -254,8 +254,9 @@ export function Sidebar({ onCollapse }: { onCollapse: () => void }) {
           // conversation list is navigation, so this is where it belongs. Only the
           // section swaps — nav, search and the footer stay put, so nothing the
           // user needs to leave with disappears.
-          <div className="mt-3">
-            <Divider />
+          // No divider above it: the section label already separates it, and a
+          // hairline plus a label is two devices doing one job.
+          <div className="mt-4">
             <ChatConversations />
           </div>
         ) : (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,6 +21,7 @@ import { ContextMenu, ContextMenuItem } from "./ContextMenu";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 import { SetupNag } from "./SetupNag";
 import { ImportDialog } from "./ImportDialog";
+import { ChatConversations } from "./ChatConversations";
 import { useCloudStore } from "../lib/cloud";
 
 // Humla mark sourced from humla-small.svg — single-path silhouette of
@@ -155,6 +156,9 @@ export function Sidebar({ onCollapse }: { onCollapse: () => void }) {
 
   const empty = folders.length === 0 && notes.length === 0;
   const noResults = searching && searchResults.length === 0;
+  // Search still wins over the route: searching notes from `/chat` is a reasonable
+  // thing to do, and its results navigate away anyway.
+  const onChat = location.pathname === "/chat";
 
   return (
     <div className="h-full flex flex-col px-2.5 pb-2.5">
@@ -243,6 +247,16 @@ export function Sidebar({ onCollapse }: { onCollapse: () => void }) {
                 folderName={n.folder_id ? folderById.get(n.folder_id)?.name : undefined}
               />
             ))}
+          </div>
+        ) : onChat ? (
+          // Route-dependent section (#95): on `/chat` the body below the nav items
+          // lists conversations instead of folders. Folders are inert there, and a
+          // conversation list is navigation, so this is where it belongs. Only the
+          // section swaps — nav, search and the footer stay put, so nothing the
+          // user needs to leave with disappears.
+          <div className="mt-3">
+            <Divider />
+            <ChatConversations />
           </div>
         ) : (
           <>

--- a/src/lib/chatPrompts.test.ts
+++ b/src/lib/chatPrompts.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { NOTE_PROMPTS, opensPromptPicker } from "./chatPrompts";
+import { LIBRARY_PROMPTS, NOTE_PROMPTS, opensPromptPicker, promptsFor } from "./chatPrompts";
 
-describe("NOTE_PROMPTS", () => {
+describe.each([
+  ["NOTE_PROMPTS", NOTE_PROMPTS],
+  ["LIBRARY_PROMPTS", LIBRARY_PROMPTS],
+])("%s", (_name, set) => {
   it("is a non-empty set with a label, description and prompt on every entry", () => {
-    expect(NOTE_PROMPTS.length).toBeGreaterThan(0);
-    for (const p of NOTE_PROMPTS) {
+    expect(set.length).toBeGreaterThan(0);
+    for (const p of set) {
       expect(p.label.trim()).not.toBe("");
       expect(p.description.trim()).not.toBe("");
       expect(p.prompt.trim()).not.toBe("");
@@ -12,8 +15,32 @@ describe("NOTE_PROMPTS", () => {
   });
 
   it("has unique labels, so popover rows can key on them", () => {
-    const labels = NOTE_PROMPTS.map((p) => p.label);
+    const labels = set.map((p) => p.label);
     expect(new Set(labels).size).toBe(labels.length);
+  });
+});
+
+describe("LIBRARY_PROMPTS", () => {
+  it("is one-click: no prompt carries a placeholder to edit before sending", () => {
+    // #82 originally proposed "…for a given client?", which forced an edit the
+    // other three didn't (#95 changed it). Nothing here should regress to that.
+    for (const p of LIBRARY_PROMPTS) {
+      expect(p.prompt).not.toMatch(/\ba given\b|\[|\{|<|xxx|TODO/i);
+    }
+  });
+
+  it("asks across notes rather than about one, which is the point of the surface", () => {
+    // Each prompt names a scope wider than a single note; none says "this".
+    for (const p of LIBRARY_PROMPTS) {
+      expect(p.prompt).not.toMatch(/\bthis (meeting|note|call)\b/i);
+    }
+  });
+});
+
+describe("promptsFor", () => {
+  it("gives a note pane the note set and /chat the library set", () => {
+    expect(promptsFor({ kind: "note", noteId: "n1" })).toBe(NOTE_PROMPTS);
+    expect(promptsFor({ kind: "global" })).toBe(LIBRARY_PROMPTS);
   });
 });
 

--- a/src/lib/chatPrompts.ts
+++ b/src/lib/chatPrompts.ts
@@ -10,6 +10,8 @@
 // "Presets" already means summary styles (`summary_preset` — Meeting / 1:1 /
 // Lecture), so reusing it would be ambiguous in Settings and in conversation.
 
+import type { ChatTarget } from "./chatTarget";
+
 export type ChatPrompt = {
   /** Shown in the popover row. */
   label: string;
@@ -43,6 +45,48 @@ export const NOTE_PROMPTS: ChatPrompt[] = [
     prompt: "What was raised but left unresolved?",
   },
 ];
+
+// Library-scoped prompts, for the `/chat` surface (issue #95). Deliberately
+// cross-note: that is what a library-wide destination is FOR, and none of these
+// can be answered from a single note's grounding — so they double as a statement
+// of what this surface does that the Note's Chat tab cannot.
+//
+// "Client status" earns its place twice: it is the only hint that narrowing by
+// client works at all, which is otherwise undiscoverable now that `/chat` has no
+// scope picker (a dropdown whose only option is "All notes" would be noise, so
+// narrowing stays a tool argument the model chooses — the tools-not-stuffing
+// decision from #81). Its wording drops #82's original "…for a given client?":
+// that carried a placeholder the user had to edit before sending, unlike the
+// other three, which are one-click.
+export const LIBRARY_PROMPTS: ChatPrompt[] = [
+  {
+    label: "Outstanding actions",
+    description: "Still open across recent meetings",
+    prompt: "What action items are still open across my recent meetings?",
+  },
+  {
+    label: "Weekly recap",
+    description: "This week across your meetings",
+    prompt: "Recap this week across my meetings.",
+  },
+  {
+    label: "Client status",
+    description: "Latest per client you've met",
+    prompt: "What's the latest for each client I've met recently?",
+  },
+  {
+    label: "Decisions log",
+    description: "What was decided, and where",
+    prompt: "What decisions were made recently, and where?",
+  },
+];
+
+/** The prompt set a pane offers: note-scoped for a Note's Chat tab, library-wide
+ *  for `/chat`. One switch on the target, so neither call site can pick the set
+ *  that doesn't match what it can actually answer. */
+export function promptsFor(target: ChatTarget): ChatPrompt[] {
+  return target.kind === "global" ? LIBRARY_PROMPTS : NOTE_PROMPTS;
+}
 
 /**
  * Whether typing this key in the composer should open the prompt picker.

--- a/src/lib/chatPrompts.ts
+++ b/src/lib/chatPrompts.ts
@@ -60,9 +60,17 @@ export const NOTE_PROMPTS: ChatPrompt[] = [
 // other three, which are one-click.
 export const LIBRARY_PROMPTS: ChatPrompt[] = [
   {
-    label: "Outstanding actions",
-    description: "Still open across recent meetings",
-    prompt: "What action items are still open across my recent meetings?",
+    // Deliberately "what needs attention" rather than "list the open actions".
+    // An enumerating prompt gets an enumeration back — every item, evenly
+    // weighted; asking what needs attention makes the model filter, which is the
+    // only useful behaviour once a library has months in it. The citation clause
+    // rides on the prompt rather than the system message on purpose: terse system
+    // prompts beat constraint-heavy ones on the small local models, which turn a
+    // list of rules into a checklist they re-litigate while thinking.
+    label: "Needs my attention",
+    description: "Unresolved, blocked, or waiting on you",
+    prompt:
+      "Review my meetings from the last 30 days and tell me what needs my attention now — not everything that happened. Focus on unresolved commitments, blocked work, decisions waiting for me, deadlines, contradictions, and issues that keep coming back. Cite the meeting for each item.",
   },
   {
     label: "Weekly recap",

--- a/src/lib/chatSessions.test.ts
+++ b/src/lib/chatSessions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   relativeTime,
   conversationTitle,
+  conversationRows,
   usageTone,
   liveChatErrorCopy,
   groundingLikelyTruncated,
@@ -170,3 +171,44 @@ describe("groundingLikelyTruncated", () => {
   });
 });
 
+
+describe("conversationRows", () => {
+  const rows = (
+    convos: { id: string; title: string; updatedAt: number }[],
+    activeId: string | null = null,
+  ) => conversationRows(convos, activeId, NOW);
+
+  it("orders most-recent first regardless of the order given", () => {
+    const out = rows([
+      { id: "a", title: "Oldest", updatedAt: NOW - 5 * 86_400_000 },
+      { id: "b", title: "Newest", updatedAt: NOW - 60_000 },
+      { id: "c", title: "Middle", updatedAt: NOW - 3 * 3_600_000 },
+    ]);
+    expect(out.map((r) => r.id)).toEqual(["b", "c", "a"]);
+    expect(out.map((r) => r.description)).toEqual(["1m ago", "3h ago", "5d ago"]);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const input = [
+      { id: "a", title: "A", updatedAt: 1 },
+      { id: "b", title: "B", updatedAt: 2 },
+    ];
+    rows(input);
+    expect(input.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("falls back to a label for an untitled conversation", () => {
+    expect(rows([{ id: "a", title: "   ", updatedAt: NOW }])[0].label).toBe("New chat");
+  });
+
+  it("marks exactly the active row, and none when there is no active id", () => {
+    const convos = [
+      { id: "a", title: "A", updatedAt: 2 },
+      { id: "b", title: "B", updatedAt: 1 },
+    ];
+    expect(rows(convos, "b").map((r) => r.active)).toEqual([false, true]);
+    expect(rows(convos, null).every((r) => !r.active)).toBe(true);
+    // An id that isn't in the list marks nothing rather than defaulting to first.
+    expect(rows(convos, "gone").every((r) => !r.active)).toBe(true);
+  });
+});

--- a/src/lib/chatSessions.ts
+++ b/src/lib/chatSessions.ts
@@ -1,7 +1,8 @@
-// Display helpers for the chat history popover (issue #62). Kept pure and
-// framework-free so they unit-test without rendering. `relativeTime` is generic
-// enough to hoist to a shared module if a second caller ever appears; for now
-// the chat history list is its only consumer.
+// Display helpers for the chat conversation lists (issue #62, extended for
+// `/chat`'s Recents in #95). Kept pure and framework-free so they unit-test
+// without rendering — the only import is a type, so nothing runtime comes with it.
+
+import type { ConversationMeta } from "./ipc";
 
 
 // A short, human relative timestamp: "just now" / "5m ago" / "3h ago" /
@@ -41,6 +42,11 @@ export function conversationTitle(meta: { title: string }): string {
   return meta.title.trim() || "New chat";
 }
 
+/** The conversation fields a row is built from — named once rather than spelled
+ *  out structurally at every call site. A `Pick` of the real DTO so a field
+ *  rename on the backend contract surfaces here rather than silently diverging. */
+export type ConversationFields = Pick<ConversationMeta, "id" | "title" | "updatedAt">;
+
 /** One row of a conversation list, ready to render. */
 export type ConversationRow = {
   id: string;
@@ -64,7 +70,7 @@ export type ConversationRow = {
  * own `activeId` and simply ignores the extra field.
  */
 export function conversationRows(
-  conversations: { id: string; title: string; updatedAt: number }[],
+  conversations: ConversationFields[],
   activeId: string | null,
   now: number = Date.now(),
 ): ConversationRow[] {

--- a/src/lib/chatSessions.ts
+++ b/src/lib/chatSessions.ts
@@ -41,6 +41,43 @@ export function conversationTitle(meta: { title: string }): string {
   return meta.title.trim() || "New chat";
 }
 
+/** One row of a conversation list, ready to render. */
+export type ConversationRow = {
+  id: string;
+  label: string;
+  description: string;
+  active: boolean;
+};
+
+/**
+ * The rows for a conversation list, most-recent first (issue #95).
+ *
+ * Two surfaces show the same list — the Note header's history popover and
+ * `/chat`'s Recents — and there is no row *component* to share between them
+ * (the popover renders a `{id, label, description}` projection through
+ * `SelectablePopover`; Recents renders its own markup). So the shared thing is
+ * this projection: one place that decides ordering, the empty-title fallback and
+ * the relative date, rather than two lists that drift apart.
+ *
+ * `now` is injectable for deterministic tests, and `active` rides along for
+ * callers that mark the current row themselves — `SelectablePopover` takes its
+ * own `activeId` and simply ignores the extra field.
+ */
+export function conversationRows(
+  conversations: { id: string; title: string; updatedAt: number }[],
+  activeId: string | null,
+  now: number = Date.now(),
+): ConversationRow[] {
+  return [...conversations]
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .map((c) => ({
+      id: c.id,
+      label: conversationTitle(c),
+      description: relativeTime(c.updatedAt, now),
+      active: c.id === activeId,
+    }));
+}
+
 // Mirror of the backend's `GROUNDING_CHAR_BUDGET` (`chat/mod.rs`). Kept in sync
 // by hand — it only drives an advisory hint, so a drift makes the warning
 // slightly early or late, never wrong in a way that loses data.

--- a/src/lib/globalChat.ts
+++ b/src/lib/globalChat.ts
@@ -1,0 +1,24 @@
+// Where the `/chat` pane publishes its session projection so the SIDEBAR can
+// render the conversation list (issue #95).
+//
+// The list belongs in the left nav — it is navigation, not context about the
+// thing on screen — but the nav is a sibling of the routed page under `Layout`,
+// so the two cannot be wired together with props.
+//
+// Deliberately just a mailbox: no fetching, no derived state, no second copy of
+// anything. `ChatPanel` stays the sole owner of the conversations, the active id
+// and the paging; this holds the last projection it published, and the page
+// clears it on unmount so a stale list can't outlive the pane that owned it.
+
+import { create } from "zustand";
+import type { ChatSessionControls } from "../components/ChatPanel";
+
+type GlobalChatState = {
+  controls: ChatSessionControls | null;
+  setControls: (controls: ChatSessionControls | null) => void;
+};
+
+export const useGlobalChatStore = create<GlobalChatState>((set) => ({
+  controls: null,
+  setControls: (controls) => set({ controls }),
+}));

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -416,8 +416,16 @@ export const ipc = {
   // List / create chat sessions for a target (issue #61). Personal reads local
   // SQLite; a workspace reads/creates server-authoritative sessions. There is no
   // delete command — a deliberate v1 decision.
-  chatListConversations: (noteId: string | null) =>
-    invoke<ConversationMeta[]>("chat_list_conversations", { noteId }),
+  // `limit`/`offset` window the list, most-recent first (issue #95): `/chat`
+  // lists conversations uncapped, so it pages them in as the sidebar scrolls.
+  // Omitting `limit` returns everything, which is what the Note header's history
+  // popover has always done.
+  chatListConversations: (noteId: string | null, page?: { limit: number; offset: number }) =>
+    invoke<ConversationMeta[]>("chat_list_conversations", {
+      noteId,
+      limit: page?.limit ?? null,
+      offset: page?.offset ?? null,
+    }),
   chatNewConversation: (noteId: string | null) =>
     invoke<ConversationMeta>("chat_new_conversation", { noteId }),
   // Persist / read the Scope chip's breadth on a conversation (issue #58/#61).

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -6,6 +6,13 @@ type NotesState = {
   notes: Note[];
   folders: Folder[];
   clients: Client[];
+  /** Whether `refresh` has completed at least once (issue #95).
+   *
+   *  Without this, `notes.length === 0` means either "the library is empty" or
+   *  "the first load hasn't landed yet", and a caller that acts on emptiness —
+   *  `/chat` disables its composer and says there's nothing to ask about — would
+   *  make that claim for a frame on every launch. */
+  loaded: boolean;
   refresh: () => Promise<void>;
   refreshFolders: () => Promise<void>;
   refreshClients: () => Promise<void>;
@@ -24,13 +31,14 @@ export const useNotesStore = create<NotesState>((set) => ({
   notes: [],
   folders: [],
   clients: [],
+  loaded: false,
   refresh: async () => {
     const [notes, folders, clients] = await Promise.all([
       ipc.listNotes(),
       ipc.listFolders(),
       ipc.listClients(),
     ]);
-    set({ notes, folders, clients });
+    set({ notes, folders, clients, loaded: true });
   },
   refreshFolders: async () => {
     const folders = await ipc.listFolders();

--- a/src/pages/Chat.test.tsx
+++ b/src/pages/Chat.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Chat from "./Chat";
+import { mockTauri } from "../test/tauri";
+import { useCloudStore, DISCONNECTED } from "../lib/cloud";
+import { useNotesStore } from "../lib/store";
+import type { ConversationMeta, Note } from "../lib/ipc";
+
+// The `/chat` surface (issue #95). These tests are about what this page owns —
+// the Recents rail, the library prompt set, and the empty-library state. The
+// panel's own behaviour (streaming, citations, activation, a11y) is covered by
+// ChatPanel.test.tsx and arrives here unchanged by construction (#94).
+
+const HOUR = 3_600_000;
+
+function conversation(over: Partial<ConversationMeta> & { id: string }): ConversationMeta {
+  return { title: "Untitled", breadth: "all", updatedAt: 1, messageCount: 2, ...over };
+}
+
+function seedNotes(count: number) {
+  const notes = Array.from({ length: count }, (_, i) => ({ id: `n${i}` }) as unknown as Note);
+  useNotesStore.setState({ notes, loaded: true });
+}
+
+function renderChat() {
+  return render(
+    <MemoryRouter>
+      <Chat />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockTauri();
+  useCloudStore.setState({ status: DISCONNECTED });
+  // Default: a library with notes, already loaded — the ordinary case.
+  seedNotes(3);
+});
+
+describe("/chat page", () => {
+  it("opens on the composer, with the library-wide target", async () => {
+    const asked: unknown[] = [];
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      chat_list_conversations: (args) => {
+        asked.push(args);
+        return [];
+      },
+    });
+    renderChat();
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/Ask about your notes/)).toBeInTheDocument(),
+    );
+    // No greeting and no display heading — just the page title (#95).
+    expect(screen.getByRole("heading", { name: "Chat" })).toBeInTheDocument();
+    // An ABSENT note id is what the backend reads as the global scope; an empty
+    // string is rejected (#93), so this assertion is the wire contract.
+    expect(asked).toContainEqual({ noteId: null });
+  });
+
+  it("lists recent conversations most-recent first and marks the active one", async () => {
+    const now = Date.now();
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: "c-mid", messages: [] }),
+      chat_list_conversations: () => [
+        conversation({ id: "c-old", title: "Budget questions", updatedAt: now - 50 * HOUR }),
+        conversation({ id: "c-new", title: "This week", updatedAt: now - 1 * HOUR }),
+        conversation({ id: "c-mid", title: "Client status", updatedAt: now - 5 * HOUR }),
+      ],
+    });
+    renderChat();
+
+    const rows = await waitFor(() => {
+      const found = screen.getAllByRole("listitem");
+      expect(found.length).toBe(3);
+      return found;
+    });
+    expect(rows.map((r) => r.textContent)).toEqual([
+      "This week1h ago",
+      "Client status5h ago",
+      "Budget questions2d ago",
+    ]);
+    // The loaded conversation is marked, and only it.
+    const current = screen.getAllByRole("button", { current: true });
+    expect(current).toHaveLength(1);
+    expect(current[0].textContent).toContain("Client status");
+  });
+
+  it("caps Recents at ten rows", async () => {
+    const now = Date.now();
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      chat_list_conversations: () =>
+        Array.from({ length: 14 }, (_, i) =>
+          conversation({ id: `c${i}`, title: `Chat ${i}`, updatedAt: now - i * HOUR }),
+        ),
+    });
+    renderChat();
+
+    await waitFor(() => expect(screen.getAllByRole("listitem")).toHaveLength(10));
+    // The ten kept are the most recent ten, not the first ten returned.
+    expect(screen.getByText("Chat 0")).toBeInTheDocument();
+    expect(screen.queryByText("Chat 13")).toBeNull();
+  });
+
+  it("says so when there is no history to browse", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      // A lone untouched conversation isn't history worth listing (#62).
+      chat_list_conversations: () => [conversation({ id: "c1", title: "", messageCount: 0 })],
+    });
+    renderChat();
+
+    await waitFor(() => expect(screen.getByText("No conversations yet")).toBeInTheDocument());
+    expect(screen.queryByRole("listitem")).toBeNull();
+  });
+
+  it("loads the conversation whose row is clicked", async () => {
+    const requested: unknown[] = [];
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: (args) => {
+        requested.push(args);
+        return { conversationId: null, messages: [] };
+      },
+      chat_list_conversations: () => [
+        conversation({ id: "c-a", title: "Alpha", updatedAt: 2 }),
+        conversation({ id: "c-b", title: "Beta", updatedAt: 1 }),
+      ],
+    });
+    renderChat();
+
+    fireEvent.click(await screen.findByText("Beta"));
+    await waitFor(() =>
+      expect(requested).toContainEqual({ noteId: null, conversationId: "c-b" }),
+    );
+  });
+
+  it("offers the library prompt set, not the note-scoped one", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+    });
+    renderChat();
+
+    const input = await screen.findByPlaceholderText(/Ask about your notes/);
+    fireEvent.keyDown(input, { key: "/" });
+
+    expect(await screen.findByText("Outstanding actions")).toBeInTheDocument();
+    expect(screen.getByText("Client status")).toBeInTheDocument();
+    // "What I missed" only makes sense with a note on screen to have missed.
+    expect(screen.queryByText("What I missed")).toBeNull();
+  });
+});
+
+describe("/chat with an empty library", () => {
+  it("disables the composer and says there is nothing to search", async () => {
+    useNotesStore.setState({ notes: [], loaded: true });
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+    });
+    renderChat();
+
+    const input = await screen.findByLabelText("Ask about your notes");
+    expect(input).toBeDisabled();
+    expect(screen.getByPlaceholderText("Nothing to search yet")).toBeInTheDocument();
+    // The standing invitation is replaced, not merely supplemented — it would
+    // otherwise invite a question whose only answer is "I couldn't find anything".
+    expect(screen.getByText(/No notes yet\./)).toBeInTheDocument();
+    expect(screen.queryByText(/Ask anything about your notes/)).toBeNull();
+  });
+
+  it("keeps the composer enabled while the first load is still in flight", async () => {
+    // notes: [] with loaded: false is "we don't know yet", not "empty" — claiming
+    // an empty library here would fire on every launch for one frame.
+    useNotesStore.setState({ notes: [], loaded: false });
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+    });
+    renderChat();
+
+    const input = await screen.findByPlaceholderText(/Ask about your notes/);
+    expect(input).not.toBeDisabled();
+  });
+});

--- a/src/pages/Chat.test.tsx
+++ b/src/pages/Chat.test.tsx
@@ -70,8 +70,10 @@ describe("/chat page", () => {
     await waitFor(() =>
       expect(screen.getByPlaceholderText(/Ask about your notes/)).toBeInTheDocument(),
     );
-    // No greeting and no display heading — just the page title (#95).
-    expect(screen.getByRole("heading", { name: "Chat" })).toBeInTheDocument();
+    // No greeting and no page heading at all: the title lives in the app bar,
+    // and a second "Chat" beneath it would be the same word twice (#95).
+    expect(screen.queryByRole("heading")).toBeNull();
+    expect(screen.getByTitle("Chat")).toBeInTheDocument();
     // An ABSENT note id is what the backend reads as the global scope; an empty
     // string is rejected (#93), so this assertion is the wire contract. The window
     // is the first page — the list is uncapped and pages in as it scrolls.
@@ -187,8 +189,7 @@ describe("/chat header", () => {
     expect(screen.queryByText(/visible to members/)).toBeNull();
   });
 
-  it("says Personal and Private outside a workspace, with the library size", async () => {
-    seedNotes(17);
+  it("says Personal and Private outside a workspace", async () => {
     mockTauri({
       provider_key_get: () => "sk-test",
       chat_history: () => ({ conversationId: null, messages: [] }),
@@ -197,7 +198,22 @@ describe("/chat header", () => {
 
     expect(await screen.findByText("Personal")).toBeInTheDocument();
     expect(screen.getByText("Private")).toBeInTheDocument();
-    expect(screen.getByText("17 notes")).toBeInTheDocument();
+  });
+
+  it("names the open conversation, and falls back to \"Chat\" for a fresh one", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: "c1", messages: [] }),
+      chat_list_conversations: () => [
+        { id: "c1", title: "Budget questions", breadth: "all", updatedAt: 2, messageCount: 4 },
+        // Untitled until the backend derives one from the first turn.
+        { id: "c2", title: "", breadth: "all", updatedAt: 1, messageCount: 0 },
+      ],
+    });
+    renderChat();
+
+    expect(await screen.findByTitle("Budget questions")).toBeInTheDocument();
+    expect(screen.queryByTitle("Chat")).toBeNull();
   });
 
   it("names the answering model in the header, not the composer row", async () => {
@@ -219,11 +235,10 @@ describe("/chat header", () => {
     expect(screen.queryByTestId("chat-model-indicator")).toBeNull();
   });
 
-  it("claims no library size or model in a workspace", async () => {
-    // Retrieval is server-side there: the local mirror can lag, and the local
-    // chat_model isn't what answers (#80). Both would be claims we can't make.
+  it("claims no model in a workspace", async () => {
+    // The turn runs on the server's model there, so naming the local chat_model
+    // would name something that isn't answering (#80).
     signIntoWorkspace();
-    seedNotes(17);
     mockTauri({
       chat_history: () => ({ conversationId: null, messages: [] }),
       settings_get: (args) => {
@@ -236,34 +251,46 @@ describe("/chat header", () => {
     renderChat();
 
     await screen.findByText("Acme Team");
-    expect(screen.queryByText("17 notes")).toBeNull();
     expect(screen.queryByText("gpt-5.1")).toBeNull();
   });
 });
 
 describe("/chat session chrome placement", () => {
-  // Exactly one home at a time: the sidebar owns the list and the "+" while it's
-  // open; collapsed, it takes them with it, so the popover fallback appears in the
-  // page header instead. Two "new chat" buttons on one screen is a puzzle.
-  it("stays out of the page header while the sidebar is open", async () => {
+  // Actions live in the app bar, as they do in the Note view, so "new chat" has
+  // one home whatever the sidebar is doing. History is the exception: the sidebar
+  // list IS the history while it's open, and the popover beside it would be the
+  // same thing twice.
+  it("keeps new chat in the bar whether or not the sidebar is open", async () => {
     mockTauri({
       provider_key_get: () => "sk-test",
       chat_history: () => ({ conversationId: null, messages: [] }),
+      chat_list_conversations: () => [
+        { id: "c1", title: "Earlier", breadth: "all", updatedAt: 2, messageCount: 4 },
+        { id: "c2", title: "Later", breadth: "all", updatedAt: 3, messageCount: 2 },
+      ],
     });
     renderChat(false);
 
-    await screen.findByPlaceholderText(/Ask about your notes/);
-    expect(screen.queryByLabelText("New chat")).toBeNull();
+    expect(await screen.findByLabelText("New chat")).toBeInTheDocument();
+    // Two conversations, so history WOULD be offerable — it's the visible sidebar
+    // list that suppresses the popover, not a lack of history.
+    expect(screen.queryByTitle("Chat history")).toBeNull();
   });
 
-  it("appears in the page header once the sidebar is collapsed", async () => {
+  it("adds the history popover once the sidebar is collapsed", async () => {
     mockTauri({
       provider_key_get: () => "sk-test",
       chat_history: () => ({ conversationId: null, messages: [] }),
+      chat_list_conversations: () => [
+        { id: "c1", title: "Earlier", breadth: "all", updatedAt: 2, messageCount: 4 },
+        { id: "c2", title: "Later", breadth: "all", updatedAt: 3, messageCount: 2 },
+      ],
     });
     renderChat(true);
 
     expect(await screen.findByLabelText("New chat")).toBeInTheDocument();
+    // Collapsed, the popover is the only way back to a past thread.
+    expect(await screen.findByTitle("Chat history")).toBeInTheDocument();
   });
 });
 

--- a/src/pages/Chat.test.tsx
+++ b/src/pages/Chat.test.tsx
@@ -173,6 +173,74 @@ describe("/chat page", () => {
   });
 });
 
+describe("/chat header", () => {
+  it("states the tenant and who can read it, as separate pills", async () => {
+    signIntoWorkspace();
+    mockTauri({ chat_history: () => ({ conversationId: null, messages: [] }) });
+    renderChat();
+
+    // The visibility claim is the highest-stakes fact on the screen, so it's its
+    // own pill rather than a clause in a sentence.
+    expect(await screen.findByText("Acme Team")).toBeInTheDocument();
+    expect(screen.getByText("All members")).toBeInTheDocument();
+    // The old single-line phrasing is gone.
+    expect(screen.queryByText(/visible to members/)).toBeNull();
+  });
+
+  it("says Personal and Private outside a workspace, with the library size", async () => {
+    seedNotes(17);
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+    });
+    renderChat();
+
+    expect(await screen.findByText("Personal")).toBeInTheDocument();
+    expect(screen.getByText("Private")).toBeInTheDocument();
+    expect(screen.getByText("17 notes")).toBeInTheDocument();
+  });
+
+  it("names the answering model in the header, not the composer row", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      settings_get: (args) => {
+        const key = (args as { key?: string }).key;
+        if (key === "chat_model") return "gpt-5.1";
+        if (key === "onboarding_completed") return "true";
+        return null;
+      },
+    });
+    renderChat();
+
+    expect(await screen.findByText("gpt-5.1")).toBeInTheDocument();
+    // #80 put this chip in the composer row; on the page it moved to the header,
+    // and showing the same fact twice would just be clutter.
+    expect(screen.queryByTestId("chat-model-indicator")).toBeNull();
+  });
+
+  it("claims no library size or model in a workspace", async () => {
+    // Retrieval is server-side there: the local mirror can lag, and the local
+    // chat_model isn't what answers (#80). Both would be claims we can't make.
+    signIntoWorkspace();
+    seedNotes(17);
+    mockTauri({
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      settings_get: (args) => {
+        const key = (args as { key?: string }).key;
+        if (key === "chat_model") return "gpt-5.1";
+        if (key === "onboarding_completed") return "true";
+        return null;
+      },
+    });
+    renderChat();
+
+    await screen.findByText("Acme Team");
+    expect(screen.queryByText("17 notes")).toBeNull();
+    expect(screen.queryByText("gpt-5.1")).toBeNull();
+  });
+});
+
 describe("/chat session chrome placement", () => {
   // Exactly one home at a time: the sidebar owns the list and the "+" while it's
   // open; collapsed, it takes them with it, so the popover fallback appears in the

--- a/src/pages/Chat.test.tsx
+++ b/src/pages/Chat.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import Chat from "./Chat";
+import { Chat } from "./Chat";
 import { mockTauri } from "../test/tauri";
-import { useCloudStore, DISCONNECTED } from "../lib/cloud";
+import { useCloudStore, DISCONNECTED, type CloudRole } from "../lib/cloud";
 import { useNotesStore } from "../lib/store";
 import type { ConversationMeta, Note } from "../lib/ipc";
 
@@ -31,9 +31,23 @@ function renderChat() {
   );
 }
 
+function signIntoWorkspace(role: CloudRole = "owner") {
+  const ws = { id: "ws1", name: "Acme Team", role, plan_status: "active" as const };
+  useCloudStore.setState({
+    status: {
+      ...DISCONNECTED,
+      configured: true,
+      logged_in: true,
+      base_url: "https://sync.humla.team",
+      current_workspace: ws,
+      workspaces: [ws],
+    },
+  });
+}
+
 beforeEach(() => {
   mockTauri();
-  useCloudStore.setState({ status: DISCONNECTED });
+  useCloudStore.setState({ status: DISCONNECTED, syncStatus: null });
   // Default: a library with notes, already loaded — the ordinary case.
   seedNotes(3);
 });
@@ -159,8 +173,8 @@ describe("/chat page", () => {
   });
 });
 
-describe("/chat with an empty library", () => {
-  it("disables the composer and says there is nothing to search", async () => {
+describe("/chat with nothing to retrieve", () => {
+  it("holds the composer and says there is nothing to search", async () => {
     useNotesStore.setState({ notes: [], loaded: true });
     mockTauri({
       provider_key_get: () => "sk-test",
@@ -169,7 +183,11 @@ describe("/chat with an empty library", () => {
     renderChat();
 
     const input = await screen.findByLabelText("Ask about your notes");
-    expect(input).toBeDisabled();
+    // readOnly, not disabled: `disabled` drops the control out of the tab order,
+    // so a keyboard or screen-reader user would never reach the placeholder that
+    // explains why they can't type.
+    expect(input).toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("aria-disabled", "true");
     expect(screen.getByPlaceholderText("Nothing to search yet")).toBeInTheDocument();
     // The standing invitation is replaced, not merely supplemented — it would
     // otherwise invite a question whose only answer is "I couldn't find anything".
@@ -177,7 +195,32 @@ describe("/chat with an empty library", () => {
     expect(screen.queryByText(/Ask anything about your notes/)).toBeNull();
   });
 
-  it("keeps the composer enabled while the first load is still in flight", async () => {
+  it("holds it in a workspace too, where a wasted turn is metered", async () => {
+    signIntoWorkspace();
+    useNotesStore.setState({ notes: [], loaded: true });
+    mockTauri({ chat_history: () => ({ conversationId: null, messages: [] }) });
+    renderChat();
+
+    const input = await screen.findByLabelText("Ask about your notes");
+    expect(input).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("says notes are still arriving, not that there are none, mid-sync", async () => {
+    // An empty local mirror during a workspace pull is not evidence of an empty
+    // workspace — claiming "No notes yet" there would be a false statement about
+    // someone's library.
+    signIntoWorkspace();
+    useNotesStore.setState({ notes: [], loaded: true });
+    useCloudStore.setState({ syncStatus: "syncing" });
+    mockTauri({ chat_history: () => ({ conversationId: null, messages: [] }) });
+    renderChat();
+
+    expect(await screen.findByText(/Still syncing your notes/)).toBeInTheDocument();
+    expect(screen.queryByText(/No notes yet\./)).toBeNull();
+    expect(screen.getByLabelText("Ask about your notes")).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("leaves the composer open while the first load is still in flight", async () => {
     // notes: [] with loaded: false is "we don't know yet", not "empty" — claiming
     // an empty library here would fire on every launch for one frame.
     useNotesStore.setState({ notes: [], loaded: false });
@@ -188,6 +231,21 @@ describe("/chat with an empty library", () => {
     renderChat();
 
     const input = await screen.findByPlaceholderText(/Ask about your notes/);
-    expect(input).not.toBeDisabled();
+    expect(input).not.toHaveAttribute("readonly");
+    expect(input).not.toHaveAttribute("aria-disabled");
+  });
+});
+
+describe("/chat breadth chrome", () => {
+  it("shows no scope picker — its only option would be 'All notes'", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+    });
+    renderChat();
+
+    await screen.findByPlaceholderText(/Ask about your notes/);
+    expect(screen.queryByLabelText("Chat scope")).toBeNull();
+    expect(screen.queryByText("All notes")).toBeNull();
   });
 });

--- a/src/pages/Chat.test.tsx
+++ b/src/pages/Chat.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
 import { Chat } from "./Chat";
 import { mockTauri } from "../test/tauri";
@@ -105,7 +105,46 @@ describe("/chat page", () => {
     expect(useGlobalChatStore.getState().controls).toBeNull();
   });
 
-  it("offers the library prompt set, not the note-scoped one", async () => {
+  it("shows the library prompts as cards on a new chat", async () => {
+    // A blank page tells a first-time user nothing about what this can do, and on
+    // a library-wide surface the useful questions are the least guessable ones.
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+    });
+    renderChat();
+
+    await screen.findByPlaceholderText(/Ask about your notes/);
+    expect(await screen.findByRole("button", { name: /Outstanding actions/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Client status/ })).toBeInTheDocument();
+    // "What I missed" only makes sense with a note on screen to have missed.
+    expect(screen.queryByText("What I missed")).toBeNull();
+  });
+
+  it("fills the composer from a card rather than spending a turn", async () => {
+    // These are starting points. A card that sent immediately — a metered turn, in
+    // a workspace — would commit the user to a question they hadn't finished
+    // thinking about.
+    let sent = false;
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      chat_send: () => {
+        sent = true;
+        return { conversationId: "c1", truncated: false };
+      },
+    });
+    renderChat();
+
+    const input = await screen.findByPlaceholderText(/Ask about your notes/);
+    fireEvent.click(await screen.findByRole("button", { name: /Weekly recap/ }));
+
+    expect(input).toHaveValue("Recap this week across my meetings.");
+    expect(sent).toBe(false);
+  });
+
+  it("offers the same set from the '/' menu", async () => {
+    // One list, two surfaces — the cards are not a second set that could drift.
     mockTauri({
       provider_key_get: () => "sk-test",
       chat_history: () => ({ conversationId: null, messages: [] }),
@@ -115,10 +154,10 @@ describe("/chat page", () => {
     const input = await screen.findByPlaceholderText(/Ask about your notes/);
     fireEvent.keyDown(input, { key: "/" });
 
-    expect(await screen.findByText("Outstanding actions")).toBeInTheDocument();
-    expect(screen.getByText("Client status")).toBeInTheDocument();
-    // "What I missed" only makes sense with a note on screen to have missed.
-    expect(screen.queryByText("What I missed")).toBeNull();
+    const menu = await screen.findByRole("listbox", { name: "Prompts" });
+    for (const label of ["Outstanding actions", "Weekly recap", "Client status", "Decisions log"]) {
+      expect(within(menu).getByText(label)).toBeInTheDocument();
+    }
   });
 
   it("shows no scope picker — its only option would be 'All notes'", async () => {

--- a/src/pages/Chat.test.tsx
+++ b/src/pages/Chat.test.tsx
@@ -117,10 +117,22 @@ describe("/chat page", () => {
     renderChat();
 
     await screen.findByPlaceholderText(/Ask about your notes/);
-    expect(await screen.findByRole("button", { name: /Outstanding actions/ })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /Needs my attention/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Client status/ })).toBeInTheDocument();
     // "What I missed" only makes sense with a note on screen to have missed.
     expect(screen.queryByText("What I missed")).toBeNull();
+  });
+
+  it("says how to reach the prompts again once the cards are gone", async () => {
+    // The "/" menu shipped in #80 and was mentioned nowhere, so it was
+    // discoverable only by accident.
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+    });
+    renderChat();
+
+    expect(await screen.findByText(/in the composer for these any time/)).toBeInTheDocument();
   });
 
   it("fills the composer from a card rather than spending a turn", async () => {
@@ -157,7 +169,7 @@ describe("/chat page", () => {
     fireEvent.keyDown(input, { key: "/" });
 
     const menu = await screen.findByRole("listbox", { name: "Prompts" });
-    for (const label of ["Outstanding actions", "Weekly recap", "Client status", "Decisions log"]) {
+    for (const label of ["Needs my attention", "Weekly recap", "Client status", "Decisions log"]) {
       expect(within(menu).getByText(label)).toBeInTheDocument();
     }
   });

--- a/src/pages/Chat.test.tsx
+++ b/src/pages/Chat.test.tsx
@@ -1,34 +1,21 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
 import { Chat } from "./Chat";
 import { mockTauri } from "../test/tauri";
 import { useCloudStore, DISCONNECTED, type CloudRole } from "../lib/cloud";
 import { useNotesStore } from "../lib/store";
-import type { ConversationMeta, Note } from "../lib/ipc";
+import { useGlobalChatStore } from "../lib/globalChat";
+import type { Note } from "../lib/ipc";
 
-// The `/chat` surface (issue #95). These tests are about what this page owns —
-// the Recents rail, the library prompt set, and the empty-library state. The
-// panel's own behaviour (streaming, citations, activation, a11y) is covered by
-// ChatPanel.test.tsx and arrives here unchanged by construction (#94).
-
-const HOUR = 3_600_000;
-
-function conversation(over: Partial<ConversationMeta> & { id: string }): ConversationMeta {
-  return { title: "Untitled", breadth: "all", updatedAt: 1, messageCount: 2, ...over };
-}
+// The `/chat` page (issue #95). The page owns the shell, the library-wide target
+// and the collapsed-sidebar fallback; the conversation list it publishes is
+// rendered by the sidebar and tested in ChatConversations.test.tsx. Panel
+// behaviour (streaming, citations, activation, a11y) is ChatPanel.test.tsx's.
 
 function seedNotes(count: number) {
   const notes = Array.from({ length: count }, (_, i) => ({ id: `n${i}` }) as unknown as Note);
   useNotesStore.setState({ notes, loaded: true });
-}
-
-function renderChat() {
-  return render(
-    <MemoryRouter>
-      <Chat />
-    </MemoryRouter>,
-  );
 }
 
 function signIntoWorkspace(role: CloudRole = "owner") {
@@ -45,9 +32,24 @@ function signIntoWorkspace(role: CloudRole = "owner") {
   });
 }
 
+// `Chat` reads `sidebarCollapsed` from the Layout's outlet context, so it has to
+// be rendered under a layout route rather than bare.
+function renderChat(sidebarCollapsed = false) {
+  return render(
+    <MemoryRouter initialEntries={["/chat"]}>
+      <Routes>
+        <Route path="/" element={<Outlet context={{ sidebarCollapsed }} />}>
+          <Route path="chat" element={<Chat />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
 beforeEach(() => {
   mockTauri();
   useCloudStore.setState({ status: DISCONNECTED, syncStatus: null });
+  useGlobalChatStore.setState({ controls: null });
   // Default: a library with notes, already loaded — the ordinary case.
   seedNotes(3);
 });
@@ -71,89 +73,36 @@ describe("/chat page", () => {
     // No greeting and no display heading — just the page title (#95).
     expect(screen.getByRole("heading", { name: "Chat" })).toBeInTheDocument();
     // An ABSENT note id is what the backend reads as the global scope; an empty
-    // string is rejected (#93), so this assertion is the wire contract.
-    expect(asked).toContainEqual({ noteId: null });
+    // string is rejected (#93), so this assertion is the wire contract. The window
+    // is the first page — the list is uncapped and pages in as it scrolls.
+    expect(asked[0]).toMatchObject({ noteId: null, offset: 0 });
+    expect((asked[0] as { limit: number }).limit).toBeGreaterThan(0);
   });
 
-  it("lists recent conversations most-recent first and marks the active one", async () => {
-    const now = Date.now();
-    mockTauri({
-      provider_key_get: () => "sk-test",
-      chat_history: () => ({ conversationId: "c-mid", messages: [] }),
-      chat_list_conversations: () => [
-        conversation({ id: "c-old", title: "Budget questions", updatedAt: now - 50 * HOUR }),
-        conversation({ id: "c-new", title: "This week", updatedAt: now - 1 * HOUR }),
-        conversation({ id: "c-mid", title: "Client status", updatedAt: now - 5 * HOUR }),
-      ],
-    });
-    renderChat();
-
-    const rows = await waitFor(() => {
-      const found = screen.getAllByRole("listitem");
-      expect(found.length).toBe(3);
-      return found;
-    });
-    expect(rows.map((r) => r.textContent)).toEqual([
-      "This week1h ago",
-      "Client status5h ago",
-      "Budget questions2d ago",
-    ]);
-    // The loaded conversation is marked, and only it.
-    const current = screen.getAllByRole("button", { current: true });
-    expect(current).toHaveLength(1);
-    expect(current[0].textContent).toContain("Client status");
-  });
-
-  it("caps Recents at ten rows", async () => {
-    const now = Date.now();
+  it("publishes its session projection for the sidebar to render", async () => {
     mockTauri({
       provider_key_get: () => "sk-test",
       chat_history: () => ({ conversationId: null, messages: [] }),
-      chat_list_conversations: () =>
-        Array.from({ length: 14 }, (_, i) =>
-          conversation({ id: `c${i}`, title: `Chat ${i}`, updatedAt: now - i * HOUR }),
-        ),
+      chat_list_conversations: () => [],
     });
     renderChat();
 
-    await waitFor(() => expect(screen.getAllByRole("listitem")).toHaveLength(10));
-    // The ten kept are the most recent ten, not the first ten returned.
-    expect(screen.getByText("Chat 0")).toBeInTheDocument();
-    expect(screen.queryByText("Chat 13")).toBeNull();
+    // The list lives in the sidebar, which is not in this tree — the page's job is
+    // to get the projection into the store.
+    await waitFor(() => expect(useGlobalChatStore.getState().controls).not.toBeNull());
+    expect(useGlobalChatStore.getState().controls?.targetKey).toBe("global");
   });
 
-  it("says so when there is no history to browse", async () => {
+  it("clears the projection on unmount, so the sidebar can't outlive the pane", async () => {
     mockTauri({
       provider_key_get: () => "sk-test",
       chat_history: () => ({ conversationId: null, messages: [] }),
-      // A lone untouched conversation isn't history worth listing (#62).
-      chat_list_conversations: () => [conversation({ id: "c1", title: "", messageCount: 0 })],
     });
-    renderChat();
+    const { unmount } = renderChat();
+    await waitFor(() => expect(useGlobalChatStore.getState().controls).not.toBeNull());
 
-    await waitFor(() => expect(screen.getByText("No conversations yet")).toBeInTheDocument());
-    expect(screen.queryByRole("listitem")).toBeNull();
-  });
-
-  it("loads the conversation whose row is clicked", async () => {
-    const requested: unknown[] = [];
-    mockTauri({
-      provider_key_get: () => "sk-test",
-      chat_history: (args) => {
-        requested.push(args);
-        return { conversationId: null, messages: [] };
-      },
-      chat_list_conversations: () => [
-        conversation({ id: "c-a", title: "Alpha", updatedAt: 2 }),
-        conversation({ id: "c-b", title: "Beta", updatedAt: 1 }),
-      ],
-    });
-    renderChat();
-
-    fireEvent.click(await screen.findByText("Beta"));
-    await waitFor(() =>
-      expect(requested).toContainEqual({ noteId: null, conversationId: "c-b" }),
-    );
+    unmount();
+    expect(useGlobalChatStore.getState().controls).toBeNull();
   });
 
   it("offers the library prompt set, not the note-scoped one", async () => {
@@ -170,6 +119,44 @@ describe("/chat page", () => {
     expect(screen.getByText("Client status")).toBeInTheDocument();
     // "What I missed" only makes sense with a note on screen to have missed.
     expect(screen.queryByText("What I missed")).toBeNull();
+  });
+
+  it("shows no scope picker — its only option would be 'All notes'", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+    });
+    renderChat();
+
+    await screen.findByPlaceholderText(/Ask about your notes/);
+    expect(screen.queryByLabelText("Chat scope")).toBeNull();
+    expect(screen.queryByText("All notes")).toBeNull();
+  });
+});
+
+describe("/chat session chrome placement", () => {
+  // Exactly one home at a time: the sidebar owns the list and the "+" while it's
+  // open; collapsed, it takes them with it, so the popover fallback appears in the
+  // page header instead. Two "new chat" buttons on one screen is a puzzle.
+  it("stays out of the page header while the sidebar is open", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+    });
+    renderChat(false);
+
+    await screen.findByPlaceholderText(/Ask about your notes/);
+    expect(screen.queryByLabelText("New chat")).toBeNull();
+  });
+
+  it("appears in the page header once the sidebar is collapsed", async () => {
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+    });
+    renderChat(true);
+
+    expect(await screen.findByLabelText("New chat")).toBeInTheDocument();
   });
 });
 
@@ -233,19 +220,5 @@ describe("/chat with nothing to retrieve", () => {
     const input = await screen.findByPlaceholderText(/Ask about your notes/);
     expect(input).not.toHaveAttribute("readonly");
     expect(input).not.toHaveAttribute("aria-disabled");
-  });
-});
-
-describe("/chat breadth chrome", () => {
-  it("shows no scope picker — its only option would be 'All notes'", async () => {
-    mockTauri({
-      provider_key_get: () => "sk-test",
-      chat_history: () => ({ conversationId: null, messages: [] }),
-    });
-    renderChat();
-
-    await screen.findByPlaceholderText(/Ask about your notes/);
-    expect(screen.queryByLabelText("Chat scope")).toBeNull();
-    expect(screen.queryByText("All notes")).toBeNull();
   });
 });

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,122 +1,68 @@
 // The `/chat` route (issue #95): chat's front door.
 //
 // Until now `ChatPanel` was mounted in exactly one place — the Chat tab of the
-// Note right panel — so asking about your whole library meant opening some
+// Note right panel — so asking about your whole library meant opening an
 // arbitrary note first and widening the breadth. This is the destination that
 // makes a library-wide question a first-class thing to do.
 //
 // Everything substantive is borrowed: the panel arrives here parameterised by a
 // chat target (#94), so activation, prompts, citations, truncation, streaming and
 // a11y come for free, and the retrieval it drives is the same server- or
-// local-side engine (#93). What this file owns is the page shell and the Recents
-// rail.
+// local-side engine (#93). What this file owns is the page shell — the
+// conversation list lives in the SIDEBAR (`ChatConversations`), because a list you
+// navigate between belongs in the nav column, not in the right-hand slot this app
+// uses for context about the thing on screen.
 //
 // Deliberately absent: a greeting (we have no local user name — one exists only
 // via `CloudUser.name` when signed into cloud, so it would be blank for the
 // local-only majority) and a scope picker (its only option would be "All notes";
 // narrowing stays a tool argument the model chooses, per #81).
 
-import { useState } from "react";
-import { Plus } from "lucide-react";
-import { ChatPanel, type ChatSessionControls } from "../components/ChatPanel";
-import { conversationRows } from "../lib/chatSessions";
+import { useEffect } from "react";
+import { useOutletContext } from "react-router-dom";
+import { ChatPanel } from "../components/ChatPanel";
+import { ChatHistoryControls } from "../components/ChatHistoryControls";
+import type { LayoutOutletContext } from "../components/Layout";
+import { useGlobalChatStore } from "../lib/globalChat";
 import type { ChatTarget } from "../lib/chatTarget";
-import { cn } from "../lib/cn";
 
 // Module-level so the identity is stable across renders — the panel keys its
 // load effect off the target's note id, but a stable object costs nothing and
 // keeps the prop honest.
 const GLOBAL_TARGET: ChatTarget = { kind: "global" };
 
-// Flat list, no time-bucket headers: `relativeTime` already puts "just now" /
-// "yesterday" / "4d ago" on every row, so buckets would restate it. Ten rows is
-// enough that the list stays a glance rather than a filing cabinet — worth
-// revisiting only once someone actually keeps 20+ conversations.
-const RECENTS_LIMIT = 10;
-
 export function Chat() {
-  // The panel publishes its session projection upward (#62); here it feeds the
-  // Recents rail instead of the Note header's popover.
-  const [controls, setControls] = useState<ChatSessionControls | null>(null);
+  const { sidebarCollapsed } = useOutletContext<LayoutOutletContext>();
+  const controls = useGlobalChatStore((s) => s.controls);
+  const setControls = useGlobalChatStore((s) => s.setControls);
 
-  // `canBrowseHistory` is the panel's lone-empty-conversation rule: a single
-  // untouched conversation isn't history worth listing. Reused rather than
-  // reimplemented, so the rail and the Note header agree on what counts.
-  const rows = controls?.canBrowseHistory
-    ? conversationRows(controls.conversations, controls.activeConversationId).slice(0, RECENTS_LIMIT)
-    : [];
+  // Clear on the way out, or the sidebar would keep rendering a list belonging to
+  // a pane that no longer exists. (`ChatPanel` publishes `null` when chat isn't
+  // usable, but unmounting isn't one of those moments — it can't publish then.)
+  useEffect(() => () => setControls(null), [setControls]);
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      <div className="shrink-0 max-w-[1040px] mx-auto w-full px-8 pt-14">
-        <h1 className="px-2 text-[25px] font-semibold tracking-[-0.022em] truncate">Chat</h1>
+      <div className="shrink-0 max-w-[880px] mx-auto w-full px-8 pt-14">
+        <div className="flex items-center gap-3 px-2">
+          <h1 className="text-[25px] font-semibold tracking-[-0.022em] truncate">Chat</h1>
+          {/* The session chrome lives in exactly one place at a time. The sidebar
+              owns it while it's open; collapsed (manually, or automatically under
+              900px) it would take the conversation list with it, so the popover
+              fallback appears here instead. Never both — two "new chat" buttons
+              on one screen is a puzzle, not an affordance. */}
+          {sidebarCollapsed && controls && (
+            <div className="ml-auto">
+              <ChatHistoryControls controls={controls} />
+            </div>
+          )}
+        </div>
       </div>
 
-      {/* The page opens on the composer: no display heading, no hero. The panel
-          gets the room and the rail sits beside it. */}
-      <div className="flex-1 min-h-0 max-w-[1040px] mx-auto w-full px-8 pt-3 pb-5 flex gap-5">
-        {/* `min-h-0` as well as `min-w-0`: the panel scrolls its own message log,
-            which only works while its height stays bounded by this column. */}
-        <div className="flex-1 min-w-0 min-h-0 flex flex-col">
-          <ChatPanel target={GLOBAL_TARGET} onControls={setControls} />
-        </div>
-
-        <aside
-          aria-label="Recent conversations"
-          className="w-[224px] shrink-0 flex flex-col border-l border-[var(--color-line)] pl-4"
-        >
-          <div className="shrink-0 flex items-center justify-between gap-2 pb-1">
-            <span className="nd-label">Recent</span>
-            <button
-              type="button"
-              onClick={() => void controls?.newChat()}
-              disabled={!controls}
-              title="New chat"
-              aria-label="New chat"
-              // `.nd-btn-icon` has no `:disabled` rule and its hover isn't
-              // guarded, so a bare `disabled` would still light up on hover while
-              // doing nothing. Same dimming the send button uses.
-              className={cn("nd-btn-icon", !controls && "opacity-40 pointer-events-none")}
-            >
-              <Plus size={16} strokeWidth={1.7} aria-hidden="true" />
-            </button>
-          </div>
-
-          <div className="flex-1 min-h-0 overflow-y-auto -mx-1 px-1">
-            {rows.length === 0 ? (
-              <p className="px-2 py-2 text-xs text-[var(--color-text-disabled)]">
-                No conversations yet
-              </p>
-            ) : (
-              // Read-only rows: selecting one loads it, and "new chat" is the only
-              // other move. No rename or delete — in a workspace, who may remove a
-              // conversation every member can see is still an open question (#60),
-              // and shipping a delete that ignores it would answer it by accident.
-              <ul className="flex flex-col gap-0.5 list-none">
-                {rows.map((row) => (
-                  <li key={row.id}>
-                    <button
-                      type="button"
-                      onClick={() => void controls?.openConversation(row.id)}
-                      aria-current={row.active ? "true" : undefined}
-                      className={cn(
-                        "w-full rounded-[var(--radius)] px-2 py-1.5 text-left transition-colors",
-                        row.active
-                          ? "bg-[var(--color-accent-soft)] text-[var(--color-accent-text)]"
-                          : "hover:bg-[var(--color-pill-hover)]",
-                      )}
-                    >
-                      <span className="block truncate text-[13px]">{row.label}</span>
-                      <span className="block truncate text-xs text-[var(--color-text-muted)] tabular-nums">
-                        {row.description}
-                      </span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        </aside>
+      {/* The page opens on the composer: no display heading, no hero, and now no
+          rail either — the panel gets the whole width. */}
+      <div className="flex-1 min-h-0 max-w-[880px] mx-auto w-full px-8 pt-3 pb-5 flex flex-col">
+        <ChatPanel target={GLOBAL_TARGET} onControls={setControls} />
       </div>
     </div>
   );

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -16,7 +16,7 @@
 // local-only majority) and a scope picker (its only option would be "All notes";
 // narrowing stays a tool argument the model chooses, per #81).
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Plus } from "lucide-react";
 import { ChatPanel, type ChatSessionControls } from "../components/ChatPanel";
 import { conversationRows } from "../lib/chatSessions";
@@ -34,26 +34,22 @@ const GLOBAL_TARGET: ChatTarget = { kind: "global" };
 // revisiting only once someone actually keeps 20+ conversations.
 const RECENTS_LIMIT = 10;
 
-export default function Chat() {
+export function Chat() {
   // The panel publishes its session projection upward (#62); here it feeds the
   // Recents rail instead of the Note header's popover.
   const [controls, setControls] = useState<ChatSessionControls | null>(null);
 
-  const rows = useMemo(() => {
-    // `canBrowseHistory` is the panel's lone-empty-conversation rule: a single
-    // untouched conversation isn't history worth listing. Reused rather than
-    // reimplemented, so the rail and the Note header agree on what counts.
-    if (!controls?.canBrowseHistory) return [];
-    return conversationRows(controls.conversations, controls.activeConversationId).slice(
-      0,
-      RECENTS_LIMIT,
-    );
-  }, [controls]);
+  // `canBrowseHistory` is the panel's lone-empty-conversation rule: a single
+  // untouched conversation isn't history worth listing. Reused rather than
+  // reimplemented, so the rail and the Note header agree on what counts.
+  const rows = controls?.canBrowseHistory
+    ? conversationRows(controls.conversations, controls.activeConversationId).slice(0, RECENTS_LIMIT)
+    : [];
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
       <div className="shrink-0 max-w-[1040px] mx-auto w-full px-8 pt-14">
-        <h1 className="px-2 text-[25px] font-semibold tracking-[-0.022em]">Chat</h1>
+        <h1 className="px-2 text-[25px] font-semibold tracking-[-0.022em] truncate">Chat</h1>
       </div>
 
       {/* The page opens on the composer: no display heading, no hero. The panel
@@ -77,7 +73,10 @@ export default function Chat() {
               disabled={!controls}
               title="New chat"
               aria-label="New chat"
-              className="nd-btn-icon"
+              // `.nd-btn-icon` has no `:disabled` rule and its hover isn't
+              // guarded, so a bare `disabled` would still light up on hover while
+              // doing nothing. Same dimming the send button uses.
+              className={cn("nd-btn-icon", !controls && "opacity-40 pointer-events-none")}
             >
               <Plus size={16} strokeWidth={1.7} aria-hidden="true" />
             </button>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -13,17 +13,23 @@
 // navigate between belongs in the nav column, not in the right-hand slot this app
 // uses for context about the thing on screen.
 //
-// Deliberately absent: a greeting (we have no local user name — one exists only
+// Deliberately absent: a greeting. We have no local user name — one exists only
 // via `CloudUser.name` when signed into cloud, so it would be blank for the
-// local-only majority) and a scope picker (its only option would be "All notes";
-// narrowing stays a tool argument the model chooses, per #81).
+// local-only majority, and a nameless display heading does no work. The prompt
+// cards on a new chat do the job a greeting pretends to.
+//
+// Also absent: a scope picker (its only option would be "All notes"; narrowing
+// stays a tool argument the model chooses, per #81).
 
 import { useEffect } from "react";
 import { useOutletContext } from "react-router-dom";
+import { Files, Users } from "lucide-react";
 import { ChatPanel } from "../components/ChatPanel";
 import { ChatHistoryControls } from "../components/ChatHistoryControls";
 import type { LayoutOutletContext } from "../components/Layout";
 import { useGlobalChatStore } from "../lib/globalChat";
+import { useCloudStore } from "../lib/cloud";
+import { useNotesStore } from "../lib/store";
 import type { ChatTarget } from "../lib/chatTarget";
 
 // Module-level so the identity is stable across renders — the panel keys its
@@ -35,6 +41,8 @@ export function Chat() {
   const { sidebarCollapsed } = useOutletContext<LayoutOutletContext>();
   const controls = useGlobalChatStore((s) => s.controls);
   const setControls = useGlobalChatStore((s) => s.setControls);
+  const workspaceName = useCloudStore((s) => s.status.current_workspace?.name ?? null);
+  const noteCount = useNotesStore((s) => s.notes.length);
 
   // Clear on the way out, or the sidebar would keep rendering a list belonging to
   // a pane that no longer exists. (`ChatPanel` publishes `null` when chat isn't
@@ -43,8 +51,8 @@ export function Chat() {
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      <div className="shrink-0 max-w-[880px] mx-auto w-full px-8 pt-14">
-        <div className="flex items-center gap-3 px-2">
+      <div className="shrink-0 max-w-[820px] mx-auto w-full px-8 pt-14">
+        <div className="flex items-center gap-3">
           <h1 className="text-[25px] font-semibold tracking-[-0.022em] truncate">Chat</h1>
           {/* The session chrome lives in exactly one place at a time. The sidebar
               owns it while it's open; collapsed (manually, or automatically under
@@ -57,12 +65,34 @@ export function Chat() {
             </div>
           )}
         </div>
+
+        {/* Meta bar, mirroring the Note view's: the identity of what you're talking
+            to, in the header rather than as a banner inside the pane. In a
+            workspace that's the tenant and — the part that actually matters — that
+            teammates can read this. In Personal it's the size of the library being
+            searched, the same count the sidebar's "All notes" shows, from the same
+            store. Not shown for a workspace, where retrieval runs server-side and
+            the local mirror can lag, so the number would be a claim we can't make.
+            `-ml-2` pulls the first chip's own padding back to the title's edge. */}
+        <div className="-ml-2 flex flex-wrap items-center">
+          {workspaceName ? (
+            <span className="nd-meta">
+              <Users size={14} strokeWidth={1.7} />
+              {workspaceName} · visible to members
+            </span>
+          ) : (
+            <span className="nd-meta">
+              <Files size={14} strokeWidth={1.7} />
+              {noteCount === 1 ? "1 note" : `${noteCount} notes`}
+            </span>
+          )}
+        </div>
       </div>
 
-      {/* The page opens on the composer: no display heading, no hero, and now no
-          rail either — the panel gets the whole width. */}
-      <div className="flex-1 min-h-0 max-w-[880px] mx-auto w-full px-8 pt-3 pb-5 flex flex-col">
-        <ChatPanel target={GLOBAL_TARGET} onControls={setControls} />
+      {/* The page opens on the composer, and the panel runs edge to edge inside
+          this gutter — no rail, no internal padding of its own. */}
+      <div className="flex-1 min-h-0 max-w-[820px] mx-auto w-full px-8 pt-2 pb-5 flex flex-col">
+        <ChatPanel target={GLOBAL_TARGET} onControls={setControls} variant="page" />
       </div>
     </div>
   );

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -8,41 +8,45 @@
 // Everything substantive is borrowed: the panel arrives here parameterised by a
 // chat target (#94), so activation, prompts, citations, truncation, streaming and
 // a11y come for free, and the retrieval it drives is the same server- or
-// local-side engine (#93). What this file owns is the page shell — the
-// conversation list lives in the SIDEBAR (`ChatConversations`), because a list you
-// navigate between belongs in the nav column, not in the right-hand slot this app
-// uses for context about the thing on screen.
+// local-side engine (#93). What this file owns is the app bar — the conversation
+// list lives in the SIDEBAR (`ChatConversations`), because a list you navigate
+// between belongs in the nav column, not in the right-hand slot this app uses for
+// context about the thing on screen.
+//
+// The layout follows the Note view and Claude Desktop rather than inventing
+// anything: identity and actions ride in the title-bar row, and the body below is
+// only the conversation. No page heading — a second "Chat" under the bar's title
+// would be the same word twice, and once a conversation is open its own title is
+// the honest thing to show.
 //
 // Deliberately absent: a greeting. We have no local user name — one exists only
 // via `CloudUser.name` when signed into cloud, so it would be blank for the
-// local-only majority, and a nameless display heading does no work. The prompt
-// cards on a new chat do the job a greeting pretends to.
-//
-// Also absent: a scope picker (its only option would be "All notes"; narrowing
-// stays a tool argument the model chooses, per #81).
+// local-only majority. The prompt cards on a new chat do the job a greeting
+// pretends to. Also absent: a scope picker (its only option would be "All notes";
+// narrowing stays a tool argument the model chooses, per #81).
 
 import { useEffect } from "react";
 import { useOutletContext } from "react-router-dom";
-import { Files, Lock, Sparkles, Users, type LucideIcon } from "lucide-react";
+import { Lock, Sparkles, Users, type LucideIcon } from "lucide-react";
 import { ChatPanel } from "../components/ChatPanel";
 import { ChatHistoryControls } from "../components/ChatHistoryControls";
 import type { LayoutOutletContext } from "../components/Layout";
 import { useGlobalChatStore } from "../lib/globalChat";
 import { useCloudStore } from "../lib/cloud";
-import { useNotesStore } from "../lib/store";
 import type { ChatTarget } from "../lib/chatTarget";
+import { cn } from "../lib/cn";
 
 // Module-level so the identity is stable across renders — the panel keys its
 // load effect off the target's note id, but a stable object costs nothing and
 // keeps the prop honest.
 const GLOBAL_TARGET: ChatTarget = { kind: "global" };
 
-/** A bordered status pill for the header row.
+/** A bordered status pill for the app bar.
  *
  *  Not `.nd-chip`: that utility is uppercase with wide tracking — a survivor of
  *  the pre-v0.30 aesthetic — and the current design system is sentence case
- *  throughout. This is the note meta row's typography in a pill outline, so the
- *  two kinds of information sit together without shouting. */
+ *  throughout. This is the note meta row's typography in a pill outline, so
+ *  identity and status can sit together without either shouting. */
 function StatusPill({ icon: Icon, children }: { icon: LucideIcon; children: React.ReactNode }) {
   return (
     <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-line-visible)] px-2.5 py-[3px] text-[12px] text-[var(--color-text-muted)] whitespace-nowrap">
@@ -57,80 +61,79 @@ export function Chat() {
   const controls = useGlobalChatStore((s) => s.controls);
   const setControls = useGlobalChatStore((s) => s.setControls);
   const workspaceName = useCloudStore((s) => s.status.current_workspace?.name ?? null);
-  const noteCount = useNotesStore((s) => s.notes.length);
 
   // Clear on the way out, or the sidebar would keep rendering a list belonging to
   // a pane that no longer exists. (`ChatPanel` publishes `null` when chat isn't
   // usable, but unmounting isn't one of those moments — it can't publish then.)
   useEffect(() => () => setControls(null), [setControls]);
 
+  // The open conversation's own title once it has one. A fresh thread's title is
+  // empty until the backend derives it from the first turn, so "Chat" stands in
+  // until then and gives way as soon as there's something to name.
+  const active =
+    controls?.conversations.find((c) => c.id === controls.activeConversationId) ?? null;
+  const barTitle = active?.title.trim() || "Chat";
+
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      <div className="shrink-0 max-w-[820px] mx-auto w-full px-8 pt-14">
-        <div className="flex items-center gap-3">
-          <h1 className="text-[25px] font-semibold tracking-[-0.022em] truncate">Chat</h1>
-          {/* The session chrome lives in exactly one place at a time. The sidebar
-              owns it while it's open; collapsed (manually, or automatically under
-              900px) it would take the conversation list with it, so the popover
-              fallback appears here instead. Never both — two "new chat" buttons
-              on one screen is a puzzle, not an affordance. */}
-          {sidebarCollapsed && controls && (
-            <div className="ml-auto">
-              <ChatHistoryControls controls={controls} />
-            </div>
-          )}
-        </div>
+      {/* Title-bar row, same geometry as the Note view's toolbar: `h-12`, a drag
+          region, and a left inset that clears the macOS traffic lights when the
+          sidebar card isn't there to host them. */}
+      <div
+        data-tauri-drag-region
+        className={cn(
+          "relative z-30 h-12 shrink-0 flex items-center gap-2 pr-3",
+          sidebarCollapsed ? "pl-[116px]" : "pl-3",
+        )}
+      >
+        <span className="truncate text-[13.5px] font-medium" title={barTitle}>
+          {barTitle}
+        </span>
 
-        {/* Meta row, mirroring the Note view's: who you're talking to and where it
-            goes, in the header rather than as a banner inside the pane.
-            `-ml-2` pulls the first item's own padding back to the title's edge.
-            Two kinds of thing, deliberately styled apart — identity reads flat
-            like the note's meta row, status reads as a bordered pill. */}
-        <div className="-ml-2 flex flex-wrap items-center gap-1">
-          {/* Tenant, with the same initial badge the note's meta row uses. */}
-          <span className="nd-meta">
-            <span
-              className="grid place-items-center w-[17px] h-[17px] rounded-[5px] text-[9px] font-semibold"
-              style={{ background: "var(--color-surface-raised)", color: "var(--color-text)" }}
-            >
-              {(workspaceName ?? "Personal").charAt(0).toUpperCase()}
-            </span>
-            {workspaceName ?? "Personal"}
+        {/* Tenant, with the same initial badge the note's meta row uses. */}
+        <span className="nd-meta shrink-0">
+          <span
+            className="grid place-items-center w-[17px] h-[17px] rounded-[5px] text-[9px] font-semibold"
+            style={{ background: "var(--color-surface-raised)", color: "var(--color-text)" }}
+          >
+            {(workspaceName ?? "Personal").charAt(0).toUpperCase()}
           </span>
+          {workspaceName ?? "Personal"}
+        </span>
 
-          {/* Who can read this — the highest-stakes fact on the screen, so it gets
-              the pill treatment rather than being tucked into a sentence. */}
-          <StatusPill icon={workspaceName ? Users : Lock}>
-            {workspaceName ? "All members" : "Private"}
-          </StatusPill>
+        {/* Who can read this — the highest-stakes fact on the screen, so it gets
+            the pill treatment rather than being tucked into a sentence. */}
+        <StatusPill icon={workspaceName ? Users : Lock}>
+          {workspaceName ? "All members" : "Private"}
+        </StatusPill>
 
-          {/* Personal only, on both counts. The library size is genuinely useful on
-              a surface that searches all of it — but in a workspace retrieval runs
-              server-side and the local mirror can lag, so the number would be a
-              claim we can't make. Likewise the model: a workspace turn runs on the
-              server's model, and this is the local setting (#80), which is why the
-              panel publishes it as null there. */}
-          {!workspaceName && (
-            <span className="nd-meta">
-              <Files size={14} strokeWidth={1.7} />
-              {noteCount === 1 ? "1 note" : `${noteCount} notes`}
-            </span>
-          )}
-          {controls?.status && (
-            <span
-              className="nd-meta"
-              title={`Answering with ${controls.status.model} (${controls.status.provider}) — change it in Settings → Chat`}
-            >
-              <Sparkles size={14} strokeWidth={1.7} />
-              <span className="max-w-[220px] truncate">{controls.status.model}</span>
-            </span>
-          )}
-        </div>
+        <div className="flex-1" />
+
+        {/* What's about to answer. Published by the pane rather than re-derived —
+            `useChatReadiness` polls a local Ollama server every 2s and a second
+            caller would double that to render one label. Null in a workspace on
+            purpose: the turn runs on the server's model, so naming the local
+            setting would name something that isn't answering (#80). */}
+        {controls?.status && (
+          <span
+            className="nd-meta shrink-0"
+            title={`Answering with ${controls.status.model} (${controls.status.provider}) — change it in Settings → Chat`}
+          >
+            <Sparkles size={14} strokeWidth={1.7} />
+            <span className="max-w-[200px] truncate">{controls.status.model}</span>
+          </span>
+        )}
+
+        {/* Actions belong to the bar, as they do in the Note view — so the sidebar
+            section is purely the list. History is the exception: while the sidebar
+            is open it IS the history, and the popover would be a second copy of
+            it; collapsed, the popover is the only way back to a past thread. */}
+        {controls && <ChatHistoryControls controls={controls} showHistory={sidebarCollapsed} />}
       </div>
 
-      {/* The page opens on the composer, and the panel runs edge to edge inside
-          this gutter — no rail, no internal padding of its own. */}
-      <div className="flex-1 min-h-0 max-w-[820px] mx-auto w-full px-8 pt-2 pb-5 flex flex-col">
+      {/* Just the conversation: the log fills the height (so a new chat's prompt
+          cards sit centred in it) and the composer is seated at the bottom. */}
+      <div className="flex-1 min-h-0 max-w-[820px] mx-auto w-full px-8 pb-4 flex flex-col">
         <ChatPanel target={GLOBAL_TARGET} onControls={setControls} variant="page" />
       </div>
     </div>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,0 +1,124 @@
+// The `/chat` route (issue #95): chat's front door.
+//
+// Until now `ChatPanel` was mounted in exactly one place — the Chat tab of the
+// Note right panel — so asking about your whole library meant opening some
+// arbitrary note first and widening the breadth. This is the destination that
+// makes a library-wide question a first-class thing to do.
+//
+// Everything substantive is borrowed: the panel arrives here parameterised by a
+// chat target (#94), so activation, prompts, citations, truncation, streaming and
+// a11y come for free, and the retrieval it drives is the same server- or
+// local-side engine (#93). What this file owns is the page shell and the Recents
+// rail.
+//
+// Deliberately absent: a greeting (we have no local user name — one exists only
+// via `CloudUser.name` when signed into cloud, so it would be blank for the
+// local-only majority) and a scope picker (its only option would be "All notes";
+// narrowing stays a tool argument the model chooses, per #81).
+
+import { useMemo, useState } from "react";
+import { Plus } from "lucide-react";
+import { ChatPanel, type ChatSessionControls } from "../components/ChatPanel";
+import { conversationRows } from "../lib/chatSessions";
+import type { ChatTarget } from "../lib/chatTarget";
+import { cn } from "../lib/cn";
+
+// Module-level so the identity is stable across renders — the panel keys its
+// load effect off the target's note id, but a stable object costs nothing and
+// keeps the prop honest.
+const GLOBAL_TARGET: ChatTarget = { kind: "global" };
+
+// Flat list, no time-bucket headers: `relativeTime` already puts "just now" /
+// "yesterday" / "4d ago" on every row, so buckets would restate it. Ten rows is
+// enough that the list stays a glance rather than a filing cabinet — worth
+// revisiting only once someone actually keeps 20+ conversations.
+const RECENTS_LIMIT = 10;
+
+export default function Chat() {
+  // The panel publishes its session projection upward (#62); here it feeds the
+  // Recents rail instead of the Note header's popover.
+  const [controls, setControls] = useState<ChatSessionControls | null>(null);
+
+  const rows = useMemo(() => {
+    // `canBrowseHistory` is the panel's lone-empty-conversation rule: a single
+    // untouched conversation isn't history worth listing. Reused rather than
+    // reimplemented, so the rail and the Note header agree on what counts.
+    if (!controls?.canBrowseHistory) return [];
+    return conversationRows(controls.conversations, controls.activeConversationId).slice(
+      0,
+      RECENTS_LIMIT,
+    );
+  }, [controls]);
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden">
+      <div className="shrink-0 max-w-[1040px] mx-auto w-full px-8 pt-14">
+        <h1 className="px-2 text-[25px] font-semibold tracking-[-0.022em]">Chat</h1>
+      </div>
+
+      {/* The page opens on the composer: no display heading, no hero. The panel
+          gets the room and the rail sits beside it. */}
+      <div className="flex-1 min-h-0 max-w-[1040px] mx-auto w-full px-8 pt-3 pb-5 flex gap-5">
+        {/* `min-h-0` as well as `min-w-0`: the panel scrolls its own message log,
+            which only works while its height stays bounded by this column. */}
+        <div className="flex-1 min-w-0 min-h-0 flex flex-col">
+          <ChatPanel target={GLOBAL_TARGET} onControls={setControls} />
+        </div>
+
+        <aside
+          aria-label="Recent conversations"
+          className="w-[224px] shrink-0 flex flex-col border-l border-[var(--color-line)] pl-4"
+        >
+          <div className="shrink-0 flex items-center justify-between gap-2 pb-1">
+            <span className="nd-label">Recent</span>
+            <button
+              type="button"
+              onClick={() => void controls?.newChat()}
+              disabled={!controls}
+              title="New chat"
+              aria-label="New chat"
+              className="nd-btn-icon"
+            >
+              <Plus size={16} strokeWidth={1.7} aria-hidden="true" />
+            </button>
+          </div>
+
+          <div className="flex-1 min-h-0 overflow-y-auto -mx-1 px-1">
+            {rows.length === 0 ? (
+              <p className="px-2 py-2 text-xs text-[var(--color-text-disabled)]">
+                No conversations yet
+              </p>
+            ) : (
+              // Read-only rows: selecting one loads it, and "new chat" is the only
+              // other move. No rename or delete — in a workspace, who may remove a
+              // conversation every member can see is still an open question (#60),
+              // and shipping a delete that ignores it would answer it by accident.
+              <ul className="flex flex-col gap-0.5 list-none">
+                {rows.map((row) => (
+                  <li key={row.id}>
+                    <button
+                      type="button"
+                      onClick={() => void controls?.openConversation(row.id)}
+                      aria-current={row.active ? "true" : undefined}
+                      className={cn(
+                        "w-full rounded-[var(--radius)] px-2 py-1.5 text-left transition-colors",
+                        row.active
+                          ? "bg-[var(--color-accent-soft)] text-[var(--color-accent-text)]"
+                          : "hover:bg-[var(--color-pill-hover)]",
+                      )}
+                    >
+                      <span className="block truncate text-[13px]">{row.label}</span>
+                      <span className="block truncate text-xs text-[var(--color-text-muted)] tabular-nums">
+                        {row.description}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -23,7 +23,7 @@
 
 import { useEffect } from "react";
 import { useOutletContext } from "react-router-dom";
-import { Files, Users } from "lucide-react";
+import { Files, Lock, Sparkles, Users, type LucideIcon } from "lucide-react";
 import { ChatPanel } from "../components/ChatPanel";
 import { ChatHistoryControls } from "../components/ChatHistoryControls";
 import type { LayoutOutletContext } from "../components/Layout";
@@ -36,6 +36,21 @@ import type { ChatTarget } from "../lib/chatTarget";
 // load effect off the target's note id, but a stable object costs nothing and
 // keeps the prop honest.
 const GLOBAL_TARGET: ChatTarget = { kind: "global" };
+
+/** A bordered status pill for the header row.
+ *
+ *  Not `.nd-chip`: that utility is uppercase with wide tracking — a survivor of
+ *  the pre-v0.30 aesthetic — and the current design system is sentence case
+ *  throughout. This is the note meta row's typography in a pill outline, so the
+ *  two kinds of information sit together without shouting. */
+function StatusPill({ icon: Icon, children }: { icon: LucideIcon; children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-line-visible)] px-2.5 py-[3px] text-[12px] text-[var(--color-text-muted)] whitespace-nowrap">
+      <Icon size={13} strokeWidth={1.7} className="opacity-75" />
+      {children}
+    </span>
+  );
+}
 
 export function Chat() {
   const { sidebarCollapsed } = useOutletContext<LayoutOutletContext>();
@@ -66,24 +81,48 @@ export function Chat() {
           )}
         </div>
 
-        {/* Meta bar, mirroring the Note view's: the identity of what you're talking
-            to, in the header rather than as a banner inside the pane. In a
-            workspace that's the tenant and — the part that actually matters — that
-            teammates can read this. In Personal it's the size of the library being
-            searched, the same count the sidebar's "All notes" shows, from the same
-            store. Not shown for a workspace, where retrieval runs server-side and
-            the local mirror can lag, so the number would be a claim we can't make.
-            `-ml-2` pulls the first chip's own padding back to the title's edge. */}
-        <div className="-ml-2 flex flex-wrap items-center">
-          {workspaceName ? (
-            <span className="nd-meta">
-              <Users size={14} strokeWidth={1.7} />
-              {workspaceName} · visible to members
+        {/* Meta row, mirroring the Note view's: who you're talking to and where it
+            goes, in the header rather than as a banner inside the pane.
+            `-ml-2` pulls the first item's own padding back to the title's edge.
+            Two kinds of thing, deliberately styled apart — identity reads flat
+            like the note's meta row, status reads as a bordered pill. */}
+        <div className="-ml-2 flex flex-wrap items-center gap-1">
+          {/* Tenant, with the same initial badge the note's meta row uses. */}
+          <span className="nd-meta">
+            <span
+              className="grid place-items-center w-[17px] h-[17px] rounded-[5px] text-[9px] font-semibold"
+              style={{ background: "var(--color-surface-raised)", color: "var(--color-text)" }}
+            >
+              {(workspaceName ?? "Personal").charAt(0).toUpperCase()}
             </span>
-          ) : (
+            {workspaceName ?? "Personal"}
+          </span>
+
+          {/* Who can read this — the highest-stakes fact on the screen, so it gets
+              the pill treatment rather than being tucked into a sentence. */}
+          <StatusPill icon={workspaceName ? Users : Lock}>
+            {workspaceName ? "All members" : "Private"}
+          </StatusPill>
+
+          {/* Personal only, on both counts. The library size is genuinely useful on
+              a surface that searches all of it — but in a workspace retrieval runs
+              server-side and the local mirror can lag, so the number would be a
+              claim we can't make. Likewise the model: a workspace turn runs on the
+              server's model, and this is the local setting (#80), which is why the
+              panel publishes it as null there. */}
+          {!workspaceName && (
             <span className="nd-meta">
               <Files size={14} strokeWidth={1.7} />
               {noteCount === 1 ? "1 note" : `${noteCount} notes`}
+            </span>
+          )}
+          {controls?.status && (
+            <span
+              className="nd-meta"
+              title={`Answering with ${controls.status.model} (${controls.status.provider}) — change it in Settings → Chat`}
+            >
+              <Sparkles size={14} strokeWidth={1.7} />
+              <span className="max-w-[220px] truncate">{controls.status.model}</span>
             </span>
           )}
         </div>

--- a/src/pages/Note.tsx
+++ b/src/pages/Note.tsx
@@ -22,7 +22,6 @@ import {
   MessageSquare,
   MoreHorizontal,
   PanelRight,
-  Plus,
   RefreshCw,
   Sparkles,
   Users,
@@ -40,7 +39,7 @@ import { groupTimeline, resolveActivePill, formatSessionCaption } from "../lib/s
 import { RecordingBar } from "../components/RecordingBar";
 import { ChatPanel, type ChatSessionControls } from "../components/ChatPanel";
 import { SelectablePopover } from "../components/SelectablePopover";
-import { conversationRows } from "../lib/chatSessions";
+import { ChatHistoryControls } from "../components/ChatHistoryControls";
 import { targetKey, type ChatTarget } from "../lib/chatTarget";
 import type { LayoutOutletContext } from "../components/Layout";
 import { SkeletonLines } from "../components/Skeleton";
@@ -1360,51 +1359,7 @@ function FolderPicker({
   );
 }
 
-// Per-Note Client picker (issue #43). Built on the reusable
-// Chat session chrome for the panel header (issue #62): a "+" that starts a
-// fresh conversation and a history button opening a popover of this Note's
-// conversations (title + relative date, most recent first, current one marked).
-// Selecting one loads it. The history button is hidden for a lone empty
-// conversation — the panel decides that via `canBrowseHistory`. All state lives
-// in ChatPanel; this only renders the projection it publishes.
-function ChatHistoryControls({ controls }: { controls: ChatSessionControls }) {
-  const { conversations, activeConversationId, canBrowseHistory, newChat, openConversation } =
-    controls;
-  // Same projection `/chat`'s Recents renders from (#95) — ordering, the
-  // empty-title fallback and the relative date are decided in one place. The
-  // popover takes its own `activeId`, so it ignores each row's `active`.
-  const items = conversationRows(conversations, activeConversationId);
-  return (
-    <div className="flex items-center gap-0.5">
-      <button
-        type="button"
-        onClick={() => void newChat()}
-        title="New chat"
-        aria-label="New chat"
-        className="nd-btn-icon"
-      >
-        <Plus size={16} strokeWidth={1.7} aria-hidden="true" />
-      </button>
-      {canBrowseHistory && (
-        <SelectablePopover
-          ariaLabel="Chat history"
-          align="end"
-          items={items}
-          activeId={activeConversationId}
-          onSelect={(id) => {
-            if (id) void openConversation(id);
-          }}
-          trigger={
-            <span className="nd-btn-icon" title="Chat history">
-              <History size={16} strokeWidth={1.7} aria-hidden="true" />
-            </span>
-          }
-        />
-      )}
-    </div>
-  );
-}
-
+// Per-Note Client picker (issue #43).
 // SelectablePopover primitive: assign / reassign / unassign plus full inline
 // create / rename / delete — all Client management lives here (there's no
 // browse-by-Client surface). Mirrors FolderPicker's placement but is richer,

--- a/src/pages/Note.tsx
+++ b/src/pages/Note.tsx
@@ -40,7 +40,7 @@ import { groupTimeline, resolveActivePill, formatSessionCaption } from "../lib/s
 import { RecordingBar } from "../components/RecordingBar";
 import { ChatPanel, type ChatSessionControls } from "../components/ChatPanel";
 import { SelectablePopover } from "../components/SelectablePopover";
-import { conversationTitle, relativeTime } from "../lib/chatSessions";
+import { conversationRows } from "../lib/chatSessions";
 import { targetKey, type ChatTarget } from "../lib/chatTarget";
 import type { LayoutOutletContext } from "../components/Layout";
 import { SkeletonLines } from "../components/Skeleton";
@@ -1370,13 +1370,10 @@ function FolderPicker({
 function ChatHistoryControls({ controls }: { controls: ChatSessionControls }) {
   const { conversations, activeConversationId, canBrowseHistory, newChat, openConversation } =
     controls;
-  const items = [...conversations]
-    .sort((a, b) => b.updatedAt - a.updatedAt)
-    .map((c) => ({
-      id: c.id,
-      label: conversationTitle(c),
-      description: relativeTime(c.updatedAt),
-    }));
+  // Same projection `/chat`'s Recents renders from (#95) — ordering, the
+  // empty-title fallback and the relative date are decided in one place. The
+  // popover takes its own `activeId`, so it ignores each row's `active`.
+  const items = conversationRows(conversations, activeConversationId);
   return (
     <div className="flex items-center gap-0.5">
       <button

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -244,6 +244,13 @@ select:focus, textarea:focus {
 
 textarea { resize: none; }
 
+/* Scrolls without advertising it. For surfaces that auto-scroll and are read
+   rather than navigated — the chat log, whose bar would otherwise sit on top of
+   the answer's citation chips (#95). Not for lists the user has to explore:
+   there, the bar is the only hint there's more. */
+.nd-scroll-hidden { scrollbar-width: none; -ms-overflow-style: none; }
+.nd-scroll-hidden::-webkit-scrollbar { display: none; }
+
 input::placeholder, textarea::placeholder {
   color: var(--color-text-muted);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -242,6 +242,20 @@ select:focus, textarea:focus {
   border-radius: 0 !important;
 }
 
+/* The chat composer's field on the `/chat` page, where the composer BOX is the
+   surface (#95). The `select, textarea` rule above is unlayered, so it outranks
+   every Tailwind utility — a field inside a styled container has to opt out with
+   a rule of the same kind, and set its own padding while it's there. The right
+   inset is the room the send button needs; without it long text slides under the
+   button. `.nd-bare` is the wrong tool here: its `padding: 0 !important` would
+   beat any padding we then asked for. */
+.nd-chat-input {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 8px 44px 8px 8px;
+}
+
 textarea { resize: none; }
 
 /* Scrolls without advertising it. For surfaces that auto-scroll and are read


### PR DESCRIPTION
Closes #95. Child 3 of 3 under #82 — the visible one.

## What this is

Chat had no home. `ChatPanel` was mounted in exactly one place (the Chat tab of the Note right panel), so asking about your whole library meant opening an arbitrary note first and widening the breadth. That's the structural gap against Steno: we have the better engine — hybrid retrieval, agentic loop, real citations, none of which they have — and were missing the front door.

- **`/chat` route** + a sidebar NavItem directly under "All notes", same tier.
- Renders `ChatPanel` with a `{kind:"global"}` target (#94), so activation, citations, truncation, streaming and a11y arrive unchanged rather than reimplemented.
- **Flat Recents rail** — most-recent first, capped at 10, read-only rows, active row marked. No time buckets (`relativeTime` already dates every row), no rename/delete (#60's workspace-permission question is still open, and shipping a delete would answer it by accident).
- **One shared row projection.** There was no row *component* to extract, so the shareable thing is `conversationRows`: ordering, the empty-title fallback and the relative date, now feeding both the Note header's popover and Recents.
- **Library-scoped prompt set**, chosen by target via `promptsFor`. Cross-note by design — none of the four is answerable from one note's grounding. "Client status" also teaches that client narrowing exists, otherwise undiscoverable with no scope picker.
- **Nothing-to-retrieve state**: the composer holds instead of inviting a question whose only answer is "I couldn't find anything".

No greeting (no local user name exists — `CloudUser.name` only when signed into cloud, so it'd be blank for the local-only majority) and no scope picker. The note pane is untouched, including its "All notes" breadth; the two-histories wart is accepted and recorded in #82.

## Review findings folded in (second commit)

The spec axis caught two things worth calling out, because both were me shipping the letter of #94 over the intent of #95:

1. **The scope picker still rendered.** #94's `hasAnchor` collapsed its *options*, which left precisely the one-option dropdown #95 names as deliberately-not-here. The rule now lives in `BreadthPicker`: fewer than two options, no picker.
2. **The workspace empty case was dropped rather than distinguished.** Gating on `!inWorkspace` meant an empty workspace library got an open composer — spending a *metered* turn to learn there was nothing there, the exact harm the issue cited. The hold now applies everywhere, and sync state tells the two apart: mid-pull says notes are still arriving; settled-and-empty says there are none.

Standards axis: the held composer used `disabled`, which drops it out of the tab order — so a keyboard or screen-reader user would never reach the placeholder explaining why they can't type (now `readOnly` + `aria-disabled`); the disabled New-chat button still lit up on hover because `.nd-btn-icon` has no `:disabled` rule; named export to match every other page; `ConversationFields` names the row's input type once.

## A superseded test, rewritten not deleted

#94 has a test asserting a global pane shows a one-option "All notes" picker — the behaviour this PR removes. Its *other* purpose still matters (a global pane must never offer an anchor-dependent breadth, and must survive an unreadable stored breadth), so it now asserts the picker is absent entirely.

## Known residual

The server reports `index_state` (`empty` = backfilling / `quarantined` / `ready`) authoritatively, but no client code consumes it. Sync state is a local proxy: a workspace that has synced zero notes while the server index is still backfilling would read as "No notes yet". Filed separately rather than smuggled in here.

## Verification

- 317 frontend tests (11 new for this page, plus the lib helpers), `tsc --noEmit` clean.
- Route, nav item, rail and empty-history copy checked in the Vite preview in light and dark at 1280 and 920 — no console errors.
- **AC 12 is not covered here**: a cold `pnpm tauri dev` pass with no note open, in Personal and in a workspace, needs a real backend and a real key. That one's for @michaelwilhelmsen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)