### PR TITLE
feat: add Cmd+=/- zoom in/out keyboard shortcuts

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,8 +5,8 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "core:webview:allow-set-webview-zoom",
     "core:event:default",
+    "core:webview:allow-set-webview-zoom",
     "core:window:allow-start-dragging",
     "dialog:allow-save",
     "dialog:allow-open",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:webview:allow-set-webview-zoom",
     "core:event:default",
     "core:window:allow-start-dragging",
     "dialog:allow-save",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,11 +22,13 @@ import { bindBackendListeners, useNotesStore } from "./lib/store";
 import { useCloudStore } from "./lib/cloud";
 import { useThemeBoot } from "./lib/theme";
 import { usePaletteBoot } from "./lib/palette";
+import { useZoomBoot } from "./lib/zoom";
 
 export default function App() {
   useGlobalShortcuts();
   useThemeBoot();
   usePaletteBoot();
+  useZoomBoot();
   const refresh = useNotesStore((s) => s.refresh);
   const refreshCloud = useCloudStore((s) => s.refresh);
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,6 +24,7 @@ import { SetupNag } from "./SetupNag";
 import { ImportDialog } from "./ImportDialog";
 import { ChatConversations } from "./ChatConversations";
 import { useCloudStore } from "../lib/cloud";
+import { trafficLightSpacerCssPx, useZoomStore } from "../lib/zoom";
 
 // Humla mark sourced from humla-small.svg — single-path silhouette of
 // the bee's head + antennae arc. Uses currentColor so it inherits text
@@ -164,12 +165,19 @@ export function Sidebar({ onCollapse }: { onCollapse: () => void }) {
   // list on screen is that surface's conversations, and showing the folder tree
   // beneath a folder's own chat would offer navigation the page already is.
   const onChat = location.pathname === "/chat" || /^\/folder\/[^/]+\/chat$/.test(location.pathname);
+  // Webview zoom scales the DOM but not the native traffic lights, so the
+  // clearance strip grows as 1/zoom to keep ~34 device px under the lights.
+  const zoom = useZoomStore((s) => s.zoom);
 
   return (
     <div className="h-full flex flex-col px-2.5 pb-2.5">
       {/* Traffic-light clearance + window drag handle — the macOS lights
           sit over this strip in the nav card's top-left. */}
-      <div data-tauri-drag-region className="h-[34px] w-full shrink-0" />
+      <div
+        data-tauri-drag-region
+        className="w-full shrink-0"
+        style={{ height: `${trafficLightSpacerCssPx(zoom)}px` }}
+      />
 
       {/* Brand */}
       <div

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { ipc } from "./ipc";
 import { useNotesStore, useRecordingStore } from "./store";
 import { useCloudStore } from "./cloud";
+import { useZoomStore } from "./zoom";
 
 export function useGlobalShortcuts() {
   const navigate = useNavigate();
@@ -47,6 +48,15 @@ export function useGlobalShortcuts() {
         e.preventDefault();
         const el = document.querySelector<HTMLInputElement>("[data-search-input]");
         el?.focus();
+      } else if (e.key === "=" || e.key === "+") {
+        e.preventDefault();
+        await useZoomStore.getState().zoomIn();
+      } else if (e.key === "-") {
+        e.preventDefault();
+        await useZoomStore.getState().zoomOut();
+      } else if (e.key === "0") {
+        e.preventDefault();
+        await useZoomStore.getState().zoomReset();
       }
     }
     window.addEventListener("keydown", onKey);

--- a/src/lib/zoom.test.ts
+++ b/src/lib/zoom.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  clamp,
+  resolveStoredZoom,
+  trafficLightSpacerCssPx,
+  TRAFFIC_LIGHT_CLEARANCE_PX,
+  useZoomStore,
+} from "./zoom";
+
+describe("clamp", () => {
+  it("keeps values inside 0.5–2.0", () => {
+    expect(clamp(0.5)).toBe(0.5);
+    expect(clamp(1)).toBe(1);
+    expect(clamp(2)).toBe(2);
+  });
+
+  it("floors below the min and ceilings above the max", () => {
+    expect(clamp(0.1)).toBe(0.5);
+    expect(clamp(0)).toBe(0.5);
+    expect(clamp(-1)).toBe(0.5);
+    expect(clamp(2.5)).toBe(2);
+    expect(clamp(10)).toBe(2);
+  });
+
+  it("rounds to one decimal to kill float drift on 0.1 steps", () => {
+    expect(clamp(1.0000001)).toBe(1);
+    // 0.1 steps accumulate binary float noise (e.g. 1 + 0.1*3 ≠ 1.3 exactly).
+    expect(clamp(1 + 0.1 + 0.1 + 0.1)).toBe(1.3);
+    expect(clamp(1.149)).toBe(1.1);
+    expect(clamp(1.15)).toBe(1.2);
+  });
+});
+
+describe("resolveStoredZoom", () => {
+  it("returns the default for missing or garbage values", () => {
+    expect(resolveStoredZoom(null)).toBe(1);
+    expect(resolveStoredZoom("")).toBe(1);
+    expect(resolveStoredZoom("nope")).toBe(1);
+    expect(resolveStoredZoom("NaN")).toBe(1);
+  });
+
+  it("clamps stored values that sit outside the allowed range", () => {
+    expect(resolveStoredZoom("0.2")).toBe(0.5);
+    expect(resolveStoredZoom("3")).toBe(2);
+    expect(resolveStoredZoom("1.5")).toBe(1.5);
+  });
+});
+
+describe("trafficLightSpacerCssPx", () => {
+  it("keeps device clearance constant under zoom", () => {
+    expect(trafficLightSpacerCssPx(1)).toBe(TRAFFIC_LIGHT_CLEARANCE_PX);
+    expect(trafficLightSpacerCssPx(0.5)).toBe(TRAFFIC_LIGHT_CLEARANCE_PX / 0.5);
+    expect(trafficLightSpacerCssPx(2)).toBe(TRAFFIC_LIGHT_CLEARANCE_PX / 2);
+  });
+});
+
+describe("hydrate", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useZoomStore.setState({ zoom: 1 });
+  });
+
+  it("loads a clamped stored level even when setZoom is unavailable", async () => {
+    localStorage.setItem("humla.zoom", "1.7");
+    await useZoomStore.getState().hydrate();
+    expect(useZoomStore.getState().zoom).toBe(1.7);
+  });
+
+  it("falls back to 1 when localStorage holds garbage", async () => {
+    localStorage.setItem("humla.zoom", "banana");
+    await useZoomStore.getState().hydrate();
+    expect(useZoomStore.getState().zoom).toBe(1);
+  });
+
+  it("does not throw when the Tauri webview API is missing", async () => {
+    await expect(useZoomStore.getState().hydrate()).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/zoom.test.ts
+++ b/src/lib/zoom.test.ts
@@ -76,3 +76,40 @@ describe("hydrate", () => {
     await expect(useZoomStore.getState().hydrate()).resolves.toBeUndefined();
   });
 });
+
+describe("setZoom / zoomIn / zoomOut / zoomReset", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useZoomStore.setState({ zoom: 1 });
+  });
+
+  // This is the exact path the global keydown handler awaits (shortcuts.ts) —
+  // the original bug report was an unhandled rejection from here, not from hydrate.
+  it("does not reject when the webview call fails", async () => {
+    await expect(useZoomStore.getState().zoomIn()).resolves.toBeUndefined();
+  });
+
+  it("commits the clamped zoom even when the webview call fails", async () => {
+    // setZoom must commit state (and persist it) *before* awaiting the native
+    // call, not after — a held-down key fires the next keydown before the
+    // previous call's native round-trip resolves, and zoomIn/zoomOut compute
+    // their step from get().zoom. Committing after the await would let two
+    // overlapping calls read the same stale zoom and collapse into one step.
+    await useZoomStore.getState().setZoom(1.4);
+    expect(useZoomStore.getState().zoom).toBe(1.4);
+    expect(localStorage.getItem("humla.zoom")).toBe("1.4");
+  });
+
+  it("zoomIn and zoomOut step from the current zoom", async () => {
+    await useZoomStore.getState().zoomIn();
+    expect(useZoomStore.getState().zoom).toBe(1.1);
+    await useZoomStore.getState().zoomOut();
+    expect(useZoomStore.getState().zoom).toBe(1);
+  });
+
+  it("zoomReset returns to the default", async () => {
+    await useZoomStore.getState().setZoom(1.7);
+    await useZoomStore.getState().zoomReset();
+    expect(useZoomStore.getState().zoom).toBe(1);
+  });
+});

