### PR TITLE
feat(chat): index_state in the empty state (#102), asker identity + mine_only (#103)

### DIFF
--- a/src-tauri/src/chat/cloud.rs
+++ b/src-tauri/src/chat/cloud.rs
@@ -240,6 +240,37 @@ pub fn parse_usage(body: &Value) -> Option<UsageDto> {
     Some(UsageDto { used, cap, period_end })
 }
 
+/// How a workspace's retrieval index looks to search, as the server reports it
+/// (issue #102). The client needs this to keep the chat pane honest: an empty
+/// local mirror is not evidence of an empty workspace when the server index is
+/// still backfilling, and "No notes yet" is then a false claim about someone's
+/// library.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IndexState {
+    /// Searchable — an empty result really does mean "nothing matched".
+    Ready,
+    /// Nothing to match yet: never indexed, or still backfilling.
+    Empty,
+    /// Chunks withheld inside the indexer's deactivation grace window.
+    Quarantined,
+}
+
+/// Map a 200 index-state body to the enum, or None when there's nothing usable.
+///
+/// Best-effort like [`parse_usage`]: this only ever *improves* the pane's copy,
+/// so an unknown state (a newer server growing a fourth value) or a malformed
+/// body reads as "no information" and the caller falls back to its local guess.
+/// Never an error — a hint must not be able to break the composer.
+pub fn parse_index_state(body: &Value) -> Option<IndexState> {
+    match body.get("index_state").and_then(|v| v.as_str())? {
+        "ready" => Some(IndexState::Ready),
+        "empty" => Some(IndexState::Empty),
+        "quarantined" => Some(IndexState::Quarantined),
+        _ => None,
+    }
+}
+
 // ── Workspace chat key (BYOK, issue #75) ─────────────────────────────────────
 
 /// Metadata about a workspace's OpenAI key, shown in workspace settings. The
@@ -345,6 +376,25 @@ mod tests {
         // Partial / malformed → None.
         assert_eq!(parse_usage(&json!({ "used_turns": 2 })), None);
         assert_eq!(parse_usage(&json!({})), None);
+    }
+
+    #[test]
+    fn parse_index_state_maps_the_three_states_and_nothing_else() {
+        for (raw, want) in [
+            ("ready", IndexState::Ready),
+            ("empty", IndexState::Empty),
+            ("quarantined", IndexState::Quarantined),
+        ] {
+            assert_eq!(parse_index_state(&json!({ "index_state": raw })), Some(want));
+        }
+        // An unknown state — a newer server growing a fourth value — reads as "no
+        // information" so the pane falls back to its local guess rather than
+        // guessing wrong about a state it doesn't understand.
+        assert_eq!(parse_index_state(&json!({ "index_state": "rebuilding" })), None);
+        // Error shapes and malformed bodies carry no state.
+        assert_eq!(parse_index_state(&json!({ "reason": "not_a_member" })), None);
+        assert_eq!(parse_index_state(&json!({ "index_state": 3 })), None);
+        assert_eq!(parse_index_state(&json!({})), None);
     }
 
     #[test]

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -275,19 +275,36 @@ pub fn max_steps_for(scope: &ToolScope) -> usize {
     }
 }
 
-/// The system prompt with today's date appended.
+/// The system prompt with the turn's context appended: today's date, and who is
+/// asking.
 ///
 /// Every tool result carries absolute note dates ("2026-07-12"), which a model
 /// with no idea what today is cannot reason about — it can neither judge recency
