### PR TITLE
docs(context): name the Title, and say which ones Humla may overwrite

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,10 @@ Personal macOS meeting-notes app: freeform user notes plus recorded audio, trans
 A single meeting record: the user's typed notes, the audio transcript, and an AI-generated summary, together as one unit.
 _Avoid_: Meeting, recording, entry
 
+**Title**:
+A Note's name, as it shows in the notes list and above the body. Either **user-owned** — typed by the user, or carried in from an imported file's own name — or **generated**, written by Humla for a Note that had no name of its own: the `Recording 19 Aug 14:32` a menu-bar capture starts with, and the short phrase derived from the Note's first paragraphs once it has content. Only a generated Title is ever overwritten automatically; a user-owned one changes only when the user edits it or explicitly asks for a new one. The distinction is read off the Title's *shape* at the moment it matters — Humla stores no flag recording who wrote it, so a generated Title that happens to look human-written is treated as human-written.
+_Avoid_: Name, heading, subject, label
+
 **Folder**:
 A general-purpose, user-defined bucket a Note can optionally belong to (zero-or-one). Used purely for browsing/organizing however the user likes — by project, by time period, by meeting type — with no fixed meaning beyond "the user filed it here."
 _Avoid_: Category, tag, group


### PR DESCRIPTION
Adds a **Title** entry to the `CONTEXT.md` glossary, defining user-owned versus generated Titles.

Falls out of the #90 grilling. The whole eligibility rule there — which Titles the automatic path may replace — turns on a distinction the glossary had no word for, and the distinction is read off the Title's *shape* rather than from any stored flag, so the vocabulary carries what the schema doesn't.

Glossary only: no code, no behaviour. The implementation is specified in the #90 agent brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)