--- a/src/lib/zoom.ts
+++ b/src/lib/zoom.ts
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { create } from "zustand";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+
+const ZOOM_KEY = "humla.zoom";
+const ZOOM_MIN = 0.5;
+const ZOOM_MAX = 2.0;
+const ZOOM_STEP = 0.1;
+const ZOOM_DEFAULT = 1.0;
+
+function clamp(v: number): number {
+  return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(v * 10) / 10));
+}
+
+type ZoomState = {
+  zoom: number;
+  setZoom: (level: number) => Promise<void>;
+  zoomIn: () => Promise<void>;
+  zoomOut: () => Promise<void>;
+  zoomReset: () => Promise<void>;
+  hydrate: () => Promise<void>;
+};
+
+export const useZoomStore = create<ZoomState>((set, get) => ({
+  zoom: ZOOM_DEFAULT,
+
+  setZoom: async (level) => {
+    const z = clamp(level);
+    await getCurrentWebview().setZoom(z);
+    set({ zoom: z });
+    localStorage.setItem(ZOOM_KEY, String(z));
+  },
+
+  zoomIn: () => get().setZoom(get().zoom + ZOOM_STEP),
+  zoomOut: () => get().setZoom(get().zoom - ZOOM_STEP),
+  zoomReset: () => get().setZoom(ZOOM_DEFAULT),
+
+  hydrate: async () => {
+    const stored = parseFloat(localStorage.getItem(ZOOM_KEY) ?? "");
+    const z = isNaN(stored) ? ZOOM_DEFAULT : clamp(stored);
+    await getCurrentWebview().setZoom(z);
+    set({ zoom: z });
+  },
+}));
+
+export function useZoomBoot() {
+  const hydrate = useZoomStore((s) => s.hydrate);
+  useEffect(() => { hydrate(); }, [hydrate]);
+}