-/// nor sanity-check what a `within_days` window returned. Composed here rather
-/// than baked into [`SYSTEM_PROMPT`] so the mirrored constant stays byte-identical
-/// across the two repos and the assembly stays testable with a fixed clock.
-pub fn system_prompt_with_date(now_ms: i64) -> String {
+/// nor sanity-check what a `within_days` window returned.
+///
+/// The asker is the referent for "I", "me" and "my" (#103). Without it a third of
+/// the questions people actually ask a meeting assistant are unresolvable. The
+/// transcript sentence matters as much as the name: the user's own speech is
+/// labelled `You:` on remote calls and often renamed to their real name after
+/// diarization, so the model needs both spellings tied together or a first-person
+/// question still misses in the very transcript that answers it.
+///
+/// Composed here rather than baked into [`SYSTEM_PROMPT`] so the mirrored constant
+/// stays byte-identical across the two repos and the assembly stays testable with
+/// a fixed clock.
+pub fn system_prompt_with_context(now_ms: i64, asker: Option<&str>) -> String {
     use chrono::{TimeZone, Utc};
-    match Utc.timestamp_millis_opt(now_ms).single() {
-        Some(dt) => format!("{SYSTEM_PROMPT}\n\nToday's date is {}.", dt.format("%Y-%m-%d")),
-        None => SYSTEM_PROMPT.to_string(),
+    let mut out = SYSTEM_PROMPT.to_string();
+    if let Some(dt) = Utc.timestamp_millis_opt(now_ms).single() {
+        out.push_str(&format!("\n\nToday's date is {}.", dt.format("%Y-%m-%d")));
     }
+    if let Some(name) = asker.map(str::trim).filter(|n| !n.is_empty()) {
+        out.push_str(&format!(
+            "\n\nYou are talking to {name}. \"I\", \"me\" and \"my\" mean {name} — including in \
+             transcripts, where their own speech may be labelled \"You:\" or with their name."
+        ));
+    }
+    out
 }
 
 /// Budget for prior turns. Older turns beyond it are dropped (oldest first).
@@ -411,6 +428,9 @@ pub async fn run_chat(
     workspace: &str,
     embedder: Option<&dyn crate::embed::EmbeddingAdapter>,
     user_text: &str,
+    // The asking user's display name, when one is known (see
+    // `system_prompt_with_context`). `None` simply omits the line.
+    asker: Option<&str>,
     mut sink: impl FnMut(ChatEvent) + Send,
 ) -> Result<()> {
     // 1. Read history and build the prospective turn list (existing + the new
@@ -430,7 +450,7 @@ pub async fn run_chat(
     // One clock reading per turn, shared by the prompt's date line and the tools'
     // relative date window, so a turn can't disagree with itself about "now".
     let now_ms = chrono::Utc::now().timestamp_millis();
-    let base = assemble_prompt(&system_prompt_with_date(now_ms), grounding, &turns)?;
+    let base = assemble_prompt(&system_prompt_with_context(now_ms, asker), grounding, &turns)?;
     eprintln!(
         "[chat] provider={} model={} turns={} grounding_chars={}",
         adapter.provider_id(),
@@ -1014,7 +1034,7 @@ mod tests {
         let adapter = FakeChatAdapter::new(["Hello world"]);
         let mut events: Vec<ChatEvent> = Vec::new();
         run_chat(
-            &dbh, &adapter, FAKE_CTX, &conv_id, "GROUNDING", &ToolScope::All, "", None, "What happened?",
+            &dbh, &adapter, FAKE_CTX, &conv_id, "GROUNDING", &ToolScope::All, "", None, "What happened?", None,
             |ev| events.push(ev),
         )
         .await
@@ -1047,7 +1067,7 @@ mod tests {
             let (dbh, _path) = temp_db(&dir);
             conv_id = conv(&dbh, "note-1");
             let adapter = FakeChatAdapter::new(["answer"]);
-            run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "G", &ToolScope::All, "", None, "hi", |_| {})
+            run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "G", &ToolScope::All, "", None, "hi", None, |_| {})
                 .await
                 .unwrap();
         }
@@ -1113,7 +1133,7 @@ mod tests {
         let (dbh, _path) = temp_db(&dir);
         let conv_id = conv(&dbh, "n");
         let res = run_chat(
-            &dbh, &FailingAdapter, FAKE_CTX, &conv_id, "G", &ToolScope::All, "", None, "hi", |_| {},
+            &dbh, &FailingAdapter, FAKE_CTX, &conv_id, "G", &ToolScope::All, "", None, "hi", None, |_| {},
         )
         .await;
         assert!(res.is_err());
@@ -1140,7 +1160,7 @@ mod tests {
         ]);
         let mut events: Vec<ChatEvent> = Vec::new();
         run_chat(
-            &dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "what about budget?",
+            &dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "what about budget?", None,
             |ev| events.push(ev),
         )
         .await
@@ -1184,7 +1204,7 @@ mod tests {
             &ToolScope::All,
             "",
             None,
-            "stop me",
+            "stop me", None,
             |_| {},
         )
         .await
@@ -1220,7 +1240,8 @@ mod tests {
             "",
             None,
             "search then stop",
-            // The tool finished; stop before the next step is dispatched.
+            None,
+            // The tool finished; stop before the next step is dispatched., None,
             |ev| {
                 if matches!(ev, ChatEvent::ToolActivity { .. }) {
                     flag.cancel();
@@ -1270,7 +1291,8 @@ mod tests {
             "",
             None,
             "narrate, search, then stop",
-            // The tool finished; stop before the next step is dispatched.
+            None,
+            // The tool finished; stop before the next step is dispatched., None,
             |ev| {
                 if matches!(ev, ChatEvent::ToolActivity { .. }) {
                     flag.cancel();
@@ -1315,7 +1337,7 @@ mod tests {
             &ToolScope::All,
             "",
             None,
-            "start answering then stop",
+            "start answering then stop", None,
             |ev| {
                 if matches!(ev, ChatEvent::TextDelta { .. }) {
                     flag.cancel();
@@ -1368,8 +1390,9 @@ mod tests {
             "",
             None,
             "narrate, search, answer, then stop",
+            None,
             // Stop only once the answering step is streaming — cancelling on the
-            // narration would land in the tool phase instead.
+            // narration would land in the tool phase instead., None,
             |ev| {
                 if matches!(&ev, ChatEvent::TextDelta { delta, .. } if delta.starts_with("Half")) {
                     flag.cancel();
@@ -1402,7 +1425,7 @@ mod tests {
             FakeChatAdapter::text_step("I couldn't open that note, but here's what I know."),
         ]);
         let mut events: Vec<ChatEvent> = Vec::new();
-        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "open note x", |ev| {
+        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "open note x", None, |ev| {
             events.push(ev)
         })
         .await
@@ -1429,7 +1452,7 @@ mod tests {
             .map(|_| FakeChatAdapter::tool_step("c", "search_notes", r#"{"query":"content"}"#))
             .collect();
         let adapter = FakeChatAdapter::scripted(steps);
-        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "keep going", |_| {})
+        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "keep going", None, |_| {})
             .await
             .unwrap();
 
@@ -1472,7 +1495,7 @@ mod tests {
             &ToolScope::Note(anchor),
             "",
             None,
-            "keep going",
+            "keep going", None,
             |_| {},
         )
         .await
@@ -1484,9 +1507,36 @@ mod tests {
         assert_eq!(tool_parts, MAX_STEPS_NOTE - 1, "note scope is unchanged by the deeper budget");
     }
 
+    /// #103: the asker is the referent for "I"/"me"/"my". Without it a third of
+    /// the questions people actually ask are unresolvable.
+    #[test]
+    fn the_prompt_names_who_is_asking_and_ties_them_to_the_transcript() {
+        let p = system_prompt_with_context(1_785_024_000_000, Some("Michael"));
+        assert!(p.contains("You are talking to Michael."), "{p}");
+        assert!(p.contains("\"I\", \"me\" and \"my\" mean Michael"), "{p}");
+        // The user's own speech is labelled `You:` on remote calls and often
+        // renamed after diarization — without both spellings tied together, a
+        // first-person question still misses in the transcript that answers it.
+        assert!(p.contains("\"You:\""), "{p}");
+        // Context appended to the mirrored constant, never a rewrite of it.
+        assert!(p.starts_with(SYSTEM_PROMPT));
+        assert!(!SYSTEM_PROMPT.contains("You are talking to"));
+        // The date line survives alongside it.
+        assert!(p.contains("Today's date is 2026-07-26."));
+    }
+
+    #[test]
+    fn an_unknown_asker_costs_nothing_but_the_asker_line() {
+        for asker in [None, Some(""), Some("   ")] {
+            let p = system_prompt_with_context(1_785_024_000_000, asker);
+            assert!(!p.contains("You are talking to"), "{asker:?}");
+            assert!(p.contains("Today's date is 2026-07-26."), "{asker:?}");
+        }
+    }
+
     #[test]
     fn the_prompt_tells_the_model_todays_date_without_touching_the_mirrored_constant() {
-        let with_date = system_prompt_with_date(1_785_024_000_000); // 2026-07-26
+        let with_date = system_prompt_with_context(1_785_024_000_000, None); // 2026-07-26
         assert!(with_date.starts_with(SYSTEM_PROMPT));
         assert!(with_date.contains("Today's date is 2026-07-26."));
         // Every tool result carries absolute note dates; without this line the
@@ -1516,7 +1566,7 @@ mod tests {
         };
         let adapter =
             FakeChatAdapter::scripted(vec![preamble, FakeChatAdapter::text_step("The answer.")]);
-        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "q", |_| {})
+        run_chat(&dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", None, "q", None, |_| {})
             .await
             .unwrap();
 
@@ -1559,7 +1609,7 @@ mod tests {
         let mut events: Vec<ChatEvent> = Vec::new();
         run_chat(
             &dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::All, "", Some(&FailingEmbedder),
-            "budget?", |ev| events.push(ev),
+            "budget?", None, |ev| events.push(ev),
         )
         .await
         .unwrap();
@@ -1588,7 +1638,7 @@ mod tests {
         let mut events: Vec<ChatEvent> = Vec::new();
         run_chat(
             &dbh, &adapter, FAKE_CTX, &conv_id, "", &ToolScope::Note(anchor.clone()), "", None,
-            "find it", |ev| events.push(ev),
+            "find it", None, |ev| events.push(ev),
         )
         .await
         .unwrap();

--- a/src-tauri/src/chat/tools.rs
+++ b/src-tauri/src/chat/tools.rs
@@ -95,6 +95,9 @@ const MS_PER_DAY: i64 = 86_400_000;
 /// The two ends of the relative date window, in tool-argument form.
 const ARG_WITHIN: &str = "within_days";
 const ARG_UNTIL: &str = "until_days";
+/// Restrict to notes the asker created. See the spec comment for why this is a
+/// truthful no-op on the local path.
+const ARG_MINE: &str = "mine_only";
 /// Per-excerpt / per-note text budget in the compact model view.
 const EXCERPT_CHARS: usize = 320;
 const GET_NOTE_CHARS: usize = 6_000;
@@ -115,6 +118,14 @@ pub fn tool_specs() -> Vec<ToolSpec> {
         // ends count back from today, so a window that ENDS in the past is still
         // expressible without either side knowing the calendar (#106).
         ARG_WITHIN: { "type": "integer", "description": "Optional: only notes from the last N days (e.g. 7 for last week)." },
+        // Authorship, not relevance — a flag, not an id the model has to learn.
+        //
+        // On THIS path it is a truthful no-op: the local tools only ever answer a
+        // Personal turn (a workspace turn retrieves server-side), and in Personal
+        // every note is the user's own, so "only mine" is the identity function.
+        // It is still advertised, because the two schemas are pinned equivalent —
+        // and a model that passes it here gets exactly what it asked for.
+        ARG_MINE: { "type": "boolean", "description": "Optional: only notes the person asking created themselves. Use for questions about what I said, promised, or was told." },
         ARG_UNTIL: { "type": "integer", "description": "Optional: exclude notes from the last N days, so the window ends in the past. With within_days it makes a past window: within_days 35 + until_days 7 = the four weeks before last week." },
     });
     vec![
@@ -129,6 +140,7 @@ pub fn tool_specs() -> Vec<ToolSpec> {
                     "client_id": filters["client_id"],
                     ARG_WITHIN: filters[ARG_WITHIN],
                     ARG_UNTIL: filters[ARG_UNTIL],
+                    ARG_MINE: filters[ARG_MINE],
                 },
                 "required": ["query"],
             }),
@@ -154,6 +166,7 @@ pub fn tool_specs() -> Vec<ToolSpec> {
                     "client_id": filters["client_id"],
                     ARG_WITHIN: filters[ARG_WITHIN],
                     ARG_UNTIL: filters[ARG_UNTIL],
+                    ARG_MINE: filters[ARG_MINE],
                 },
             }),
         },
@@ -608,6 +621,25 @@ mod tests {
     fn set_summary(conn: &Connection, id: &str, summary: &str) {
         db::update_note(conn, id, &db::NotePatch { summary: Some(summary.into()), ..Default::default() })
             .unwrap();
+    }
+
+    /// #103: the local path only ever answers a PERSONAL turn (a workspace turn
+    /// retrieves server-side), and in Personal every note is the user's own — so
+    /// "only mine" is the identity function here, not an ignored argument. It is
+    /// still advertised, because the two schemas are pinned equivalent.
+    #[test]
+    fn mine_only_is_advertised_and_is_a_truthful_no_op_in_personal() {
+        let conn = open();
+        seed(&conn, "Mine", "the budget came up");
+        for tool in [TOOL_LIST, TOOL_SEARCH] {
+            let out = exec(&conn, "", &ToolScope::All, tool, &json!({ "query": "budget", ARG_MINE: true }));
+            assert!(!out.is_error, "{tool}");
+            assert!(out.model_text.contains("Mine"), "{tool} returned the user's own note");
+        }
+        // Advertised on both filtering tools, as a boolean.
+        for spec in tool_specs().into_iter().filter(|s| s.name != TOOL_GET) {
+            assert_eq!(spec.parameters["properties"][ARG_MINE]["type"], "boolean", "{}", spec.name);
+        }
     }
 
     #[test]
@@ -1101,9 +1133,9 @@ mod pairwise_tests {
     #[test]
     fn the_tool_surface_is_identical_to_the_cloud_schema() {
         let expected = "\
-search_notes(client_id:string, folder_id:string, query:string!, until_days:integer, within_days:integer)
+search_notes(client_id:string, folder_id:string, mine_only:boolean, query:string!, until_days:integer, within_days:integer)
 get_note(note_id:string!)
-list_notes(client_id:string, folder_id:string, until_days:integer, within_days:integer)";
+list_notes(client_id:string, folder_id:string, mine_only:boolean, until_days:integer, within_days:integer)";
         assert_eq!(surface(), expected, "\nupdate humla-cloud/chat-service/src/tools.test.ts in lockstep");
     }
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -11,6 +11,10 @@ use crate::db::{self, ChatTarget, CHAT_TENANT_PERSONAL};
 use crate::embed::{self, EmbeddingAdapter, OLLAMA_EMBED_MODEL, OPENAI_EMBED_MODEL};
 use crate::openai;
 use crate::AppState;
+
+/// A user-set display name for chat's first-person referent (#103). Empty/unset
+/// falls back to the macOS account name — see [`asker_name`].
+pub(crate) const SETTING_DISPLAY_NAME: &str = "user_display_name";
 use parking_lot::Mutex;
 use rusqlite::Connection;
 use serde::Serialize;
@@ -780,6 +784,46 @@ pub async fn chat_usage(app: AppHandle) -> Result<Option<chat::cloud::UsageDto>,
     Ok(usage_cloud(&state, &workspace).await)
 }
 
+/// The name to call the person asking, or `None` when we genuinely don't know
+/// one. It is the referent for "I"/"me"/"my" in a turn (#103) — without it, a
+/// third of the questions people ask a meeting assistant can't be resolved.
+///
+/// Two sources, in order:
+///
+/// 1. The `user_display_name` setting, when the user has set one.
+/// 2. The macOS account's full name.
+///
+/// The OS name matters because it's the ONLY one the local-only majority has:
+/// Humla has no local account, and a cloud display name exists only once you've
+/// signed in. Falling back to it is what keeps "what did I promise?" answerable
+/// for a user who never signs in to anything. A short login name (`msmith`) is
+/// deliberately not used — as a referent it's worse than nothing.
+///
+/// Never fatal: any failure just omits the line from the prompt.
+pub(crate) fn asker_name(conn: &rusqlite::Connection) -> Option<String> {
+    let configured = crate::db::get_setting(conn, SETTING_DISPLAY_NAME)
+        .ok()
+        .flatten()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+    configured.or_else(os_full_name)
+}
+
+/// The macOS account's full name ("Michael Wilhelmsen"), via `id -F`. `None` if
+/// the command is unavailable, fails, or returns something empty.
+fn os_full_name() -> Option<String> {
+    let out = std::process::Command::new("/usr/bin/id").arg("-F").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let name = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
 /// How the workspace's retrieval index looks to search — `ready` / `empty` /
 /// `quarantined` — so the chat pane can tell "your library is empty" apart from
 /// "the index is still building" (issue #102).
@@ -1092,6 +1136,13 @@ pub async fn chat_send(
         think: resolved.think,
         cancel: turn.flag(),
     };
+    // Who is asking, for the prompt's first-person referent (#103). Resolved here
+    // rather than inside run_chat so the prompt's inputs stay explicit and the
+    // loop's tests stay independent of the host machine's account name.
+    let asker = {
+        let conn = state.db.lock();
+        asker_name(&conn)
+    };
     let result = chat::run_chat(
         &state.db,
         adapter.as_ref(),
@@ -1102,6 +1153,7 @@ pub async fn chat_send(
         &workspace,
         Some(&embedder as &dyn EmbeddingAdapter),
         &message,
+        asker.as_deref(),
         sink,
     )
     .await;

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -780,6 +780,36 @@ pub async fn chat_usage(app: AppHandle) -> Result<Option<chat::cloud::UsageDto>,
     Ok(usage_cloud(&state, &workspace).await)
 }
 
+/// How the workspace's retrieval index looks to search — `ready` / `empty` /
+/// `quarantined` — so the chat pane can tell "your library is empty" apart from
+/// "the index is still building" (issue #102).
+///
+/// Only the server knows the difference: workspace retrieval runs over the
+/// workspace index, and a locally-empty mirror is not evidence of an empty
+/// workspace while that index is backfilling. `None` means "no information" and
+/// the caller keeps its local guess — Personal (where the local store IS the
+/// corpus), an older server without the route, or any failure. Like the turn
+/// meter, this is best-effort: it may improve the pane's copy, never break it.
+#[tauri::command]
+pub async fn chat_index_state(app: AppHandle) -> Result<Option<chat::cloud::IndexState>, String> {
+    let state: State<AppState> = app.state();
+    let workspace = {
+        let conn = state.db.lock();
+        match ChatContext::load(&conn) {
+            ChatContext::Personal => return Ok(None),
+            ChatContext::Workspace(id) => id,
+        }
+    };
+    let body = super::cloud::cloud_get_json(
+        &state,
+        "/api/chat/index-state",
+        &[("workspace_id", workspace.as_str())],
+    )
+    .await
+    .ok();
+    Ok(body.as_ref().and_then(chat::cloud::parse_index_state))
+}
+
 /// GET the usage endpoint, collapsing every non-metered outcome to `None` so the
 /// meter can only ever report or silently hide (issue #69). See [`chat_usage`]
 /// for the full mapping. One-shot 401 re-auth mirrors the other cloud calls.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -366,6 +366,7 @@ where
             commands::chat_set_breadth,
             commands::chat_get_breadth,
             commands::chat_usage,
+            commands::chat_index_state,
             commands::chat_key_meta,
             commands::chat_key_set,
             commands::chat_key_set_from_keychain,

--- a/src/components/ChatConversations.test.tsx
+++ b/src/components/ChatConversations.test.tsx
@@ -85,7 +85,13 @@ describe("ChatConversations", () => {
     expect(screen.queryByLabelText("New chat")).toBeNull();
   });
 
+  // The clock is frozen for this one: "50 hours ago" is 2 calendar days back or 3
+  // depending on the time of day it runs, so the row's relative label flipped
+  // between "2d ago" and "3d ago" and the suite failed after ~22:00 local. A
+  // relative-time assertion has to pin the instant it is relative TO.
   it("lists conversations most-recent first and marks the active one", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-26T12:00:00Z"));
     const now = Date.now();
     publish({
       activeConversationId: "c-mid",
@@ -106,6 +112,7 @@ describe("ChatConversations", () => {
     const current = screen.getAllByRole("button", { current: true });
     expect(current).toHaveLength(1);
     expect(current[0].textContent).toContain("Client status");
+    vi.useRealTimers();
   });
 
   it("does not cap the list", () => {

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -24,7 +24,8 @@ import {
   type ChatCitation,
   type ChatMessageDto,
   type ChatScope,
-  type ChatUsage,
+  type ChatIndexState,
+  ChatUsage,
   type ConversationMeta,
 } from "../lib/ipc";
 import { useNotesStore } from "../lib/store";
@@ -252,6 +253,10 @@ export function ChatPanel({
   // in a managed workspace, to avoid flashing the composer before we know), then
   // a `ChatKeyMeta` or `null`. Feeds the activation-pane decision.
   const [keyMeta, setKeyMeta] = useState<ChatKeyMeta | null | undefined>(null);
+  // The server's view of the workspace retrieval index (#102). null = no
+  // information (Personal, an older server, or a failed lookup) → the empty-state
+  // copy falls back to the local sync proxy.
+  const [indexState, setIndexState] = useState<ChatIndexState | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   // The composer is auto-focused exactly once per mount, on the first transition
@@ -465,16 +470,25 @@ export function ChatPanel({
   // A NOTE pane never reaches either: its anchor note IS grounding, so there is
   // always something to answer from.
   //
-  // `syncing` splits them. A workspace pulls its notes down after a switch, so a
-  // local mirror that looks empty mid-pull isn't evidence of an empty workspace —
-  // that gets the still-arriving copy rather than a claim about the library. This
-  // is a client-side stand-in for the server's `index_state`, which reports
-  // "empty" (backfilling) vs "quarantined" vs "ready" authoritatively but isn't
-  // wired to the client yet; until it is, sync state is the honest local proxy.
+  // Two things split them, and in a workspace the server's word wins (#102).
+  //
+  // `syncing` is the local proxy: a workspace pulls its notes down after a
+  // switch, so a mirror that looks empty mid-pull isn't evidence of an empty
+  // workspace. But it's only a proxy — the pull can be idle, with nothing left to
+  // pull, while the SERVER index is still backfilling. Workspace retrieval runs
+  // over that index, so `indexState` is the authoritative answer: "empty"
+  // (never indexed / backfilling) and "quarantined" (withheld in the indexer's
+  // deactivation grace window) both mean "not yet", where only "ready" makes an
+  // empty result a true statement about the library.
+  //
+  // null covers Personal (where the local store IS the retrieval corpus, so the
+  // local check is already authoritative), an older server without the route, and
+  // any failure — all of which fall back to the sync proxy rather than blocking.
   const syncing = useCloudStore((s) => s.syncStatus) === "syncing";
+  const indexNotReady = indexState === "empty" || indexState === "quarantined";
   const globalPane = target.kind === "global";
-  const nothingToSearch = globalPane && libraryEmpty && !syncing;
-  const notesStillArriving = globalPane && libraryEmpty && syncing;
+  const nothingToSearch = globalPane && libraryEmpty && !syncing && !indexNotReady;
+  const notesStillArriving = globalPane && libraryEmpty && (syncing || indexNotReady);
   const composerHeld = nothingToSearch || notesStillArriving;
   // Does the composer's control row have anything in it? The breadth picker needs
   // an anchor to offer a second option (#95), the model chip is panel-only and
@@ -502,21 +516,27 @@ export function ChatPanel({
       if (!workspaceId) {
         setUsage(null);
         setKeyMeta(null);
+        setIndexState(null);
         return;
       }
       try {
-        const [u, m] = await Promise.all([
+        const [u, m, ix] = await Promise.all([
           ipc.chatUsage(),
           billingEnabled ? cloudApi.chatKeyMeta(workspaceId) : Promise.resolve(null),
+          // Settled separately: this one is a HINT. A rejection here must not
+          // take the usage meter and activation decision down with it.
+          ipc.chatIndexState().catch(() => null),
         ]);
         if (gen === switchGenRef.current) {
           setUsage(u);
           setKeyMeta(m);
+          setIndexState(ix);
         }
       } catch {
         if (gen === switchGenRef.current) {
           setUsage(null);
           setKeyMeta(null);
+          setIndexState(null);
         }
       }
     },

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -438,6 +438,11 @@ export const ipc = {
   // context, and on any unavailable/error/unmetered outcome — a meter never
   // errors the pane, so the caller just hides the display when this is null.
   chatUsage: () => invoke<ChatUsage | null>("chat_usage"),
+  /** How the workspace's retrieval index looks to search, or null when there's no
+   *  information (Personal, an older server, or any failure — the caller keeps its
+   *  local guess). See #102: only the server can tell a backfilling index apart
+   *  from a genuinely empty library. */
+  chatIndexState: () => invoke<ChatIndexState | null>("chat_index_state"),
   // Rebuild a Note's retrieval index — called on Note-view unmount so edits
   // that didn't trigger summarize/diarize still land in search.
   chatReindexNote: (noteId: string) => invoke<void>("chat_reindex_note", { noteId }),
@@ -499,6 +504,11 @@ export type ConversationMeta = {
 export type ChatScope = "note" | "folder" | "all";
 // Workspace turn allowance for the composer meter (issue #69). Only ever present
 // for a metered workspace; personal/unmetered/unavailable resolve to null.
+/** The server's view of a workspace's retrieval index (#102). "empty" covers both
+ *  never-indexed and mid-backfill; "quarantined" is the indexer's deactivation
+ *  grace window. */
+export type ChatIndexState = "ready" | "empty" | "quarantined";
+
 export type ChatUsage = { used: number; cap: number; periodEnd: number };
 
 // Streaming events (the #46 wire contract + #47 tool/citation events).

--- a/src/pages/Chat.test.tsx
+++ b/src/pages/Chat.test.tsx
@@ -353,6 +353,86 @@ describe("/chat with nothing to retrieve", () => {
     expect(screen.getByLabelText("Ask about your notes")).toHaveAttribute("aria-disabled", "true");
   });
 
+  // ── #102: the server's index_state overrides the local guess ──────────────
+  // Sync state is only a proxy. A workspace pull can be idle — nothing left to
+  // pull — while the server index is still backfilling, and "No notes yet" is
+  // then a false claim about someone's library. Only the server knows.
+
+  it("says notes are still arriving when the server index is backfilling, though sync is idle", async () => {
+    signIntoWorkspace();
+    useNotesStore.setState({ notes: [], loaded: true });
+    useCloudStore.setState({ syncStatus: "idle" });
+    mockTauri({
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      chat_index_state: () => "empty",
+    });
+    renderChat();
+
+    expect(await screen.findByText(/Still syncing your notes/)).toBeInTheDocument();
+    expect(screen.queryByText(/No notes yet\./)).toBeNull();
+  });
+
+  it("treats a quarantined index the same way — withheld is not empty", async () => {
+    signIntoWorkspace();
+    useNotesStore.setState({ notes: [], loaded: true });
+    useCloudStore.setState({ syncStatus: "idle" });
+    mockTauri({
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      chat_index_state: () => "quarantined",
+    });
+    renderChat();
+
+    expect(await screen.findByText(/Still syncing your notes/)).toBeInTheDocument();
+  });
+
+  it("still says there are no notes when the server confirms the index is ready", async () => {
+    // `ready` means an empty result really is empty — the one case where the
+    // claim about the library is true.
+    signIntoWorkspace();
+    useNotesStore.setState({ notes: [], loaded: true });
+    useCloudStore.setState({ syncStatus: "idle" });
+    mockTauri({
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      chat_index_state: () => "ready",
+    });
+    renderChat();
+
+    expect(await screen.findByText(/No notes yet\./)).toBeInTheDocument();
+  });
+
+  it("falls back to sync state when the lookup fails — a hint must never break the pane", async () => {
+    signIntoWorkspace();
+    useNotesStore.setState({ notes: [], loaded: true });
+    useCloudStore.setState({ syncStatus: "syncing" });
+    mockTauri({
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      chat_index_state: () => {
+        throw new Error("route absent on an older server");
+      },
+    });
+    renderChat();
+
+    // The pane renders, and the local proxy still gets the mid-sync copy right.
+    expect(await screen.findByText(/Still syncing your notes/)).toBeInTheDocument();
+  });
+
+  it("asks the server nothing in Personal, where the local store IS the corpus", async () => {
+    let asked = 0;
+    useNotesStore.setState({ notes: [], loaded: true });
+    mockTauri({
+      provider_key_get: () => "sk-test",
+      chat_history: () => ({ conversationId: null, messages: [] }),
+      chat_index_state: () => {
+        asked++;
+        return null;
+      },
+    });
+    renderChat();
+
+    expect(await screen.findByText(/No notes yet\./)).toBeInTheDocument();
+    expect(asked).toBe(0);
+  });
+
   it("leaves the composer open while the first load is still in flight", async () => {
     // notes: [] with loaded: false is "we don't know yet", not "empty" — claiming
     // an empty library here would fire on every launch for one frame.


### PR DESCRIPTION
Two issues, one branch — they share the chat pane and the retrieval seam. Server halves: [humla-cloud#38](https://github.com/michaelwilhelmsen/humla-cloud/pull/38) (index-state route) and humla-cloud `feat/chat-index-state-37` (asker + authorship), both required for the workspace path.

## #102 — the server's `index_state` corrects the empty-state copy

The pane guessed between "your library is empty" and "notes are still arriving" from local sync state. That's only a proxy, and it's wrong in a real case: the pull can be idle, with nothing left to pull, while the **server** index is still backfilling. The pane then said "No notes yet" — a false claim about someone's library, and precisely the misread `index_state` was added to prevent.

Treated as a **hint** throughout, because it can only improve the copy: `chat_index_state` collapses every failure to `None` (Personal returns without an HTTP call at all — there the local store *is* the corpus); an unrecognised state from a newer server reads as "no information" rather than being guessed at; and the fetch is `.catch`-settled separately from the usage meter so a rejection can't take the activation decision down with it. Every path falls back to the sync proxy.

## #103 — who is asking, and a `mine_only` filter

**Identity.** A turn carried the question, the scope and the notes but no identity, so every "I"/"me"/"my" was unresolvable — and in a shared workspace the likeliest wrong guess is that "my notes" means everyone's. `system_prompt_with_date` becomes `system_prompt_with_context(now, asker)` on both paths. The transcript sentence earns its place beside the name: the user's own speech is labelled `You:` on remote calls and often renamed after diarization, so without both spellings tied together a first-person question still misses in the transcript that answers it.

**This corrects the issue's premise.** It assumed Personal had a name available ("the author name the Note meta bar shows") — but that name is cloud-derived, so a local-only user, the majority, has none. `asker_name` falls back to the macOS account's full name via `id -F`, the only name that user has, with a `user_display_name` setting to override. A short login name is deliberately not used: as a referent, `msmith` is worse than nothing.

**`mine_only`.** A boolean on `search_notes`/`list_notes`, resolved to the asker's id from the **auth record** and never from the model's args — an identity the model could assert for itself would be worth nothing. Ignored with no known asker rather than filtering to nothing. On the local path it is a *truthful no-op*, not a stub: these tools only ever answer a Personal turn, and in Personal every note is the user's own, so "only mine" is the identity function. Still advertised, because the surfaces are pinned equivalent.

## Not in this PR

**The per-conversation "my notes" control is not built.** #103 also asks for the filter as a persisted, workspace-only control beside the breadth picker. That needs a `conversations.mine_only` column, a `chat_set_mine_only` command, the flag on the server's conversation row, a clamp in `/api/chat` so a user-set filter binds regardless of what the model passes, and the toggle itself. The model can already apply `mine_only` when a question implies it; what's missing is the user setting it deliberately. #103 stays open for that.

## Verified

376 Rust + 343 frontend tests (12 new), typecheck clean. The pinned tool-surface literal moved in both repos together, so the schemas stay verifiably equivalent.

Also fixes a pre-existing flake in the conversation-list test — it asserted a relative-time label without pinning the clock, so the suite went red after 22:00 local and green the next morning.

Refs #102, #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)