--- a/src/lib/zoom.ts
+++ b/src/lib/zoom.ts
@@ -8,8 +8,22 @@ const ZOOM_MAX = 2.0;
 const ZOOM_STEP = 0.1;
 const ZOOM_DEFAULT = 1.0;
 
-function clamp(v: number): number {
+/** Native traffic-light row height in device px — CSS spacer scales by 1/zoom. */
+export const TRAFFIC_LIGHT_CLEARANCE_PX = 34;
+
+export function clamp(v: number): number {
   return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(v * 10) / 10));
+}
+
+/** Parse a localStorage value into a clamped zoom; garbage → default. */
+export function resolveStoredZoom(raw: string | null): number {
+  const stored = parseFloat(raw ?? "");
+  return Number.isNaN(stored) ? ZOOM_DEFAULT : clamp(stored);
+}
+
+/** CSS px for the traffic-light spacer so device height stays constant under zoom. */
+export function trafficLightSpacerCssPx(zoom: number): number {
+  return TRAFFIC_LIGHT_CLEARANCE_PX / zoom;
 }
 
 type ZoomState = {
@@ -26,7 +40,12 @@ export const useZoomStore = create<ZoomState>((set, get) => ({
 
   setZoom: async (level) => {
     const z = clamp(level);
-    await getCurrentWebview().setZoom(z);
+    try {
+      await getCurrentWebview().setZoom(z);
+    } catch {
+      // Tests / non-Tauri shells lack webview metadata; shortcuts must not reject.
+      return;
+    }
     set({ zoom: z });
     localStorage.setItem(ZOOM_KEY, String(z));
   },
@@ -36,14 +55,19 @@ export const useZoomStore = create<ZoomState>((set, get) => ({
   zoomReset: () => get().setZoom(ZOOM_DEFAULT),
 
   hydrate: async () => {
-    const stored = parseFloat(localStorage.getItem(ZOOM_KEY) ?? "");
-    const z = isNaN(stored) ? ZOOM_DEFAULT : clamp(stored);
-    await getCurrentWebview().setZoom(z);
+    const z = resolveStoredZoom(localStorage.getItem(ZOOM_KEY));
+    try {
+      await getCurrentWebview().setZoom(z);
+    } catch {
+      // Same gap as setZoom — still sync the store so the spacer can react.
+    }
     set({ zoom: z });
   },
 }));
 
 export function useZoomBoot() {
   const hydrate = useZoomStore((s) => s.hydrate);
-  useEffect(() => { hydrate(); }, [hydrate]);
+  useEffect(() => {
+    void hydrate();
+  }, [hydrate]);
 }

--- a/src/lib/zoom.ts
+++ b/src/lib/zoom.ts
@@ -40,14 +40,19 @@ export const useZoomStore = create<ZoomState>((set, get) => ({
 
   setZoom: async (level) => {
     const z = clamp(level);
-    try {
-      await getCurrentWebview().setZoom(z);
-    } catch {
-      // Tests / non-Tauri shells lack webview metadata; shortcuts must not reject.
-      return;
-    }
+    // Commit synchronously, before awaiting the native call: zoomIn/zoomOut
+    // read get().zoom to compute the next step, and a held-down key fires
+    // the next keydown before this await resolves. Committing only after
+    // the await let two overlapping calls read the same stale zoom and
+    // collapse a held-down key's steps into one.
     set({ zoom: z });
     localStorage.setItem(ZOOM_KEY, String(z));
+    try {
+      await getCurrentWebview().setZoom(z);
+    } catch (err) {
+      // Tests / non-Tauri shells lack webview metadata; shortcuts must not reject.
+      console.error("setZoom failed", err);
+    }
   },
 
   zoomIn: () => get().setZoom(get().zoom + ZOOM_STEP),


### PR DESCRIPTION
## What

Adds keyboard shortcuts to zoom the app in/out using Tauri's native `setZoom` API.

| Shortcut | Action |
|---|---|
| `Cmd` + `=` / `+` | Zoom in |
| `Cmd` + `-` | Zoom out |
| `Cmd` + `0` | Reset to 100% |

Zoom steps by 10% and is clamped between 50% and 200%. The level persists across restarts via `localStorage`.

## How

- `src/lib/zoom.ts` — `useZoomStore` wrapping `getCurrentWebview().setZoom()` with clamp/persist; `useZoomBoot` rehydrates on startup; try/catch so missing Tauri metadata doesn't throw
- `src/lib/shortcuts.ts` — Cmd+=/+/−/0 branches in `useGlobalShortcuts`
- `src/components/Sidebar.tsx` — traffic-light spacer sized as `34 / zoom` so native buttons don't overlap when zoomed out
- `src/App.tsx` — calls `useZoomBoot()`
- `src-tauri/capabilities/default.json` — `core:webview:allow-set-webview-zoom`

## Test

1. Open the app
2. Press `Cmd+=` a few times — UI should scale up
3. Press `Cmd+-` — UI should scale down
4. Press `Cmd+0` — should return to 100%
5. Quit and reopen — zoom level should be restored
6. Zoom out to 50% — traffic lights should still clear the first sidebar row
7. `pnpm test` exits 0